### PR TITLE
Separating objects

### DIFF
--- a/src/1Lab/HLevel.lagda.md
+++ b/src/1Lab/HLevel.lagda.md
@@ -741,5 +741,15 @@ is-set→cast-pathp
   → PathP (λ i → P (q i)) px py
 is-set→cast-pathp {p = p} {q = q} P {px} {py} set  r =
   coe0→1 (λ i → PathP (λ j → P (set _ _ p q i j)) px py) r
+
+is-set→subst-refl
+  : ∀ {ℓ ℓ'} {A : Type ℓ} {x : A}
+  → (P : A → Type ℓ')
+  → is-set A
+  → (p : x ≡ x)
+  → (px : P x)
+  → subst P p px ≡ px
+is-set→subst-refl {x = x} P set p px i =
+  transp (λ j → P (set x x p refl i j)) i px
 ```
 -->

--- a/src/Algebra/Group/Cat/Base.lagda.md
+++ b/src/Algebra/Group/Cat/Base.lagda.md
@@ -23,7 +23,7 @@ import Cat.Reasoning as CR
 ```
 -->
 
-# The category of groups
+# The category of groups {defines="category-of-groups"}
 
 The category of groups, as the name implies, has its objects the
 `Groups`{.Agda ident=Group}, with the morphisms between them the `group

--- a/src/Algebra/Group/Cat/FinitelyComplete.lagda.md
+++ b/src/Algebra/Group/Cat/FinitelyComplete.lagda.md
@@ -42,7 +42,7 @@ _forced_ to do this since [right adjoints preserve limits].
 [underlying set]: Algebra.Group.Cat.Base.html#the-underlying-set
 [right adjoints preserve limits]: Cat.Functor.Adjoint.Continuous.html
 
-## The zero group
+## The zero group {defines="zero-group"}
 
 The zero object in the category of groups is given by the unit type,
 equipped with its unique group structure. Correspondingly, we may refer

--- a/src/Cat/Diagram/Coequaliser/RegularEpi.lagda.md
+++ b/src/Cat/Diagram/Coequaliser/RegularEpi.lagda.md
@@ -133,6 +133,11 @@ module _ {o ℓ} {C : Precategory o ℓ} where
 
 # Existence of regular epis
 
+Let $\cJ, \cC$ be a categories such that $\cC$ has coproducts indexed
+by the objects and arrows of $\cC$, and let $F : \cJ \to \cC$ be a functor
+with a colimit $C$ in $\cC$. The canonical map $\coprod_{j : J} F(j) \to C$
+is a regular epimorphism
+
 ```agda
 module _ {o ℓ oj ℓj}
   {C : Precategory o ℓ} {J : Precategory oj ℓj}
@@ -141,6 +146,10 @@ module _ {o ℓ oj ℓj}
   (∐Hom : has-coproducts-indexed-by C (Arrows J))
   (∐F : Colimit F)
   where
+```
+
+<!--
+```agda
   private
     module C = Cat.Reasoning C
     module J = Cat.Reasoning J
@@ -151,19 +160,40 @@ module _ {o ℓ oj ℓj}
 
   open is-regular-epi
   open is-coequaliser
+```
+-->
 
+```agda
   indexed-coproduct→regular-epi : is-regular-epi C (∐Ob.match F.₀ ∐F.ψ)
-  indexed-coproduct→regular-epi .r = ∐Hom.ΣF λ (a , b , f) → F.₀ a
-  indexed-coproduct→regular-epi .arr₁ = ∐Hom.match _ λ (a , b , f) → ∐Ob.ι F.₀ b C.∘ F.₁ f
-  indexed-coproduct→regular-epi .arr₂ = ∐Hom.match _ λ (a , b , f) → ∐Ob.ι F.₀ a
+```
+
+We start by constructing a pair of maps $p, q : \coprod_{f : \cJ(i,j)} F(i) \to \coprod_{j : J} F(j)$
+via the universal property of $\coprod_{f : \cJ(i,j)} F(i)$.
+
+```agda
+  indexed-coproduct→regular-epi .r = ∐Hom.ΣF λ (i , j , f) → F.₀ i
+  indexed-coproduct→regular-epi .arr₁ = ∐Hom.match _ λ (i , j , f) → ∐Ob.ι F.₀ j C.∘ F.₁ f
+  indexed-coproduct→regular-epi .arr₂ = ∐Hom.match _ λ (i , j , f) → ∐Ob.ι F.₀ i
+```
+
+By some rather tedious calculations, we can show that $p$ and $q$
+coequalize $f$.
+
+```agda
   indexed-coproduct→regular-epi .has-is-coeq .coequal =
-    ∐Hom.unique₂ _ λ (a , b , f) →
-    (∐Ob.match F.₀ ∐F.ψ C.∘ ∐Hom.match _ _) C.∘ ∐Hom.ι _ (a , b , f) ≡⟨ C.pullr (∐Hom.commute _) ⟩
-    ∐Ob.match F.₀ ∐F.ψ C.∘ ∐Ob.ι _ b C.∘ F.₁ f                       ≡⟨ C.pulll (∐Ob.commute _) ⟩
-    ∐F.ψ b C.∘ F.₁ f                                                 ≡⟨ ∐F.commutes f ⟩
-    ∐F.ψ a                                                           ≡˘⟨ ∐Ob.commute _ ⟩
-    ∐Ob.match F.₀ ∐F.ψ C.∘ ∐Ob.ι _ a                                 ≡˘⟨ C.pullr (∐Hom.commute _) ⟩
-    (∐Ob.match F.₀ ∐F.ψ C.∘ ∐Hom.match _ _) C.∘ ∐Hom.ι _ (a , b , f) ∎
+    ∐Hom.unique₂ _ λ (i , j , f) →
+    (∐Ob.match F.₀ ∐F.ψ C.∘ ∐Hom.match _ _) C.∘ ∐Hom.ι _ (i , j , f) ≡⟨ C.pullr (∐Hom.commute _) ⟩
+    ∐Ob.match F.₀ ∐F.ψ C.∘ ∐Ob.ι _ j C.∘ F.₁ f                       ≡⟨ C.pulll (∐Ob.commute _) ⟩
+    ∐F.ψ j C.∘ F.₁ f                                                 ≡⟨ ∐F.commutes f ⟩
+    ∐F.ψ i                                                           ≡˘⟨ ∐Ob.commute _ ⟩
+    ∐Ob.match F.₀ ∐F.ψ C.∘ ∐Ob.ι _ i                                 ≡˘⟨ C.pullr (∐Hom.commute _) ⟩
+    (∐Ob.match F.₀ ∐F.ψ C.∘ ∐Hom.match _ _) C.∘ ∐Hom.ι _ (i , j , f) ∎
+```
+
+Moreover, $p$ and $q$ form the universal such coequalizing pair. This
+follows by yet more brute-force calculation.
+
+```agda
   indexed-coproduct→regular-epi .has-is-coeq .universal {e' = e'} p =
     ∐F.universal (λ j → e' C.∘ ∐Ob.ι F.₀ j) comm
     where abstract

--- a/src/Cat/Diagram/Coequaliser/RegularEpi.lagda.md
+++ b/src/Cat/Diagram/Coequaliser/RegularEpi.lagda.md
@@ -1,9 +1,13 @@
 <!--
 ```agda
+open import Cat.Diagram.Coproduct.Indexed
+open import Cat.Instances.Shape.Interval
+open import Cat.Diagram.Colimit.Base
 open import Cat.Diagram.Coequaliser
 open import Cat.Diagram.Pullback
 open import Cat.Prelude
 
+import Cat.Functor.Reasoning
 import Cat.Reasoning
 ```
 -->
@@ -125,4 +129,60 @@ module _ {o ℓ} {C : Precategory o ℓ} where
         e' ∘ reg.arr₂                               ∎
     epi .has-is-coeq .factors = reg.factors
     epi .has-is-coeq .unique = reg.unique
+```
+
+# Existence of regular epis
+
+```agda
+module _ {o ℓ oj ℓj}
+  {C : Precategory o ℓ} {J : Precategory oj ℓj}
+  {F : Functor J C}
+  (∐Ob : has-coproducts-indexed-by C ⌞ J ⌟)
+  (∐Hom : has-coproducts-indexed-by C (Arrows J))
+  (∐F : Colimit F)
+  where
+  private
+    module C = Cat.Reasoning C
+    module J = Cat.Reasoning J
+    module F = Cat.Functor.Reasoning F
+    module ∐Ob F = Indexed-coproduct (∐Ob F)
+    module ∐Hom F = Indexed-coproduct (∐Hom F)
+    module ∐F = Colimit ∐F
+
+  open is-regular-epi
+  open is-coequaliser
+
+  indexed-coproduct→regular-epi : is-regular-epi C (∐Ob.match F.₀ ∐F.ψ)
+  indexed-coproduct→regular-epi .r = ∐Hom.ΣF λ (a , b , f) → F.₀ a
+  indexed-coproduct→regular-epi .arr₁ = ∐Hom.match _ λ (a , b , f) → ∐Ob.ι F.₀ b C.∘ F.₁ f
+  indexed-coproduct→regular-epi .arr₂ = ∐Hom.match _ λ (a , b , f) → ∐Ob.ι F.₀ a
+  indexed-coproduct→regular-epi .has-is-coeq .coequal =
+    ∐Hom.unique₂ _ λ (a , b , f) →
+    (∐Ob.match F.₀ ∐F.ψ C.∘ ∐Hom.match _ _) C.∘ ∐Hom.ι _ (a , b , f) ≡⟨ C.pullr (∐Hom.commute _) ⟩
+    ∐Ob.match F.₀ ∐F.ψ C.∘ ∐Ob.ι _ b C.∘ F.₁ f                       ≡⟨ C.pulll (∐Ob.commute _) ⟩
+    ∐F.ψ b C.∘ F.₁ f                                                 ≡⟨ ∐F.commutes f ⟩
+    ∐F.ψ a                                                           ≡˘⟨ ∐Ob.commute _ ⟩
+    ∐Ob.match F.₀ ∐F.ψ C.∘ ∐Ob.ι _ a                                 ≡˘⟨ C.pullr (∐Hom.commute _) ⟩
+    (∐Ob.match F.₀ ∐F.ψ C.∘ ∐Hom.match _ _) C.∘ ∐Hom.ι _ (a , b , f) ∎
+  indexed-coproduct→regular-epi .has-is-coeq .universal {e' = e'} p =
+    ∐F.universal (λ j → e' C.∘ ∐Ob.ι F.₀ j) comm
+    where abstract
+      comm
+        : ∀ {i j} (f : J.Hom i j)
+        → (e' C.∘ ∐Ob.ι F.₀ j) C.∘ F.₁ f ≡ e' C.∘ ∐Ob.ι F.₀ i
+      comm {i} {j} f =
+        (e' C.∘ ∐Ob.ι F.₀ j) C.∘ F.₁ f                   ≡⟨ C.pullr (sym (∐Hom.commute _)) ⟩
+        e' C.∘ (∐Hom.match _ _ C.∘ ∐Hom.ι _ (i , j , f)) ≡⟨ C.extendl p ⟩
+        e' C.∘ (∐Hom.match _ _ C.∘ ∐Hom.ι _ (i , j , f)) ≡⟨ ap₂ C._∘_ refl (∐Hom.commute _) ⟩
+        e' C.∘ ∐Ob.ι F.₀ i                               ∎
+  indexed-coproduct→regular-epi .has-is-coeq .factors {e' = e'} {p = p} =
+    ∐Ob.unique₂ F.₀ λ j →
+      (∐F.universal _ _ C.∘ ∐Ob.match F.₀ ∐F.ψ) C.∘ ∐Ob.ι F.₀ j ≡⟨ C.pullr (∐Ob.commute _) ⟩
+      ∐F.universal _ _ C.∘ ∐F.ψ j                               ≡⟨ ∐F.factors _ _ ⟩
+      e' C.∘ ∐Ob.ι F.₀ j                                        ∎
+  indexed-coproduct→regular-epi .has-is-coeq .unique {e' = e'} {colim = h} p =
+    ∐F.unique _ _ _ λ j →
+      h C.∘ ∐F.ψ j                               ≡˘⟨ ap₂ C._∘_ refl (∐Ob.commute _) ⟩
+      h C.∘ (∐Ob.match F.₀ ∐F.ψ C.∘ ∐Ob.ι F.₀ j) ≡⟨ C.pulll p ⟩
+      e' C.∘ ∐Ob.ι F.₀ j                         ∎
 ```

--- a/src/Cat/Diagram/Coproduct/Copower.lagda.md
+++ b/src/Cat/Diagram/Coproduct/Copower.lagda.md
@@ -94,10 +94,14 @@ uniqueness properties of colimiting maps.
   Copowering .F-∘ {X , A} f g = sym $
     coprods X (λ _ → A) .unique _ λ i →
       pullr (coprods _ _ .commute) ∙ extendl (coprods _ _ .commute)
+```
 
+<!--
+```agda
 cocomplete→copowering
   : ∀ {o ℓ} {C : Precategory o ℓ}
   → is-cocomplete ℓ ℓ C → Functor (Sets ℓ ×ᶜ C) C
 cocomplete→copowering colim = Copowers.Copowering λ S F →
   Colimit→IC _ (is-hlevel-suc 2 (S .is-tr)) F (colim _)
 ```
+-->

--- a/src/Cat/Diagram/Coproduct/Copower.lagda.md
+++ b/src/Cat/Diagram/Coproduct/Copower.lagda.md
@@ -96,6 +96,21 @@ uniqueness properties of colimiting maps.
       pullr (coprods _ _ .commute) ∙ extendl (coprods _ _ .commute)
 ```
 
+```agda
+  ∐! : (Idx : Type ℓ) ⦃ hl : H-Level Idx 2 ⦄ (F : Idx → Ob) → Ob
+  ∐! Idx F = ΣF (coprods (el! Idx) F)
+
+  module ∐! (Idx : Type ℓ) ⦃ hl : H-Level Idx 2 ⦄ (F : Idx → Ob) =
+    Indexed-coproduct (coprods (el! Idx) F)
+
+  _⊗!_ : (Idx : Type ℓ) ⦃ hl : H-Level Idx 2 ⦄ → Ob → Ob
+  I ⊗! X = el! I ⊗ X
+
+  module ⊗! (Idx : Type ℓ) ⦃ hl : H-Level Idx 2 ⦄ (X : Ob) =
+    Indexed-coproduct (coprods (el! Idx) (λ _ → X))
+```
+
+
 <!--
 ```agda
 cocomplete→copowering

--- a/src/Cat/Diagram/Coproduct/Indexed.lagda.md
+++ b/src/Cat/Diagram/Coproduct/Indexed.lagda.md
@@ -225,13 +225,22 @@ has-coproducts-indexed-by I = ∀ (F : I → C.Ob) → Indexed-coproduct F
 has-indexed-coproducts : ∀ ℓ → Type _
 has-indexed-coproducts ℓ = ∀ {I : Type ℓ} → has-coproducts-indexed-by I
 
+module Indexed-coproducts-by
+  {κ : Level} {Idx : Type κ}
+  (has-ic : has-coproducts-indexed-by Idx)
+  where
+  module ∐ (F : Idx → C.Ob) = Indexed-coproduct (has-ic F)
+
+  open ∐ renaming (commute to ι-commute; unique to match-unique) public
+
+
 module Indexed-coproducts
   {κ : Level}
   (has-ic : has-indexed-coproducts κ)
   where
-  module ∏ {Idx : Type κ} (F : Idx → C.Ob) = Indexed-coproduct (has-ic F)
+  module ∐ {Idx : Type κ} (F : Idx → C.Ob) = Indexed-coproduct (has-ic F)
 
-  open ∏ renaming (commute to ι-commute; unique to match-unique) public
+  open ∐ renaming (commute to ι-commute; unique to match-unique) public
 ```
 
 

--- a/src/Cat/Diagram/Coproduct/Indexed.lagda.md
+++ b/src/Cat/Diagram/Coproduct/Indexed.lagda.md
@@ -65,12 +65,6 @@ record Indexed-coproduct (F : Idx → C.Ob) : Type (o ⊔ ℓ ⊔ level-of Idx) 
     ι         : ∀ i → C.Hom (F i) ΣF
     has-is-ic : is-indexed-coproduct F ι
   open is-indexed-coproduct has-is-ic public
-
-has-coproducts-indexed-by : ∀ {ℓ} (I : Type ℓ) → Type _
-has-coproducts-indexed-by I = ∀ (F : I → C.Ob) → Indexed-coproduct F
-
-has-indexed-coproducts : ∀ ℓ → Type _
-has-indexed-coproducts ℓ = ∀ {I : Type ℓ} → has-coproducts-indexed-by I
 ```
 
 <!--
@@ -220,6 +214,24 @@ is-indexed-coproduct-assoc {A = A} {B} {X} {ΣᵃΣᵇX = ΣᵃΣᵇX} {ιᵃ = 
       ΣᵃΣᵇ .unique _ λ a →
       Σᵇ _ .unique _ λ b →
       sym (C.assoc _ _ _) ∙ p (a , b)
+```
+
+# Categories with all indexed coproducts
+
+```agda
+has-coproducts-indexed-by : ∀ {ℓ} (I : Type ℓ) → Type _
+has-coproducts-indexed-by I = ∀ (F : I → C.Ob) → Indexed-coproduct F
+
+has-indexed-coproducts : ∀ ℓ → Type _
+has-indexed-coproducts ℓ = ∀ {I : Type ℓ} → has-coproducts-indexed-by I
+
+module Indexed-coproducts
+  {κ : Level}
+  (has-ic : has-indexed-coproducts κ)
+  where
+  module ∏ {Idx : Type κ} (F : Idx → C.Ob) = Indexed-coproduct (has-ic F)
+
+  open ∏ renaming (commute to ι-commute; unique to match-unique) public
 ```
 
 

--- a/src/Cat/Diagram/Product/Indexed.lagda.md
+++ b/src/Cat/Diagram/Product/Indexed.lagda.md
@@ -337,7 +337,7 @@ module Indexed-products
   {κ : Level}
   (has-ip : has-indexed-products κ)
   where
-  module Π {Idx : Type κ} (F : Idx → C.Ob) = Indexed-product (has-ip F)
+  module ∏ {Idx : Type κ} (F : Idx → C.Ob) = Indexed-product (has-ip F)
 
-  open Π renaming (commute to π-commute; unique to tuple-unique) public
+  open ∏ renaming (commute to π-commute; unique to tuple-unique) public
 ```

--- a/src/Cat/Diagram/Separator.lagda.md
+++ b/src/Cat/Diagram/Separator.lagda.md
@@ -7,6 +7,8 @@ description: |
 ```agda
 open import Cat.Diagram.Coproduct.Copower
 open import Cat.Diagram.Coproduct.Indexed
+open import Cat.Diagram.Coequaliser.RegularEpi
+open import Cat.Diagram.Coequaliser
 open import Cat.Functor.FullSubcategory
 open import Cat.Diagram.Colimit.Base
 open import Cat.Diagram.Limit.Finite
@@ -486,7 +488,6 @@ object only lets us *equate* morphisms; ideally, we would be able to
 construct a morphism $\cC(X,Y)$ by giving a function $\cC(S,X) \to \cC(S,Y)$
 on $S$-generalized elements as well! This desire leads directly to the
 notion of a **dense separating object**.
-
 
 :::{.definition #dense-separating-object alias="dense-separator"}
 An object $S : \cC$ **dense separating object** is a

--- a/src/Cat/Diagram/Separator.lagda.md
+++ b/src/Cat/Diagram/Separator.lagda.md
@@ -5,6 +5,7 @@ description: |
 
 <!--
 ```agda
+open import Cat.Diagram.Coproduct.Copower
 open import Cat.Diagram.Coproduct.Indexed
 open import Cat.Functor.FullSubcategory
 open import Cat.Diagram.Colimit.Base
@@ -185,18 +186,16 @@ which immediately gives us $f \circ e = g \circ e$ by our hypothesis.
 
 ```agda
 module _
-  {s : Ob}
   (copowers : (I : Set ℓ) → has-coproducts-indexed-by C ∣ I ∣)
   where
-  private
-    module Elts x = Indexed-coproduct (copowers (el! (Hom s x)) λ f → s)
+  open Copowers copowers
 
-  separator→epi : ∀ {x} → is-separator s → is-epic (Elts.match x λ f → f)
-  separator→epi {x} separate f g p = separate λ e →
-    f ∘ e                       ≡⟨ pushr (sym (Elts.commute x)) ⟩
-    (f ∘ (Elts.match x λ f → f)) ∘ Elts.ι x e ≡⟨ p ⟩∘⟨refl ⟩
-    (g ∘ (Elts.match x λ f → f)) ∘ Elts.ι x e ≡⟨ pullr (Elts.commute x) ⟩
-    g ∘ e                       ∎
+  separator→epi : ∀ {s x} → is-separator s → is-epic (⊗!.match (Hom s x) s λ f → f)
+  separator→epi {s} {x} separate f g p = separate λ e →
+    f ∘ e                                     ≡⟨ pushr (sym (⊗!.commute _ _)) ⟩
+    (f ∘ (⊗!.match _ _ λ f → f)) ∘ ⊗!.ι _ _ e ≡⟨ p ⟩∘⟨refl ⟩
+    (g ∘ (⊗!.match _ _ λ f → f)) ∘ ⊗!.ι _ _ e ≡⟨ pullr (⊗!.commute _ _) ⟩
+    g ∘ e                                     ∎
 ```
 
 Conversely, if the canonical map $\gamma_{X} : \cC(S,X) \otimes S \to X$
@@ -208,9 +207,9 @@ by our hypothesis, so $f \circ \gamma_{X} = g \circ \gamma_{X}$. Moreover,
 $\gamma_{X}$ is an epi, so $f = g$.
 
 ```agda
-  epi→separator : (∀ {x} → is-epic (Elts.match x λ f → f)) → is-separator s
+  epi→separator : ∀ {s} → (∀ {x} → is-epic (⊗!.match (Hom s x) s λ f → f)) → is-separator s
   epi→separator epic {f = f} {g = g} p =
-    epic f g $ Elts.unique₂ _ λ e →
+    epic f g $ ⊗!.unique₂ _ _ λ e →
       sym (assoc _ _ _)
       ∙ p _
       ∙ assoc _ _ _
@@ -220,34 +219,16 @@ A similar result hold for separating families, but with: a family $S_i : \cC$
 is a separating family if and only if the canonical map
 $\coprod_{\Sigma (i : I), \cC(S_i, X)} S_i \to X$ is an epimorphism.
 
-<!--
 ```agda
-module _
-  {Idx : Type ℓ}
-  {sᵢ : Idx → Ob}
-  (Idx-set : is-set Idx)
-  (coprods : (I : Set ℓ) → has-coproducts-indexed-by C ∣ I ∣)
-  where
-  private
-    instance
-      H-Level-Idx : ∀ {n} → H-Level Idx (2 + n)
-      H-Level-Idx = basic-instance 2 Idx-set
-
-```
--->
-
-```agda
-  private
-    module Elts (x : Ob) =
-      Indexed-coproduct (coprods (el! (Σ[ i ∈ Idx ] Hom (sᵢ i) x)) (sᵢ ⊙ fst))
-
   separating-family→epi
-    : ∀ {x}
+    : ∀ (Idx : Set ℓ) (sᵢ : ∣ Idx ∣ → Ob)
     → is-separating-family sᵢ
-    → is-epic (Elts.match x snd)
+    → ∀ {x} → is-epic (∐!.match (Σ[ i ∈ ∣ Idx ∣ ] Hom (sᵢ i) x) (sᵢ ⊙ fst) snd)
 
   epi→separating-family
-    : (∀ {x} → is-epic (Elts.match x snd))
+    : ∀ (Idx : Set ℓ)
+    → (sᵢ : ∣ Idx ∣ → Ob)
+    → (∀ {x} → is-epic (∐!.match (Σ[ i ∈ ∣ Idx ∣ ] Hom (sᵢ i) x) (sᵢ ⊙ fst) snd))
     → is-separating-family sᵢ
 ```
 
@@ -256,14 +237,14 @@ module _
 we omit the details.
 </summary>
 ```agda
-  separating-family→epi {x = x} separate f g p = separate λ {i} eᵢ →
-    f ∘ eᵢ                                     ≡⟨ pushr (sym (Elts.commute x)) ⟩
-    (f ∘ Elts.match x snd) ∘ Elts.ι x (i , eᵢ) ≡⟨ p ⟩∘⟨refl ⟩
-    (g ∘ Elts.match x snd) ∘ Elts.ι x (i , eᵢ) ≡⟨ pullr (Elts.commute x) ⟩
+  separating-family→epi Idx sᵢ separate f g p = separate λ {i} eᵢ →
+    f ∘ eᵢ                                     ≡⟨ pushr (sym (∐!.commute _ _)) ⟩
+    (f ∘ ∐!.match _ _ snd) ∘ ∐!.ι _ _ (i , eᵢ) ≡⟨ p ⟩∘⟨refl ⟩
+    (g ∘ ∐!.match _ _ snd) ∘ ∐!.ι _ _ (i , eᵢ) ≡⟨ pullr (∐!.commute _ _) ⟩
     g ∘ eᵢ                                     ∎
 
-  epi→separating-family epic {f = f} {g = g} p =
-    epic f g $ Elts.unique₂ _ λ (i , eᵢ) →
+  epi→separating-family Idx sᵢ epic {f = f} {g = g} p =
+    epic f g $ ∐!.unique₂ _ _ λ (i , eᵢ) →
       sym (assoc _ _ _)
       ∙ p _
       ∙ assoc _ _ _
@@ -299,6 +280,12 @@ equalisers+jointly-conservative→separating-family
   → has-equalisers C
   → is-jointly-conservative (λ i → Hom-from C (sᵢ i))
   → is-separating-family sᵢ
+```
+
+<details>
+<summary>
+</summary>
+```agda
 equalisers+jointly-conservative→separating-family equalisers fᵢ∘-conservative {f = f} {g = g} p =
   invertible→epic equ-invertible f g Eq.equal
   where
@@ -313,6 +300,7 @@ equalisers+jointly-conservative→separating-family equalisers fᵢ∘-conservat
         (λ eᵢ → Eq.factors)
         (λ h → sym (Eq.unique refl))
 ```
+</details>
 
 
 # Strong separators
@@ -321,11 +309,17 @@ equalisers+jointly-conservative→separating-family equalisers fᵢ∘-conservat
 module _
   (copowers : (I : Set ℓ) → has-coproducts-indexed-by C ∣ I ∣)
   where
-  private
-    module Elts s x = Indexed-coproduct (copowers (el! (Hom s x)) λ f → s)
+  open Copowers copowers
 
   is-strong-separator : Ob → Type (o ⊔ ℓ)
-  is-strong-separator s = ∀ {x} → is-strong-epi (Elts.match s x λ e → e)
+  is-strong-separator s = ∀ {x} → is-strong-epi (⊗!.match (Hom s x) s λ e → e)
+
+  is-strong-separating-family
+    : ∀ (Idx : Set ℓ)
+    → (sᵢ : ∣ Idx ∣ → Ob)
+    → Type (o ⊔ ℓ)
+  is-strong-separating-family Idx sᵢ =
+    ∀ {x} → is-strong-epi (∐!.match (Σ[ i ∈ ∣ Idx ∣ ] (Hom (sᵢ i) x)) (sᵢ ⊙ fst) snd)
 
   strong-separator→separator
     : ∀ {s}
@@ -333,6 +327,13 @@ module _
     → is-separator s
   strong-separator→separator strong =
     epi→separator copowers (strong .fst)
+
+  strong-separating-family→separating-family
+    : ∀ (Idx : Set ℓ) (sᵢ : ∣ Idx ∣ → Ob)
+    → is-strong-separating-family Idx sᵢ
+    → is-separating-family sᵢ
+  strong-separating-family→separating-family Idx sᵢ strong =
+    epi→separating-family copowers Idx sᵢ (strong .fst)
 ```
 
 ```agda
@@ -341,7 +342,7 @@ module _
     → is-strong-separator s
     → is-conservative (Hom-from C s)
   strong-separator→conservative {s = s} strong {A = a} {B = b} {f = f} f∘-inv =
-    strong-epi-mono→is-invertible
+    strong-epi+mono→is-invertible
       f-mono
       f-strong-epi
     where
@@ -352,14 +353,14 @@ module _
         strong-separator→separator strong λ e →
         f∘-.injective (extendl p)
 
-      f' : Hom (Elts.ΣF s b) a
-      f' = Elts.match s b λ e → f∘-.from e
+      f' : Hom ((Hom s b) ⊗! s) a
+      f' = ⊗!.match (Hom s b) s λ e → f∘-.from e
 
-      f'-factors : f ∘ f' ≡ Elts.match s b (λ e → e)
-      f'-factors = Elts.unique s b _ λ e →
-        (f ∘ f') ∘ Elts.ι _ _ e ≡⟨ pullr (Elts.commute s b) ⟩
-        f ∘ f∘-.from e          ≡⟨ f∘-.ε e ⟩
-        e                       ∎
+      f'-factors : f ∘ f' ≡ ⊗!.match (Hom s b) s (λ e → e)
+      f'-factors = ⊗!.unique _ _ _ λ e →
+        (f ∘ f') ∘ ⊗!.ι (Hom s b) s e ≡⟨ pullr (⊗!.commute (Hom s b) s) ⟩
+        f ∘ f∘-.from e                ≡⟨ f∘-.ε e ⟩
+        e                             ∎
 
       f-strong-epi : is-strong-epi f
       f-strong-epi =
@@ -368,21 +369,76 @@ module _
 ```
 
 ```agda
-  finitely-complete+conservative→strong-separator
+  lex+conservative→strong-separator
     : ∀ {s}
     → Finitely-complete C
     → is-conservative (Hom-from C s)
     → is-strong-separator s
-  finitely-complete+conservative→strong-separator lex f∘-conservative =
+  lex+conservative→strong-separator lex f∘-conservative =
     is-extremal-epi→is-strong-epi lex λ m i p →
     f∘-conservative $
     is-equiv→is-invertible $
     is-iso→is-equiv $ iso
-      (λ e → i ∘ Elts.ι _ _ e)
-      (λ f' → pulll (sym p) ∙ Elts.commute _ _)
-      (λ e → m .monic _ _ (pulll (sym p) ∙ Elts.commute _ _))
+      (λ e → i ∘ ⊗!.ι _ _ e)
+      (λ f' → pulll (sym p) ∙ ⊗!.commute _ _)
+      (λ e → m .monic _ _ (pulll (sym p) ∙ ⊗!.commute _ _))
 ```
 
+```agda
+  strong-separating-family→jointly-conservative
+    : ∀ (Idx : Set ℓ) (sᵢ : ∣ Idx ∣ → Ob)
+    → is-strong-separating-family Idx sᵢ
+    → is-jointly-conservative (λ i → Hom-from C (sᵢ i))
+
+  lex+jointly-conservative→strong-separating-family
+    : ∀ (Idx : Set ℓ) (sᵢ : ∣ Idx ∣ → Ob)
+    → Finitely-complete C
+    → is-jointly-conservative (λ i → Hom-from C (sᵢ i))
+    → is-strong-separating-family Idx sᵢ
+```
+
+<details>
+<summary>
+</summary>
+```agda
+  strong-separating-family→jointly-conservative Idx sᵢ strong {x = a} {y = b} {f = f} f∘ᵢ-inv =
+    strong-epi+mono→is-invertible
+      f-mono
+      f-strong-epi
+    where
+      module f∘- {i : ∣ Idx ∣} = Equiv (_ , is-invertible→is-equiv (f∘ᵢ-inv i))
+
+      f-mono : is-monic f
+      f-mono u v p =
+        strong-separating-family→separating-family Idx sᵢ strong λ eᵢ →
+        f∘-.injective (extendl p)
+
+      f' : Hom (∐! (Σ[ i ∈ ∣ Idx ∣ ] (Hom (sᵢ i) b)) (sᵢ ⊙ fst)) a
+      f' = ∐!.match _ _ (f∘-.from ⊙ snd)
+
+      f'-factors : f ∘ f' ≡ ∐!.match (Σ[ i ∈ ∣ Idx ∣ ] (Hom (sᵢ i) b)) (sᵢ ⊙ fst) snd
+      f'-factors =
+        ∐!.unique _ _ _ λ (i , eᵢ) →
+        (f ∘ f') ∘ ∐!.ι _ _ (i , eᵢ) ≡⟨ pullr (∐!.commute _ _) ⟩
+        f ∘ f∘-.from eᵢ              ≡⟨ f∘-.ε eᵢ ⟩
+        eᵢ                           ∎
+
+      f-strong-epi : is-strong-epi f
+      f-strong-epi =
+        strong-epi-cancell f f' $
+        subst is-strong-epi (sym f'-factors) strong
+
+  lex+jointly-conservative→strong-separating-family Idx sᵢ lex f∘-conservative =
+    is-extremal-epi→is-strong-epi lex λ m f p →
+    f∘-conservative $ λ i →
+    is-equiv→is-invertible $
+    is-iso→is-equiv $ iso
+      (λ eᵢ → f ∘ ∐!.ι _ _ (i , eᵢ))
+      (λ f' → pulll (sym p) ∙ ∐!.commute _ _)
+      (λ eᵢ → m .monic _ _ (pulll (sym p) ∙ ∐!.commute _ _))
+
+```
+</details>
 
 # Dense separators
 

--- a/src/Cat/Diagram/Separator.lagda.md
+++ b/src/Cat/Diagram/Separator.lagda.md
@@ -6,12 +6,12 @@ description: |
 <!--
 ```agda
 open import Cat.Diagram.Coproduct.Indexed
-open import Cat.Diagram.Coproduct.Copower
-open import Cat.Instances.Shape.Terminal
+open import Cat.Functor.FullSubcategory
 open import Cat.Diagram.Colimit.Base
 open import Cat.Functor.Properties
-open import Cat.Instances.Lift
-open import Cat.Functor.Dense
+open import Cat.Instances.Comma
+open import Cat.Functor.Joint
+open import Cat.Functor.Base
 open import Cat.Functor.Hom
 open import Cat.Prelude
 
@@ -27,7 +27,13 @@ module Cat.Diagram.Separator {o ℓ} (C : Precategory o ℓ) where
 <!--
 ```agda
 open Cat.Reasoning C
+open _=>_
 ```
+-->
+
+<!--
+  [TODO: Reed M, 21/01/2024] Write the page on concrete categories; link separators
+  to representing objects for the faithful functors.
 -->
 
 # Separating objects
@@ -60,12 +66,6 @@ is-separator s =
   ∀ {x y} {f g : Hom x y}
   → (∀ (e : Hom s x) → f ∘ e ≡ g ∘ e)
   → f ≡ g
-
-record Separator : Type (o ⊔ ℓ) where
-  no-eta-equality
-  field
-    sep      : Ob
-    separate : is-separator sep
 ```
 
 Equivalently, an object $S$ is a separator if the hom functor $\cC(S,-)$
@@ -73,15 +73,27 @@ is [[faithful]]. A good way to view this condition is that it is requiring
 the $S$-global elements functor to be somewhat well-behaved.
 
 ```agda
-is-separator→hom-faithful : ∀ {s} → is-separator s → is-faithful (Hom-from C s)
-is-separator→hom-faithful sep p = sep (happly p)
+separator→faithful : ∀ {s} → is-separator s → is-faithful (Hom-from C s)
+separator→faithful sep p = sep (happly p)
 
-hom-faithful→is-separator : ∀ {s} → is-faithful (Hom-from C s) → is-separator s
-hom-faithful→is-separator faithful p = faithful (ext p)
+faithful→separator : ∀ {s} → is-faithful (Hom-from C s) → is-separator s
+faithful→separator faithful p = faithful (ext p)
 ```
 
 Intuitively, a separator $S$ gives us an internal version of function
 extensionality, with pointwise equality replaced by $S$-wise equality.
+We can make this formal by showing that a separator $S$ gives us an
+[[identity system]] for morphisms in $\cC$.
+
+```agda
+separator-identity-system
+  : ∀ {s x y}
+  → is-separator s
+  → is-identity-system {A = Hom x y}
+      (λ f g → ∀ (e : Hom s x) → f ∘ e ≡ g ∘ e)
+      (λ f e → refl)
+separator-identity-system separate = set-identity-system hlevel! separate
+```
 
 ## Separators and copowers
 
@@ -93,8 +105,8 @@ $\Sets(\top, X) \otimes X$ is the coproduct of $X$-many copies of $\top$,
 which is isomorphic to $X$.
 
 Generalizing from $\Sets$, we can attempt to approximate any object
-$X$ by taking the copower $\cC(S,X) \otimes X$, where $S$ is a separating
-object. While we don't quite get an isomorphism $\cC(S,X) \otimes X \iso X$,
+$X$ by taking the copower $\cC(S,X) \otimes S$, where $S$ is a separating
+object. While we don't quite get an isomorphism $\cC(S,X) \otimes S \iso X$,
 we can show that the universal map $\cC(S,X) \otimes X \to X$ out of the
 copower is an epimorphism.
 
@@ -106,10 +118,10 @@ which immediately gives us $f \circ e = g \circ e$ by our hypothesis.
 
 ```agda
 module _
-  (S : Separator)
+  {sep : Ob}
+  (separate : is-separator sep)
   (copowers : (I : Set ℓ) → has-coproducts-indexed-by C ∣ I ∣)
   where
-  open Separator S
   module copowers (I : Set ℓ) (x : Ob) = Indexed-coproduct (copowers I λ _ → x)
 
   separator-covers : ∀ x → is-epic (copowers.match (el! (Hom sep x)) sep λ f → f)
@@ -136,8 +148,10 @@ is-dense-separator s = is-fully-faithful (Hom-from C s)
 In other words: morphisms of $\cC$ are given by *functions* between
 $S$-global elements.
 
-If $S$ is a dense separator, then it is also a separating object. The
-proof of this is rather slick: suppose that $\forall (e : \cC(S,X),\ f \circ e = g \circ e)$
+If $S$ is a dense separator, then it is also a separating object.
+This follows by some abstract nonsense ($\cC(S,-)$ is fully faithful, and $S$
+is a separator if $\cC(S,-)$ is faithful), but we provide an elementary proof for the
+sake of intution. Suppose that $\forall (e : \cC(S,X),\ f \circ e = g \circ e)$
 To show $f = g$, it suffices to show that $f \circ - = g \circ -$, as
 functions $\cC(S,X) \to \cC(S,Y)$. We can then apply function extensionality,
 which gets us a $S$-global element $e : \cC(S,X)$, and our hypothesis handles
@@ -145,17 +159,175 @@ the rest!
 
 ```agda
 dense-separate : ∀ {s} → is-dense-separator s → is-separator s
-dense-separate {s} dense p =
-  Equiv.injective (_ , dense) $ funext λ e → p e
+dense-separate {s} dense p = Equiv.injective (_ , dense) $ funext λ e → p e
 ```
 
+Furthermore, if $S$ is a dense separator, then every object $X$ is a copower
+$\cC(S,X) \otimes S$. This can be seen as providing a particularly strong form
+of the [[coyoneda lemma]] for $\cC$, as every object can be expressed as a colimit
+of a single object.
+
+```agda
+dense-separator→coyoneda
+  : ∀ {s}
+  → is-dense-separator s
+  → ∀ (x : Ob) → is-indexed-coproduct C {Idx = Hom s x} (λ _ → s) (λ f → f)
+dense-separator→coyoneda dense x .is-indexed-coproduct.match fs =
+  equiv→inverse dense fs
+dense-separator→coyoneda dense x .is-indexed-coproduct.commute {e} {_} {fs} =
+  equiv→counit dense fs $ₚ e
+dense-separator→coyoneda dense x .is-indexed-coproduct.unique {h = h} fs p =
+  Equiv.adjunctl (_ , dense) $ funext p
+```
+
+The converse is also true: if every object $X$ is a copower $\cC(S,X) \otimes S$,
+then $S$ is a dense separator. Explicltly, we must construct an inverse to
+$\cC(S,-) : \cC(X,Y) \to (\cC(S, X) \to \cC(S, Y))$. Recall $X$ is a copower
+of $\cC(S,X) \otimes S$: the universal property of $\cC(S,X) \otimes S$ is *exactly*
+a function $(\cC(S, X) \to \cC(S, Y)) \to \cC(X,Y)$. Furthermore, the $\beta$ and $\eta$
+rules for copowers ensure that we actually obtain an inverse to $\cC(S,-)$.
+
+```agda
+coyoneda→dense-separator
+  : ∀ {s}
+  → (∀ (x : Ob) → is-indexed-coproduct C {Idx = Hom s x} (λ _ → s) (λ f → f))
+  → is-dense-separator s
+coyoneda→dense-separator {s} coyo {x} {y} =
+  is-iso→is-equiv $ iso (coyo.match x)
+    (λ fs → funext λ e → coyo.commute x)
+    (λ f → sym $ coyo.unique _ _ λ _ → refl)
+  where module coyo (x : Ob) = is-indexed-coproduct (coyo x)
+```
 
 # Separating Families
 
+Many categories lack a single separating object $S : \cC$, but do have a *family* of
+separating objects $S_i : I \to \cC$. The canonical is the category of presheaves:
+we cannot determine equality of natural transformations $\alpha, \beta : P \to Q$
+by looking at all maps $S \to P$ single $S$, but we *can* if we look at all
+maps $\yo(A) \to P$! This leads us to the following notion:
+
+:::{.definition #separating-object alias="separator"}
+A **separating family or **separator** is a family of objects $S : I \to \cC$ such that:
+- For every $f, g : \cC(A, B)$, if $f \circ e_i = g \circ e_i$ for every
+  $i : I$ and every $e_i : \cC(S_i,A)$, then $f = g$.
+:::
+
 ```agda
-is-separating-family : ∀ {ℓi} {I : Type ℓi} → (I → Ob) → Type _ 
+is-separating-family : ∀ {ℓi} {Idx : Type ℓi} → (Idx → Ob) → Type _ 
 is-separating-family s =
   ∀ {x y} {f g : Hom x y}
   → (∀ {i} (eᵢ : Hom (s i) x) → f ∘ eᵢ ≡ g ∘ eᵢ)
   → f ≡ g
+```
+
+Equivalently, an family $S_i : \cC$ of objects form a separating family if the hom
+functors $C(S_i, -)$ are [[jointly faithful]].
+
+```agda
+separating-family→jointly-faithful
+  : ∀ {ℓi} {Idx : Type ℓi} {sᵢ : Idx → Ob}
+  → is-separating-family sᵢ
+  → is-jointly-faithful (λ i → Hom-from C (sᵢ i ))
+separating-family→jointly-faithful separates p = separates λ eᵢ → p _ $ₚ eᵢ
+
+jointly-faithful→separating-family
+  : ∀ {ℓi} {Idx : Type ℓi} {sᵢ : Idx → Ob}
+  → is-jointly-faithful (λ i → Hom-from C (sᵢ i ))
+  → is-separating-family sᵢ
+jointly-faithful→separating-family faithful p = faithful λ i → funext p
+```
+
+Most of the theory of separating object generalizes directly to separating families.
+For instance, separating families also induce an identity system on morphisms.
+
+```agda
+separating-family-identity-system
+  : ∀ {ℓi} {Idx : Type ℓi} {sᵢ : Idx → Ob} {x y}
+  → is-separating-family sᵢ
+  → is-identity-system {A = Hom x y}
+      (λ f g → ∀ {i} (eᵢ : Hom (sᵢ i) x) → f ∘ eᵢ ≡ g ∘ eᵢ)
+      (λ f e → refl)
+separating-family-identity-system separate = set-identity-system hlevel! separate
+```
+
+## Separating families and indexed coproducts
+
+Recall that if $\cC$ is $\kappa$ locally-small and admits $\kappa$-small
+[[indexed coproducts]], then we can form an approximation of any object $X$
+via a family of objects $S_i : I \to \cC$  by forming the indexed coproduct
+$\coprod_{i : I, e_i : \cC(S_i, X)} S_i$. This approximation comes equipped
+with a canonical map $u : \coprod_{i : I, e_i : \cC(S_i, X)} S_i \to X$
+defined via the universal property of indexed coproducts. If $S_i$ is
+a separating family, then this map is an epi.
+
+```agda
+module _
+  {Idx : Type ℓ}
+  {sᵢ : Idx → Ob}
+  (Idx-set : is-set Idx)
+  (separate : is-separating-family sᵢ)
+  (coprods : (I : Set ℓ) → has-coproducts-indexed-by C ∣ I ∣)
+  where
+  module coprods (I : Set ℓ) (xᵢ : ∣ I ∣ → Ob) = Indexed-coproduct (coprods I xᵢ)
+
+  private
+    sᵢ-elts : Ob → Set ℓ
+    sᵢ-elts x .∣_∣ =  Σ[ i ∈ Idx ] Hom (sᵢ i) x
+    sᵢ-elts x .is-tr = Σ-is-hlevel 2 Idx-set (λ _ → hlevel!)
+
+  separating-family-covers
+    : ∀ x → is-epic (coprods.match (sᵢ-elts x) (sᵢ ⊙ fst) snd)
+  separating-family-covers x f g p = separate λ {i} eᵢ →
+    f ∘ eᵢ                       ≡⟨ pushr (sym commute) ⟩
+    (f ∘ match snd) ∘ ι (i , eᵢ) ≡⟨ p ⟩∘⟨refl ⟩
+    (g ∘ match snd) ∘ ι (i , eᵢ) ≡⟨ pullr commute ⟩
+    g ∘ eᵢ                       ∎
+    where open coprods (sᵢ-elts x) (sᵢ ⊙ fst)
+```
+
+## Dense separating families
+
+::: {.definition #dense-separating-family}
+A **dense separating family** is an family $S_i : I \to \cC$ such that the
+functors $\cC(S_i,-)$ are [[jointly fully faithful]].
+:::
+
+Unfortunately, we need to jump through some hoops to construct the appropriate
+functor from the full subcategory generated by $S_i$ into $[\cC, \Sets]$
+
+```agda
+is-dense-separating-family : ∀ {Idx : Type ℓ} → (Idx → Ob) → Type _
+is-dense-separating-family sᵢ =
+  is-jointly-fully-faithful (よcov C F∘ Functor.op (Forget-family {C = C} sᵢ))
+```
+
+```agda
+module _
+  {Idx : Type ℓ}
+  {sᵢ : Idx → Ob}
+  (dense : is-dense-separating-family sᵢ)
+  where
+  private
+    module dense {x} {y} = Equiv (_ , dense {x} {y})
+    open ↓Obj using (map)
+    open ↓Hom using (sq)
+
+  Approx : ∀ x → Functor (Forget-family {C = C} sᵢ ↘ x) C
+  Approx x = Forget-family sᵢ F∘ Dom _ _
+
+  dense-separating-family→coyoneda
+    : ∀ (x : Ob)
+    → is-colimit (Approx x) x _
+  dense-separating-family→coyoneda x = to-is-colimit colim where
+    open make-is-colimit
+
+    colim : make-is-colimit (Approx x) x
+    colim .ψ x = x .map
+    colim .commutes f = f .sq ∙ idl _
+    colim .universal eps p = dense.from λ where
+      .η i f → eps (↓obj f)
+      .is-natural i j f → ext λ g → sym (p (↓hom (sym (idl _))))
+    colim .factors eps p = {!!}
+    colim .unique = {!!}
 ```

--- a/src/Cat/Diagram/Separator.lagda.md
+++ b/src/Cat/Diagram/Separator.lagda.md
@@ -10,6 +10,7 @@ open import Cat.Diagram.Coproduct.Indexed
 open import Cat.Functor.FullSubcategory
 open import Cat.Diagram.Colimit.Base
 open import Cat.Diagram.Limit.Finite
+open import Cat.Diagram.Zero
 open import Cat.Diagram.Equaliser
 open import Cat.Instances.Shape.Terminal
 open import Cat.Instances.Sets
@@ -25,6 +26,8 @@ open import Cat.Prelude
 
 import Cat.Reasoning
 import Cat.Morphism.StrongEpi
+
+open import Data.Dec.Base
 ```
 -->
 
@@ -139,7 +142,7 @@ functors $C(S_i, -)$ are [[jointly faithful]].
 separating-family→jointly-faithful
   : ∀ {ℓi} {Idx : Type ℓi} {sᵢ : Idx → Ob}
   → is-separating-family sᵢ
-  → is-jointly-faithful (λ i → Hom-from C (sᵢ i ))
+  → is-jointly-faithful (λ i → Hom-from C (sᵢ i))
 separating-family→jointly-faithful separates p = separates λ eᵢ → p _ $ₚ eᵢ
 
 jointly-faithful→separating-family
@@ -302,6 +305,40 @@ equalisers+jointly-conservative→separating-family equalisers fᵢ∘-conservat
 ```
 </details>
 
+```agda
+module _
+  {κ} {Idx : Type κ} {sᵢ : Idx → Ob}
+  ⦃ Idx-Discrete : Discrete Idx ⦄
+  (coprods : has-coproducts-indexed-by C Idx)
+  (zero : Zero C)
+  where
+  open Zero zero
+  open Indexed-coproducts-by C coprods
+
+  zero+separating-family→separator
+    : is-separating-family sᵢ
+    → is-separator (ΣF sᵢ)
+  zero+separating-family→separator separate {f = f} {g = g} p =
+    separate λ {i} eᵢ →
+      f ∘ eᵢ                              ≡˘⟨ ap (f ∘_) (ι-commute _ ∙ detect-yes i eᵢ) ⟩
+      f ∘ match sᵢ (detect i eᵢ) ∘ ι sᵢ i ≡⟨ extendl (p _) ⟩
+      g ∘ match sᵢ (detect i eᵢ) ∘ ι sᵢ i ≡⟨ ap (g ∘_) (ι-commute _ ∙ detect-yes i eᵢ) ⟩
+      g ∘ eᵢ                              ∎
+    where
+      detect : ∀ {x} (i : Idx) (eᵢ : Hom (sᵢ i) x) → (j : Idx) → Hom (sᵢ j) x
+      detect i eᵢ j with i ≡? j
+      ... | yes i=j = subst _ i=j eᵢ
+      ... | no _ = zero→
+
+      detect-yes : ∀ {x} (i : Idx) (eᵢ : Hom (sᵢ i) x) → detect i eᵢ i ≡ eᵢ
+      detect-yes {x = x} i eᵢ with i ≡? i
+      ... | yes i=i =
+        is-set→subst-refl
+          (λ i → Hom (sᵢ i) x)
+          (Discrete→is-set Idx-Discrete)
+          i=i eᵢ
+      ... | no ¬i=i = absurd (¬i=i refl)
+```
 
 # Strong separators
 

--- a/src/Cat/Diagram/Separator.lagda.md
+++ b/src/Cat/Diagram/Separator.lagda.md
@@ -9,6 +9,7 @@ open import Cat.Diagram.Coproduct.Indexed
 open import Cat.Functor.FullSubcategory
 open import Cat.Diagram.Colimit.Base
 open import Cat.Diagram.Limit.Finite
+open import Cat.Diagram.Equaliser
 open import Cat.Instances.Shape.Terminal
 open import Cat.Instances.Sets
 open import Cat.Functor.Constant
@@ -268,6 +269,51 @@ we omit the details.
       ∙ assoc _ _ _
 ```
 </details>
+
+## Existence of separating families
+
+```agda
+equalisers+conservative→separator
+  : ∀ {s}
+  → has-equalisers C
+  → is-conservative (Hom-from C s)
+  → is-separator s
+equalisers+conservative→separator equalisers f∘-conservative {f = f} {g = g} p =
+  invertible→epic equ-invertible f g Eq.equal
+  where
+    module Eq = Equaliser (equalisers f g)
+
+    equ-invertible : is-invertible Eq.equ
+    equ-invertible =
+      f∘-conservative $
+      is-equiv→is-invertible $
+      is-iso→is-equiv $ iso
+        (λ e → Eq.universal (p e))
+        (λ e → Eq.factors)
+        (λ h → sym (Eq.unique refl))
+```
+
+```agda
+equalisers+jointly-conservative→separating-family
+  : ∀ {κ} {Idx : Type κ} {sᵢ : Idx → Ob}
+  → has-equalisers C
+  → is-jointly-conservative (λ i → Hom-from C (sᵢ i))
+  → is-separating-family sᵢ
+equalisers+jointly-conservative→separating-family equalisers fᵢ∘-conservative {f = f} {g = g} p =
+  invertible→epic equ-invertible f g Eq.equal
+  where
+    module Eq = Equaliser (equalisers f g)
+
+    equ-invertible : is-invertible Eq.equ
+    equ-invertible =
+      fᵢ∘-conservative λ i →
+      is-equiv→is-invertible $
+      is-iso→is-equiv $ iso
+        (λ eᵢ → Eq.universal (p eᵢ))
+        (λ eᵢ → Eq.factors)
+        (λ h → sym (Eq.unique refl))
+```
+
 
 # Strong separators
 

--- a/src/Cat/Diagram/Separator.lagda.md
+++ b/src/Cat/Diagram/Separator.lagda.md
@@ -5,7 +5,6 @@ description: |
 
 <!--
 ```agda
-open import Cat.Diagram.Coequaliser.RegularEpi
 open import Cat.Diagram.Coproduct.Copower
 open import Cat.Diagram.Coproduct.Indexed
 open import Cat.Instances.Shape.Terminal
@@ -149,7 +148,7 @@ separating-family→jointly-faithful separates p = separates λ eᵢ → p _ $�
 
 jointly-faithful→separating-family
   : ∀ {ℓi} {Idx : Type ℓi} {sᵢ : Idx → Ob}
-  → is-jointly-faithful (λ i → Hom-from C (sᵢ i ))
+  → is-jointly-faithful (λ i → Hom-from C (sᵢ i))
   → is-separating-family sᵢ
 jointly-faithful→separating-family faithful p = faithful λ i → funext p
 ```
@@ -341,143 +340,6 @@ module _
           i=i eᵢ
       ... | no ¬i=i = absurd (¬i=i refl)
 ```
-
-# Strong separators
-
-```agda
-module _
-  (copowers : (I : Set ℓ) → has-coproducts-indexed-by C ∣ I ∣)
-  where
-  open Copowers copowers
-
-  is-strong-separator : Ob → Type (o ⊔ ℓ)
-  is-strong-separator s = ∀ {x} → is-strong-epi (⊗!.match (Hom s x) s λ e → e)
-
-  is-strong-separating-family
-    : ∀ (Idx : Set ℓ)
-    → (sᵢ : ∣ Idx ∣ → Ob)
-    → Type (o ⊔ ℓ)
-  is-strong-separating-family Idx sᵢ =
-    ∀ {x} → is-strong-epi (∐!.match (Σ[ i ∈ ∣ Idx ∣ ] (Hom (sᵢ i) x)) (sᵢ ⊙ fst) snd)
-
-  strong-separator→separator
-    : ∀ {s}
-    → is-strong-separator s
-    → is-separator s
-  strong-separator→separator strong =
-    epi→separator copowers (strong .fst)
-
-  strong-separating-family→separating-family
-    : ∀ (Idx : Set ℓ) (sᵢ : ∣ Idx ∣ → Ob)
-    → is-strong-separating-family Idx sᵢ
-    → is-separating-family sᵢ
-  strong-separating-family→separating-family Idx sᵢ strong =
-    epi→separating-family copowers Idx sᵢ (strong .fst)
-```
-
-```agda
-  strong-separator→conservative
-    : ∀ {s}
-    → is-strong-separator s
-    → is-conservative (Hom-from C s)
-  strong-separator→conservative {s = s} strong {A = a} {B = b} {f = f} f∘-inv =
-    strong-epi+mono→is-invertible
-      f-mono
-      f-strong-epi
-    where
-      module f∘- = Equiv (f ∘_ , is-invertible→is-equiv f∘-inv)
-
-      f-mono : is-monic f
-      f-mono u v p =
-        strong-separator→separator strong λ e →
-        f∘-.injective (extendl p)
-
-      f' : Hom ((Hom s b) ⊗! s) a
-      f' = ⊗!.match (Hom s b) s λ e → f∘-.from e
-
-      f'-factors : f ∘ f' ≡ ⊗!.match (Hom s b) s (λ e → e)
-      f'-factors = ⊗!.unique _ _ _ λ e →
-        (f ∘ f') ∘ ⊗!.ι (Hom s b) s e ≡⟨ pullr (⊗!.commute (Hom s b) s) ⟩
-        f ∘ f∘-.from e                ≡⟨ f∘-.ε e ⟩
-        e                             ∎
-
-      f-strong-epi : is-strong-epi f
-      f-strong-epi =
-        strong-epi-cancell f f' $
-        subst is-strong-epi (sym f'-factors) strong
-```
-
-```agda
-  lex+conservative→strong-separator
-    : ∀ {s}
-    → Finitely-complete C
-    → is-conservative (Hom-from C s)
-    → is-strong-separator s
-  lex+conservative→strong-separator lex f∘-conservative =
-    is-extremal-epi→is-strong-epi lex λ m i p →
-    f∘-conservative $
-    is-equiv→is-invertible $
-    is-iso→is-equiv $ iso
-      (λ e → i ∘ ⊗!.ι _ _ e)
-      (λ f' → pulll (sym p) ∙ ⊗!.commute _ _)
-      (λ e → m .monic _ _ (pulll (sym p) ∙ ⊗!.commute _ _))
-```
-
-```agda
-  strong-separating-family→jointly-conservative
-    : ∀ (Idx : Set ℓ) (sᵢ : ∣ Idx ∣ → Ob)
-    → is-strong-separating-family Idx sᵢ
-    → is-jointly-conservative (λ i → Hom-from C (sᵢ i))
-
-  lex+jointly-conservative→strong-separating-family
-    : ∀ (Idx : Set ℓ) (sᵢ : ∣ Idx ∣ → Ob)
-    → Finitely-complete C
-    → is-jointly-conservative (λ i → Hom-from C (sᵢ i))
-    → is-strong-separating-family Idx sᵢ
-```
-
-<details>
-<summary>
-</summary>
-```agda
-  strong-separating-family→jointly-conservative Idx sᵢ strong {x = a} {y = b} {f = f} f∘ᵢ-inv =
-    strong-epi+mono→is-invertible
-      f-mono
-      f-strong-epi
-    where
-      module f∘- {i : ∣ Idx ∣} = Equiv (_ , is-invertible→is-equiv (f∘ᵢ-inv i))
-
-      f-mono : is-monic f
-      f-mono u v p =
-        strong-separating-family→separating-family Idx sᵢ strong λ eᵢ →
-        f∘-.injective (extendl p)
-
-      f' : Hom (∐! (Σ[ i ∈ ∣ Idx ∣ ] (Hom (sᵢ i) b)) (sᵢ ⊙ fst)) a
-      f' = ∐!.match _ _ (f∘-.from ⊙ snd)
-
-      f'-factors : f ∘ f' ≡ ∐!.match (Σ[ i ∈ ∣ Idx ∣ ] (Hom (sᵢ i) b)) (sᵢ ⊙ fst) snd
-      f'-factors =
-        ∐!.unique _ _ _ λ (i , eᵢ) →
-        (f ∘ f') ∘ ∐!.ι _ _ (i , eᵢ) ≡⟨ pullr (∐!.commute _ _) ⟩
-        f ∘ f∘-.from eᵢ              ≡⟨ f∘-.ε eᵢ ⟩
-        eᵢ                           ∎
-
-      f-strong-epi : is-strong-epi f
-      f-strong-epi =
-        strong-epi-cancell f f' $
-        subst is-strong-epi (sym f'-factors) strong
-
-  lex+jointly-conservative→strong-separating-family Idx sᵢ lex f∘-conservative =
-    is-extremal-epi→is-strong-epi lex λ m f p →
-    f∘-conservative $ λ i →
-    is-equiv→is-invertible $
-    is-iso→is-equiv $ iso
-      (λ eᵢ → f ∘ ∐!.ι _ _ (i , eᵢ))
-      (λ f' → pulll (sym p) ∙ ∐!.commute _ _)
-      (λ eᵢ → m .monic _ _ (pulll (sym p) ∙ ∐!.commute _ _))
-
-```
-</details>
 
 # Dense separators
 

--- a/src/Cat/Diagram/Separator.lagda.md
+++ b/src/Cat/Diagram/Separator.lagda.md
@@ -8,7 +8,10 @@ description: |
 open import Cat.Diagram.Coproduct.Indexed
 open import Cat.Functor.FullSubcategory
 open import Cat.Diagram.Colimit.Base
+open import Cat.Instances.Shape.Terminal
+open import Cat.Functor.Constant
 open import Cat.Functor.Properties
+open import Cat.Functor.Compose
 open import Cat.Instances.Comma
 open import Cat.Functor.Joint
 open import Cat.Functor.Base
@@ -39,7 +42,7 @@ open _=>_
 # Separating objects
 
 One of key property of $\Sets$ is that we can demonstrate the equality of
-2 functions $f, g : A \to B$ by proving that they are equal pointwise.
+2 functions $f, g : A \to B$ by showing that they are equal pointwise.
 Categorically, this is equivalent to saying that we can determine the
 equality of 2 morphisms $A \to B$ in $\Sets$ solely by looking at
 global elements $\top \to A$. This is not the case for general categories
@@ -60,6 +63,11 @@ In analogy to global elements, we will call morphisms $\cC(S,X)$ out of a
 separator $S$ **$S$-global elements**.
 :::
 
+::: warning
+Some authors (notably [@Borceux:vol1]) use the term "generator" to
+in place of separator.
+:::
+
 ```agda
 is-separator : Ob → Type _
 is-separator s =
@@ -69,8 +77,8 @@ is-separator s =
 ```
 
 Equivalently, an object $S$ is a separator if the hom functor $\cC(S,-)$
-is [[faithful]]. A good way to view this condition is that it is requiring
-the $S$-global elements functor to be somewhat well-behaved.
+is [[faithful]]. A good way to view this condition is that it ensures
+that the $S$-global elements functor to be somewhat well-behaved.
 
 ```agda
 separator→faithful : ∀ {s} → is-separator s → is-faithful (Hom-from C s)
@@ -92,111 +100,8 @@ separator-identity-system
   → is-identity-system {A = Hom x y}
       (λ f g → ∀ (e : Hom s x) → f ∘ e ≡ g ∘ e)
       (λ f e → refl)
-separator-identity-system separate = set-identity-system hlevel! separate
-```
-
-## Separators and copowers
-
-Recall that if $\cC$ is [[copowered]], then we can construct an
-approximation of any object $X : \cC$ by taking the copower $\cC(A,X) \otimes A$
-for some $A : \cC$. Intuitively, this approximation works by adding a copy
-of $A$ for every generalized element $\cC(A,X)$. In the category of sets,
-$\Sets(\top, X) \otimes X$ is the coproduct of $X$-many copies of $\top$,
-which is isomorphic to $X$.
-
-Generalizing from $\Sets$, we can attempt to approximate any object
-$X$ by taking the copower $\cC(S,X) \otimes S$, where $S$ is a separating
-object. While we don't quite get an isomorphism $\cC(S,X) \otimes S \iso X$,
-we can show that the universal map $\cC(S,X) \otimes X \to X$ out of the
-copower is an epimorphism.
-
-To see this, let $f, g : \cC(X, Y)$ such that
-$f \mathrm{match}(\lambda f. f) = f \circ \mathrm{match}(\lambda f. f)$;
-$S$ is a separating object, so it suffices to show that $f \circ e = g \circ e$
-for every generalized element $e : \cC(S, X)$. However, $e = \mathrm{match}(\lambda f. f) \circ \iota_e$,
-which immediately gives us $f \circ e = g \circ e$ by our hypothesis.
-
-```agda
-module _
-  {sep : Ob}
-  (separate : is-separator sep)
-  (copowers : (I : Set ℓ) → has-coproducts-indexed-by C ∣ I ∣)
-  where
-  module copowers (I : Set ℓ) (x : Ob) = Indexed-coproduct (copowers I λ _ → x)
-
-  separator-covers : ∀ x → is-epic (copowers.match (el! (Hom sep x)) sep λ f → f)
-  separator-covers x f g p = separate λ e →
-    f ∘ e                       ≡⟨ pushr (sym commute) ⟩
-    (f ∘ (match λ f → f)) ∘ ι e ≡⟨ p ⟩∘⟨refl ⟩
-    (g ∘ (match λ f → f)) ∘ ι e ≡⟨ pullr commute ⟩
-    g ∘ e                       ∎
-    where open copowers (el! (Hom sep x)) sep
-```
-
-## Dense separators
-
-::: {.definition #dense-separator}
-A **dense separator** is an object $S : \cC$ such that the functor
-$\cC(S,-)$ is [[fully faithful]].
-:::
-
-```agda
-is-dense-separator : Ob → Type _
-is-dense-separator s = is-fully-faithful (Hom-from C s)
-```
-
-In other words: morphisms of $\cC$ are given by *functions* between
-$S$-global elements.
-
-If $S$ is a dense separator, then it is also a separating object.
-This follows by some abstract nonsense ($\cC(S,-)$ is fully faithful, and $S$
-is a separator if $\cC(S,-)$ is faithful), but we provide an elementary proof for the
-sake of intution. Suppose that $\forall (e : \cC(S,X),\ f \circ e = g \circ e)$
-To show $f = g$, it suffices to show that $f \circ - = g \circ -$, as
-functions $\cC(S,X) \to \cC(S,Y)$. We can then apply function extensionality,
-which gets us a $S$-global element $e : \cC(S,X)$, and our hypothesis handles
-the rest!
-
-```agda
-dense-separate : ∀ {s} → is-dense-separator s → is-separator s
-dense-separate {s} dense p = Equiv.injective (_ , dense) $ funext λ e → p e
-```
-
-Furthermore, if $S$ is a dense separator, then every object $X$ is a copower
-$\cC(S,X) \otimes S$. This can be seen as providing a particularly strong form
-of the [[coyoneda lemma]] for $\cC$, as every object can be expressed as a colimit
-of a single object.
-
-```agda
-dense-separator→coyoneda
-  : ∀ {s}
-  → is-dense-separator s
-  → ∀ (x : Ob) → is-indexed-coproduct C {Idx = Hom s x} (λ _ → s) (λ f → f)
-dense-separator→coyoneda dense x .is-indexed-coproduct.match fs =
-  equiv→inverse dense fs
-dense-separator→coyoneda dense x .is-indexed-coproduct.commute {e} {_} {fs} =
-  equiv→counit dense fs $ₚ e
-dense-separator→coyoneda dense x .is-indexed-coproduct.unique {h = h} fs p =
-  Equiv.adjunctl (_ , dense) $ funext p
-```
-
-The converse is also true: if every object $X$ is a copower $\cC(S,X) \otimes S$,
-then $S$ is a dense separator. Explicltly, we must construct an inverse to
-$\cC(S,-) : \cC(X,Y) \to (\cC(S, X) \to \cC(S, Y))$. Recall $X$ is a copower
-of $\cC(S,X) \otimes S$: the universal property of $\cC(S,X) \otimes S$ is *exactly*
-a function $(\cC(S, X) \to \cC(S, Y)) \to \cC(X,Y)$. Furthermore, the $\beta$ and $\eta$
-rules for copowers ensure that we actually obtain an inverse to $\cC(S,-)$.
-
-```agda
-coyoneda→dense-separator
-  : ∀ {s}
-  → (∀ (x : Ob) → is-indexed-coproduct C {Idx = Hom s x} (λ _ → s) (λ f → f))
-  → is-dense-separator s
-coyoneda→dense-separator {s} coyo {x} {y} =
-  is-iso→is-equiv $ iso (coyo.match x)
-    (λ fs → funext λ e → coyo.commute x)
-    (λ f → sym $ coyo.unique _ _ λ _ → refl)
-  where module coyo (x : Ob) = is-indexed-coproduct (coyo x)
+separator-identity-system separate =
+  set-identity-system (λ _ _ → hlevel 1) separate
 ```
 
 # Separating Families
@@ -207,14 +112,14 @@ we cannot determine equality of natural transformations $\alpha, \beta : P \to Q
 by looking at all maps $S \to P$ single $S$, but we *can* if we look at all
 maps $\yo(A) \to P$! This leads us to the following notion:
 
-:::{.definition #separating-object alias="separator"}
-A **separating family or **separator** is a family of objects $S : I \to \cC$ such that:
+:::{.definition #separating-family}
+A **separating family** is a family of objects $S : I \to \cC$ such that:
 - For every $f, g : \cC(A, B)$, if $f \circ e_i = g \circ e_i$ for every
   $i : I$ and every $e_i : \cC(S_i,A)$, then $f = g$.
 :::
 
 ```agda
-is-separating-family : ∀ {ℓi} {Idx : Type ℓi} → (Idx → Ob) → Type _ 
+is-separating-family : ∀ {ℓi} {Idx : Type ℓi} → (Idx → Ob) → Type _
 is-separating-family s =
   ∀ {x y} {f g : Hom x y}
   → (∀ {i} (eᵢ : Hom (s i) x) → f ∘ eᵢ ≡ g ∘ eᵢ)
@@ -248,86 +153,409 @@ separating-family-identity-system
   → is-identity-system {A = Hom x y}
       (λ f g → ∀ {i} (eᵢ : Hom (sᵢ i) x) → f ∘ eᵢ ≡ g ∘ eᵢ)
       (λ f e → refl)
-separating-family-identity-system separate = set-identity-system hlevel! separate
+separating-family-identity-system separate =
+  set-identity-system (λ _ _ → hlevel 1) separate
 ```
 
-## Separating families and indexed coproducts
+## Separators and copowers
 
-Recall that if $\cC$ is $\kappa$ locally-small and admits $\kappa$-small
-[[indexed coproducts]], then we can form an approximation of any object $X$
-via a family of objects $S_i : I \to \cC$  by forming the indexed coproduct
-$\coprod_{i : I, e_i : \cC(S_i, X)} S_i$. This approximation comes equipped
-with a canonical map $u : \coprod_{i : I, e_i : \cC(S_i, X)} S_i \to X$
-defined via the universal property of indexed coproducts. If $S_i$ is
-a separating family, then this map is an epi.
+Recall that if $\cC$ is [[copowered]], then we can construct an
+approximation of any object $X : \cC$ by taking the copower $\cC(A,X) \otimes A$
+for some $A : \cC$. Intuitively, this approximation works by adding a copy
+of $A$ for every generalized element $\cC(A,X)$. In the category of sets,
+$\Sets(\top, X) \otimes X$ is the coproduct of $X$-many copies of $\top$,
+which is isomorphic to $X$.
 
+Generalizing from $\Sets$, we can attempt to approximate any object
+$X$ by taking the copower $\cC(S,X) \otimes S$, where $S$ is a separating
+object. While we don't quite get an isomorphism $\cC(S,X) \otimes S \iso X$,
+we can show that the universal map $\cC(S,X) \otimes X \to X$ out of the
+copower is an epimorphism.
+
+To see this, let $f, g : \cC(X, Y)$ such that
+$f \mathrm{match}(\lambda f. f) = f \circ \mathrm{match}(\lambda f. f)$;
+$S$ is a separating object, so it suffices to show that $f \circ e = g \circ e$
+for every generalized element $e : \cC(S, X)$. However, $e = \mathrm{match}(\lambda f. f) \circ \iota_e$,
+which immediately gives us $f \circ e = g \circ e$ by our hypothesis.
+
+```agda
+module _
+  {s : Ob}
+  (copowers : (I : Set ℓ) → has-coproducts-indexed-by C ∣ I ∣)
+  where
+  private
+    module ∐ᶠx x = Indexed-coproduct (copowers (el! (Hom s x)) λ f → s)
+
+  separator→epic : ∀ {x} → is-separator s → is-epic (∐ᶠx.match x λ f → f)
+  separator→epic {x} separate f g p = separate λ e →
+    f ∘ e                       ≡⟨ pushr (sym (∐ᶠx.commute x)) ⟩
+    (f ∘ (∐ᶠx.match x λ f → f)) ∘ ∐ᶠx.ι x e ≡⟨ p ⟩∘⟨refl ⟩
+    (g ∘ (∐ᶠx.match x λ f → f)) ∘ ∐ᶠx.ι x e ≡⟨ pullr (∐ᶠx.commute x) ⟩
+    g ∘ e                       ∎
+```
+
+Conversely, if the canonical map $\gamma_{X} : \cC(S,X) \otimes S \to X$
+is an epimorphism for every $X$, then $S$ is a separator.
+
+Let $f, g : \cC(X, Y)$ such that $f \circ e = g \circ e$ for every
+$e : \cC(S, X)$. Note that $f \circ \gamma_{X} \circ \iota = g \circ \gamma_{X} \circ \iota$
+by our hypothesis, so $f \circ \gamma_{X} = g \circ \gamma_{X}$. Moreover,
+$\gamma_{X}$ is an epi, so $f = g$.
+
+```agda
+  epic→separator : (∀ {x} → is-epic (∐ᶠx.match x λ f → f)) → is-separator s
+  epic→separator epic {f = f} {g = g} p =
+    epic f g $ ∐ᶠx.unique₂ _ λ e →
+      sym (assoc _ _ _)
+      ∙ p _
+      ∙ assoc _ _ _
+```
+
+A similar result hold for separating families, but with: a family $S_i : \cC$
+is a separating family if and only if the canonical map
+$\coprod_{\Sigma (i : I), \cC(S_i, X)} S_i \to X$ is an epimorphism.
+
+<!--
 ```agda
 module _
   {Idx : Type ℓ}
   {sᵢ : Idx → Ob}
   (Idx-set : is-set Idx)
-  (separate : is-separating-family sᵢ)
   (coprods : (I : Set ℓ) → has-coproducts-indexed-by C ∣ I ∣)
   where
-  module coprods (I : Set ℓ) (xᵢ : ∣ I ∣ → Ob) = Indexed-coproduct (coprods I xᵢ)
-
   private
-    sᵢ-elts : Ob → Set ℓ
-    sᵢ-elts x .∣_∣ =  Σ[ i ∈ Idx ] Hom (sᵢ i) x
-    sᵢ-elts x .is-tr = Σ-is-hlevel 2 Idx-set (λ _ → hlevel!)
+    instance
+      H-Level-Idx : ∀ {n} → H-Level Idx (2 + n)
+      H-Level-Idx = basic-instance 2 Idx-set
 
-  separating-family-covers
-    : ∀ x → is-epic (coprods.match (sᵢ-elts x) (sᵢ ⊙ fst) snd)
-  separating-family-covers x f g p = separate λ {i} eᵢ →
-    f ∘ eᵢ                       ≡⟨ pushr (sym commute) ⟩
-    (f ∘ match snd) ∘ ι (i , eᵢ) ≡⟨ p ⟩∘⟨refl ⟩
-    (g ∘ match snd) ∘ ι (i , eᵢ) ≡⟨ pullr commute ⟩
-    g ∘ eᵢ                       ∎
-    where open coprods (sᵢ-elts x) (sᵢ ⊙ fst)
+```
+-->
+
+```agda
+  private
+    module ∐ᶠxᵢ (x : Ob) =
+      Indexed-coproduct (coprods (el! (Σ[ i ∈ Idx ] Hom (sᵢ i) x)) (sᵢ ⊙ fst))
+
+  separating-family→epic
+    : ∀ {x}
+    → is-separating-family sᵢ
+    → is-epic (∐ᶠxᵢ.match x snd)
+
+  epic→separating-family
+    : (∀ {x} → is-epic (∐ᶠxᵢ.match x snd))
+    → is-separating-family sᵢ
+```
+
+<details>
+<summary>The proof is almost identical to the single-object case, so
+we omit the details.
+</summary>
+```agda
+  separating-family→epic {x = x} separate f g p = separate λ {i} eᵢ →
+    f ∘ eᵢ                                     ≡⟨ pushr (sym (∐ᶠxᵢ.commute x)) ⟩
+    (f ∘ ∐ᶠxᵢ.match x snd) ∘ ∐ᶠxᵢ.ι x (i , eᵢ) ≡⟨ p ⟩∘⟨refl ⟩
+    (g ∘ ∐ᶠxᵢ.match x snd) ∘ ∐ᶠxᵢ.ι x (i , eᵢ) ≡⟨ pullr (∐ᶠxᵢ.commute x) ⟩
+    g ∘ eᵢ                                     ∎
+
+  epic→separating-family epic {f = f} {g = g} p =
+    epic f g $ ∐ᶠxᵢ.unique₂ _ λ (i , eᵢ) →
+      sym (assoc _ _ _)
+      ∙ p _
+      ∙ assoc _ _ _
+```
+</details>
+
+
+# Dense separators
+
+As noted in the previous sections, separating objects categorify
+the idea that the behaviour of functions can be determined by their
+action on $S$-generalized elements. However, note that a separating
+object only lets us *equate* morphisms; ideally, we would be able to
+construct a morphism $\cC(X,Y)$ by giving a function $\cC(S,X) \to \cC(S,Y)$
+on $S$-generalized elements as well! This desire leads directly to the
+notion of a **dense separating object**.
+
+
+:::{.definition #dense-separating-object alias="dense-separator"}
+An object $S : \cC$ **dense separating object** is a
+**dense separating object** or **dense separator** if:
+- For all $X, Y : \cC$, a function $\eta : \cC(S,X) \to \cC(S,Y)$ induces
+  a morphism $u_{\eta} : \cC(X,Y)$; and
+- For every generalized element $e : \cC(S, X)$, $u_{\eta} \circ e = \eta e$; and
+- The map $u_{f}$ is universal among all such maps.
+:::
+
+```agda
+record is-dense-separator (s : Ob) : Type (o ⊔ ℓ) where
+  no-eta-equality
+  field
+    universal
+      : ∀ {x y}
+      → (eta : Hom s x → Hom s y)
+      → Hom x y
+    commute
+      : ∀ {x y}
+      → {eta : Hom s x → Hom s y}
+      → {e : Hom s x}
+      → universal eta ∘ e ≡ eta e
+    unique
+      : ∀ {x y}
+      → {eta : Hom s x → Hom s y}
+      → (h : Hom x y)
+      → (∀ (e : Hom s x) → h ∘ e ≡ eta e)
+      → h ≡ universal eta
+```
+
+As the name suggests, dense separators are separators: this follows
+directly from the uniqueness of the universal map.
+
+```agda
+  separate
+    : ∀ {x y}
+    → {f g : Hom x y}
+    → (∀ (e : Hom s x) → f ∘ e ≡ g ∘ e)
+    → f ≡ g
+  separate p = unique _ p ∙ sym (unique _ λ _ → refl)
+```
+
+<!--
+```agda
+module _ where
+  open is-dense-separator
+```
+-->
+
+Equivalently, an object $S$ is a dense separator if the hom functor
+$\cC(S,-)$ is [[fully faithful]].
+
+```agda
+  dense-separator→ff
+    : ∀ {s}
+    → is-dense-separator s
+    → is-fully-faithful (Hom-from C s)
+  dense-separator→ff dense =
+    is-iso→is-equiv $ iso
+      (dense .universal)
+      (λ eta → ext λ e → dense .commute)
+      (λ h → sym (dense .unique h (λ _ → refl)))
+
+  ff→dense-separator
+    : ∀ {s}
+    → is-fully-faithful (Hom-from C s)
+    → is-dense-separator s
+  ff→dense-separator ff .universal =
+    equiv→inverse ff
+  ff→dense-separator ff .commute {eta = eta} {e = e} =
+    equiv→counit ff eta $ₚ e
+  ff→dense-separator ff .unique h p =
+    sym (equiv→unit ff h) ∙ ap (equiv→inverse ff) (ext p)
+```
+
+Furthermore, if $S$ is a dense separator, then every object $X$ is a copower
+$\cC(S,X) \otimes S$. This can be seen as providing a particularly strong form
+of the [[coyoneda lemma]] for $\cC$, as every object can be expressed as a colimit
+of a single object. Alternatively, this is a categorification of the idea
+that every set is a coproduct of copies of the point!
+
+```agda
+dense-separator→coyoneda
+  : ∀ {s}
+  → is-dense-separator s
+  → ∀ (x : Ob)
+  → is-indexed-coproduct C {Idx = Hom s x} (λ _ → s) (λ f → f)
+dense-separator→coyoneda {s = s} dense x = is-copower where
+  module dense = is-dense-separator dense
+  open is-indexed-coproduct
+
+  is-copower : is-indexed-coproduct C {Idx = Hom s x} (λ _ → s) (λ f → f)
+  is-copower .match  = dense.universal
+  is-copower .commute = dense.commute
+  is-copower .unique h p = dense.unique _ p
+```
+
+The converse is also true: if every object $X$ is a copower $\cC(S,X) \otimes S$,
+then $S$ is a dense separator.
+
+```agda
+coyoneda→dense-separator
+  : ∀ {s}
+  → (∀ (x : Ob) → is-indexed-coproduct C {Idx = Hom s x} (λ _ → s) (λ f → f))
+  → is-dense-separator s
+coyoneda→dense-separator {s} coyo = dense where
+  module coyo (x : Ob) = is-indexed-coproduct (coyo x)
+  open is-dense-separator
+
+  dense : is-dense-separator s
+  dense .universal = coyo.match _
+  dense .commute = coyo.commute _
+  dense .unique h p = coyo.unique _ _ p
 ```
 
 ## Dense separating families
 
+Next, we extend the notion of a dense separator to a family of objects.
+
 ::: {.definition #dense-separating-family}
-A **dense separating family** is an family $S_i : I \to \cC$ such that the
-functors $\cC(S_i,-)$ are [[jointly fully faithful]].
+A family of objects $S_i : \cC$ is a **dense separating family** if:
+- functions $\eta : (i : I) \to \cC(S_i, X) \to \cC(S_i, y)$ with
+  $\eta i (f \circ g) = eta j f \circ g$ induce maps $u_{\eta} : \cC(X,Y)$; and
+- For every $e_i : \cC(S_i, X)$, $u_{\eta} \circ e_i = \eta i e_i$; and
+- The map $u_{f}$ is universal among all such maps.
 :::
 
-Unfortunately, we need to jump through some hoops to construct the appropriate
-functor from the full subcategory generated by $S_i$ into $[\cC, \Sets]$
-
 ```agda
-is-dense-separating-family : ∀ {Idx : Type ℓ} → (Idx → Ob) → Type _
-is-dense-separating-family sᵢ =
-  is-jointly-fully-faithful (よcov C F∘ Functor.op (Forget-family {C = C} sᵢ))
+record is-dense-separating-family
+  {Idx : Type ℓ}
+  (sᵢ : Idx → Ob)
+  : Type (o ⊔ ℓ) where
+  no-eta-equality
+  field
+    universal
+      : ∀ {x y}
+      → (eta : ∀ i → Hom (sᵢ i) x → Hom (sᵢ i) y)
+      → (∀ {i j} (f : Hom (sᵢ j) x) (g : Hom (sᵢ i) (sᵢ j)) → eta i (f ∘ g) ≡ eta j f ∘ g)
+      → Hom x y
+    commute
+      : ∀ {x y}
+      → {eta : ∀ i → Hom (sᵢ i) x → Hom (sᵢ i) y}
+      → {p : ∀ {i j} (f : Hom (sᵢ j) x) (g : Hom (sᵢ i) (sᵢ j)) → eta i (f ∘ g) ≡ eta j f ∘ g}
+      → {i : Idx} {eᵢ : Hom (sᵢ i) x}
+      → universal eta p ∘ eᵢ ≡ eta i eᵢ
+    unique
+      : ∀ {x y}
+      → {eta : ∀ i → Hom (sᵢ i) x → Hom (sᵢ i) y}
+      → {p : ∀ {i j} (f : Hom (sᵢ j) x) (g : Hom (sᵢ i) (sᵢ j)) → eta i (f ∘ g) ≡ eta j f ∘ g}
+      → (h : Hom x y)
+      → (∀ (i : Idx) → (eᵢ : Hom (sᵢ i) x) → h ∘ eᵢ ≡ eta i eᵢ)
+      → h ≡ universal eta p
 ```
 
+Like their single-object counterparts, dense separating families are
+also separating families; this follows immediately from the uniqueness
+of the universal map.
+
+```agda
+  separate
+    : ∀ {x y}
+    → {f g : Hom x y}
+    → (∀ (i : Idx) (eᵢ : Hom (sᵢ i) x) → f ∘ eᵢ ≡ g ∘ eᵢ)
+    → f ≡ g
+  separate p =
+    unique {p = λ _ _ → assoc _ _ _} _ p
+    ∙ sym (unique _ λ _ _ → refl)
+```
+
+
+<!--
+```agda
+module _ {Idx} {sᵢ : Idx → Ob} where
+  open is-dense-separating-family
+```
+-->
+
+Equivalently, a dense separating family is an family $S_i : I \to \cC$ such
+that the functors $\cC(S_i,-)$ are [[jointly fully faithful]].
+Unfortunately, we need to jump through some hoops to construct the
+appropriate functor from the full subcategory generated
+by $S_i$ into $[\cC, \Sets]$
+
+```agda
+  jointly-ff→dense-separating-family
+    : is-jointly-fully-faithful (よcov C F∘ Functor.op (Forget-family {C = C} sᵢ))
+    → is-dense-separating-family sᵢ
+  jointly-ff→dense-separating-family joint-ff .universal eta p =
+    equiv→inverse joint-ff λ where
+      .η → eta
+      .is-natural _ _ g → ext λ f → p f g
+  jointly-ff→dense-separating-family joint-ff .commute {i = i} {eᵢ = eᵢ} =
+    equiv→counit joint-ff _ ηₚ i $ₚ eᵢ
+  jointly-ff→dense-separating-family joint-ff .unique h p =
+    sym (equiv→unit joint-ff h) ∙ ap (equiv→inverse joint-ff) (ext p)
+
+  dense-separating-family→jointly-ff
+    : is-dense-separating-family sᵢ
+    → is-jointly-fully-faithful (よcov C F∘ Functor.op (Forget-family {C = C} sᵢ))
+  dense-separating-family→jointly-ff dense =
+    is-iso→is-equiv $ iso
+      (λ α → dense .universal (α .η) (λ f g → α .is-natural _ _ g $ₚ f))
+      (λ α → ext λ i eᵢ → dense .commute)
+      λ h → sym (dense .unique h λ i eᵢ → refl)
+```
+
+We can also express this universality using the language of colimits.
+In particular, if $S\_i : I \to \cC$ is a dense separating family,
+then every object of $\cC$ can be expressed as a colimit over the
+diagram $\mathrm{Dom}_{X} : S_i \downarrow X \to \cC$ that takes a map
+$\cC(S_i, X)$ to its domain.
+
+<!--
 ```agda
 module _
   {Idx : Type ℓ}
   {sᵢ : Idx → Ob}
-  (dense : is-dense-separating-family sᵢ)
   where
-  private
-    module dense {x} {y} = Equiv (_ , dense {x} {y})
-    open ↓Obj using (map)
-    open ↓Hom using (sq)
+  open ↓Obj using (map)
+  open ↓Hom using (sq)
+```
+-->
 
+```agda
   Approx : ∀ x → Functor (Forget-family {C = C} sᵢ ↘ x) C
   Approx x = Forget-family sᵢ F∘ Dom _ _
 
-  dense-separating-family→coyoneda
-    : ∀ (x : Ob)
-    → is-colimit (Approx x) x _
-  dense-separating-family→coyoneda x = to-is-colimit colim where
+  is-dense-separating-family→coyoneda
+    : is-dense-separating-family sᵢ
+    → ∀ (x : Ob) → is-colimit (Approx x) x θ↘
+```
+
+First, note that we have a canonical cocone $\mathrm{Dom}_{X} \to \Delta_{X}$
+that takes an object in slice $\cC(S_i, X)$ to itself.
+
+```agda
+  is-dense-separating-family→coyoneda dense x = to-is-colimitp colim refl where
+    module dense = is-dense-separating-family dense
     open make-is-colimit
 
     colim : make-is-colimit (Approx x) x
     colim .ψ x = x .map
     colim .commutes f = f .sq ∙ idl _
-    colim .universal eps p = dense.from λ where
-      .η i f → eps (↓obj f)
-      .is-natural i j f → ext λ g → sym (p (↓hom (sym (idl _))))
-    colim .factors eps p = {!!}
-    colim .unique = {!!}
+```
+
+Moreover, this cocone is universal: given another cocone $\epsilon$ over $Y$,
+we can form a map $X \to Y$ by using the universal property of dense
+separating families.
+
+```agda
+    colim .universal eps p =
+      dense.universal
+        (λ i fᵢ → eps (↓obj fᵢ))
+        (λ f g → sym (p (↓hom (sym (idl _)))))
+    colim .factors {j} eps p =
+      dense.universal _ _ ∘ colim .ψ j ≡⟨ dense.commute ⟩
+      eps (↓obj (j .map))             ≡⟨ ap eps (↓Obj-path _ _ refl refl refl) ⟩
+      eps j                           ∎
+    colim .unique eta p other q = dense.unique other (λ i fᵢ → q (↓obj fᵢ))
+```
+
+As expected, the converse also holds: the proof is more or less the
+previous proof in reverse, so we do not comment on it too deeply.
+
+```agda
+  coyoneda→is-dense-separating-family
+    : (∀ (x : Ob) → is-colimit (Approx x) x θ↘)
+    → is-dense-separating-family sᵢ
+  coyoneda→is-dense-separating-family colim = dense where
+    module colim {x} = is-colimit (colim x)
+    open is-dense-separating-family
+
+    dense : is-dense-separating-family sᵢ
+    dense .universal eta p =
+      colim.universal
+        (λ f → eta _ (f .map))
+        (λ γ → sym (p _ _) ∙ ap (eta _) (γ .sq ∙ idl _))
+    dense .commute {eᵢ = eᵢ} =
+      colim.factors {j = ↓obj eᵢ} _ _
+    dense .unique h p =
+      colim.unique _ _ _ λ j → p _ (j .map)
 ```

--- a/src/Cat/Diagram/Separator.lagda.md
+++ b/src/Cat/Diagram/Separator.lagda.md
@@ -1,0 +1,161 @@
+---
+description: |
+  We define separating objects, and prove some basic properties.
+---
+
+<!--
+```agda
+open import Cat.Diagram.Coproduct.Indexed
+open import Cat.Diagram.Coproduct.Copower
+open import Cat.Instances.Shape.Terminal
+open import Cat.Diagram.Colimit.Base
+open import Cat.Functor.Properties
+open import Cat.Instances.Lift
+open import Cat.Functor.Dense
+open import Cat.Functor.Hom
+open import Cat.Prelude
+
+
+import Cat.Reasoning
+```
+-->
+
+```agda
+module Cat.Diagram.Separator {o ℓ} (C : Precategory o ℓ) where
+```
+
+<!--
+```agda
+open Cat.Reasoning C
+```
+-->
+
+# Separating objects
+
+One of key property of $\Sets$ is that we can demonstrate the equality of
+2 functions $f, g : A \to B$ by proving that they are equal pointwise.
+Categorically, this is equivalent to saying that we can determine the
+equality of 2 morphisms $A \to B$ in $\Sets$ solely by looking at
+global elements $\top \to A$. This is not the case for general categories
+equipped with a terminal object: the [[category of groups]] has a terminal
+object (the [[zero group]]), yet maps out of the zero group are
+unique^[In other words, the zero group is a [[zero object]].]! In light of
+this, we can generalize the role that $\top$ plays in $\Sets$ to obtain
+the a notion of separating object:
+
+:::{.definition #separating-object alias="separator"}
+A **separating object** or **separator** is an object $S : \cC$ that lets
+us determine equality of morphisms $f, g : \cC(A,B)$ solely by looking at
+the $S$-generalized elements of $A$. Expliclity, $S$ is a separator if:
+- For every $f, g : \cC(A, B)$, if $f \circ e = g \circ e$ for every
+  $e : \cC(S,A)$, then $f = g$.
+
+In analogy to global elements, we will call morphisms $\cC(S,X)$ out of a
+separator $S$ **$S$-global elements**.
+:::
+
+```agda
+is-separator : Ob → Type _
+is-separator s =
+  ∀ {x y} {f g : Hom x y}
+  → (∀ (e : Hom s x) → f ∘ e ≡ g ∘ e)
+  → f ≡ g
+
+record Separator : Type (o ⊔ ℓ) where
+  no-eta-equality
+  field
+    sep      : Ob
+    separate : is-separator sep
+```
+
+Equivalently, an object $S$ is a separator if the hom functor $\cC(S,-)$
+is [[faithful]]. A good way to view this condition is that it is requiring
+the $S$-global elements functor to be somewhat well-behaved.
+
+```agda
+is-separator→hom-faithful : ∀ {s} → is-separator s → is-faithful (Hom-from C s)
+is-separator→hom-faithful sep p = sep (happly p)
+
+hom-faithful→is-separator : ∀ {s} → is-faithful (Hom-from C s) → is-separator s
+hom-faithful→is-separator faithful p = faithful (ext p)
+```
+
+Intuitively, a separator $S$ gives us an internal version of function
+extensionality, with pointwise equality replaced by $S$-wise equality.
+
+## Separators and copowers
+
+Recall that if $\cC$ is [[copowered]], then we can construct an
+approximation of any object $X : \cC$ by taking the copower $\cC(A,X) \otimes A$
+for some $A : \cC$. Intuitively, this approximation works by adding a copy
+of $A$ for every generalized element $\cC(A,X)$. In the category of sets,
+$\Sets(\top, X) \otimes X$ is the coproduct of $X$-many copies of $\top$,
+which is isomorphic to $X$.
+
+Generalizing from $\Sets$, we can attempt to approximate any object
+$X$ by taking the copower $\cC(S,X) \otimes X$, where $S$ is a separating
+object. While we don't quite get an isomorphism $\cC(S,X) \otimes X \iso X$,
+we can show that the universal map $\cC(S,X) \otimes X \to X$ out of the
+copower is an epimorphism.
+
+To see this, let $f, g : \cC(X, Y)$ such that
+$f \mathrm{match}(\lambda f. f) = f \circ \mathrm{match}(\lambda f. f)$;
+$S$ is a separating object, so it suffices to show that $f \circ e = g \circ e$
+for every generalized element $e : \cC(S, X)$. However, $e = \mathrm{match}(\lambda f. f) \circ \iota_e$,
+which immediately gives us $f \circ e = g \circ e$ by our hypothesis.
+
+```agda
+module _
+  (S : Separator)
+  (copowers : (I : Set ℓ) → has-coproducts-indexed-by C ∣ I ∣)
+  where
+  open Separator S
+  module copowers (I : Set ℓ) (x : Ob) = Indexed-coproduct (copowers I λ _ → x)
+
+  separator-covers : ∀ x → is-epic (copowers.match (el! (Hom sep x)) sep λ f → f)
+  separator-covers x f g p = separate λ e →
+    f ∘ e                       ≡⟨ pushr (sym commute) ⟩
+    (f ∘ (match λ f → f)) ∘ ι e ≡⟨ p ⟩∘⟨refl ⟩
+    (g ∘ (match λ f → f)) ∘ ι e ≡⟨ pullr commute ⟩
+    g ∘ e                       ∎
+    where open copowers (el! (Hom sep x)) sep
+```
+
+## Dense separators
+
+::: {.definition #dense-separator}
+A **dense separator** is an object $S : \cC$ such that the functor
+$\cC(S,-)$ is [[fully faithful]].
+:::
+
+```agda
+is-dense-separator : Ob → Type _
+is-dense-separator s = is-fully-faithful (Hom-from C s)
+```
+
+In other words: morphisms of $\cC$ are given by *functions* between
+$S$-global elements.
+
+If $S$ is a dense separator, then it is also a separating object. The
+proof of this is rather slick: suppose that $\forall (e : \cC(S,X),\ f \circ e = g \circ e)$
+To show $f = g$, it suffices to show that $f \circ - = g \circ -$, as
+functions $\cC(S,X) \to \cC(S,Y)$. We can then apply function extensionality,
+which gets us a $S$-global element $e : \cC(S,X)$, and our hypothesis handles
+the rest!
+
+```agda
+dense-separate : ∀ {s} → is-dense-separator s → is-separator s
+dense-separate {s} dense p =
+  Equiv.injective (_ , dense) $ funext λ e → p e
+```
+
+
+# Separating Families
+
+```agda
+is-separating-family : ∀ {ℓi} {I : Type ℓi} → (I → Ob) → Type _ 
+is-separating-family s =
+  ∀ {x y} {f g : Hom x y}
+  → (∀ {i} (eᵢ : Hom (s i) x) → f ∘ eᵢ ≡ g ∘ eᵢ)
+  → f ≡ g
+```

--- a/src/Cat/Diagram/Separator.lagda.md
+++ b/src/Cat/Diagram/Separator.lagda.md
@@ -5,31 +5,31 @@ description: |
 
 <!--
 ```agda
+open import Cat.Diagram.Coequaliser.RegularEpi
 open import Cat.Diagram.Coproduct.Copower
 open import Cat.Diagram.Coproduct.Indexed
-open import Cat.Diagram.Coequaliser.RegularEpi
-open import Cat.Diagram.Coequaliser
+open import Cat.Instances.Shape.Terminal
 open import Cat.Functor.FullSubcategory
 open import Cat.Diagram.Colimit.Base
 open import Cat.Diagram.Limit.Finite
-open import Cat.Diagram.Zero
-open import Cat.Diagram.Equaliser
-open import Cat.Instances.Shape.Terminal
-open import Cat.Instances.Sets
-open import Cat.Functor.Constant
 open import Cat.Functor.Conservative
+open import Cat.Diagram.Coequaliser
 open import Cat.Functor.Properties
+open import Cat.Diagram.Equaliser
+open import Cat.Functor.Constant
 open import Cat.Functor.Compose
 open import Cat.Instances.Comma
+open import Cat.Instances.Sets
 open import Cat.Functor.Joint
+open import Cat.Diagram.Zero
 open import Cat.Functor.Base
 open import Cat.Functor.Hom
 open import Cat.Prelude
 
-import Cat.Reasoning
-import Cat.Morphism.StrongEpi
-
 open import Data.Dec.Base
+
+import Cat.Morphism.StrongEpi
+import Cat.Reasoning
 ```
 -->
 

--- a/src/Cat/Diagram/Separator.lagda.md
+++ b/src/Cat/Diagram/Separator.lagda.md
@@ -8,8 +8,11 @@ description: |
 open import Cat.Diagram.Coproduct.Indexed
 open import Cat.Functor.FullSubcategory
 open import Cat.Diagram.Colimit.Base
+open import Cat.Diagram.Limit.Finite
 open import Cat.Instances.Shape.Terminal
+open import Cat.Instances.Sets
 open import Cat.Functor.Constant
+open import Cat.Functor.Conservative
 open import Cat.Functor.Properties
 open import Cat.Functor.Compose
 open import Cat.Instances.Comma
@@ -18,8 +21,8 @@ open import Cat.Functor.Base
 open import Cat.Functor.Hom
 open import Cat.Prelude
 
-
 import Cat.Reasoning
+import Cat.Morphism.StrongEpi
 ```
 -->
 
@@ -29,6 +32,7 @@ module Cat.Diagram.Separator {o ℓ} (C : Precategory o ℓ) where
 
 <!--
 ```agda
+open Cat.Morphism.StrongEpi C
 open Cat.Reasoning C
 open _=>_
 ```
@@ -184,13 +188,13 @@ module _
   (copowers : (I : Set ℓ) → has-coproducts-indexed-by C ∣ I ∣)
   where
   private
-    module ∐ᶠx x = Indexed-coproduct (copowers (el! (Hom s x)) λ f → s)
+    module Elts x = Indexed-coproduct (copowers (el! (Hom s x)) λ f → s)
 
-  separator→epic : ∀ {x} → is-separator s → is-epic (∐ᶠx.match x λ f → f)
-  separator→epic {x} separate f g p = separate λ e →
-    f ∘ e                       ≡⟨ pushr (sym (∐ᶠx.commute x)) ⟩
-    (f ∘ (∐ᶠx.match x λ f → f)) ∘ ∐ᶠx.ι x e ≡⟨ p ⟩∘⟨refl ⟩
-    (g ∘ (∐ᶠx.match x λ f → f)) ∘ ∐ᶠx.ι x e ≡⟨ pullr (∐ᶠx.commute x) ⟩
+  separator→epi : ∀ {x} → is-separator s → is-epic (Elts.match x λ f → f)
+  separator→epi {x} separate f g p = separate λ e →
+    f ∘ e                       ≡⟨ pushr (sym (Elts.commute x)) ⟩
+    (f ∘ (Elts.match x λ f → f)) ∘ Elts.ι x e ≡⟨ p ⟩∘⟨refl ⟩
+    (g ∘ (Elts.match x λ f → f)) ∘ Elts.ι x e ≡⟨ pullr (Elts.commute x) ⟩
     g ∘ e                       ∎
 ```
 
@@ -203,9 +207,9 @@ by our hypothesis, so $f \circ \gamma_{X} = g \circ \gamma_{X}$. Moreover,
 $\gamma_{X}$ is an epi, so $f = g$.
 
 ```agda
-  epic→separator : (∀ {x} → is-epic (∐ᶠx.match x λ f → f)) → is-separator s
-  epic→separator epic {f = f} {g = g} p =
-    epic f g $ ∐ᶠx.unique₂ _ λ e →
+  epi→separator : (∀ {x} → is-epic (Elts.match x λ f → f)) → is-separator s
+  epi→separator epic {f = f} {g = g} p =
+    epic f g $ Elts.unique₂ _ λ e →
       sym (assoc _ _ _)
       ∙ p _
       ∙ assoc _ _ _
@@ -233,16 +237,16 @@ module _
 
 ```agda
   private
-    module ∐ᶠxᵢ (x : Ob) =
+    module Elts (x : Ob) =
       Indexed-coproduct (coprods (el! (Σ[ i ∈ Idx ] Hom (sᵢ i) x)) (sᵢ ⊙ fst))
 
-  separating-family→epic
+  separating-family→epi
     : ∀ {x}
     → is-separating-family sᵢ
-    → is-epic (∐ᶠxᵢ.match x snd)
+    → is-epic (Elts.match x snd)
 
-  epic→separating-family
-    : (∀ {x} → is-epic (∐ᶠxᵢ.match x snd))
+  epi→separating-family
+    : (∀ {x} → is-epic (Elts.match x snd))
     → is-separating-family sᵢ
 ```
 
@@ -251,19 +255,87 @@ module _
 we omit the details.
 </summary>
 ```agda
-  separating-family→epic {x = x} separate f g p = separate λ {i} eᵢ →
-    f ∘ eᵢ                                     ≡⟨ pushr (sym (∐ᶠxᵢ.commute x)) ⟩
-    (f ∘ ∐ᶠxᵢ.match x snd) ∘ ∐ᶠxᵢ.ι x (i , eᵢ) ≡⟨ p ⟩∘⟨refl ⟩
-    (g ∘ ∐ᶠxᵢ.match x snd) ∘ ∐ᶠxᵢ.ι x (i , eᵢ) ≡⟨ pullr (∐ᶠxᵢ.commute x) ⟩
+  separating-family→epi {x = x} separate f g p = separate λ {i} eᵢ →
+    f ∘ eᵢ                                     ≡⟨ pushr (sym (Elts.commute x)) ⟩
+    (f ∘ Elts.match x snd) ∘ Elts.ι x (i , eᵢ) ≡⟨ p ⟩∘⟨refl ⟩
+    (g ∘ Elts.match x snd) ∘ Elts.ι x (i , eᵢ) ≡⟨ pullr (Elts.commute x) ⟩
     g ∘ eᵢ                                     ∎
 
-  epic→separating-family epic {f = f} {g = g} p =
-    epic f g $ ∐ᶠxᵢ.unique₂ _ λ (i , eᵢ) →
+  epi→separating-family epic {f = f} {g = g} p =
+    epic f g $ Elts.unique₂ _ λ (i , eᵢ) →
       sym (assoc _ _ _)
       ∙ p _
       ∙ assoc _ _ _
 ```
 </details>
+
+# Strong separators
+
+```agda
+module _
+  (copowers : (I : Set ℓ) → has-coproducts-indexed-by C ∣ I ∣)
+  where
+  private
+    module Elts s x = Indexed-coproduct (copowers (el! (Hom s x)) λ f → s)
+
+  is-strong-separator : Ob → Type (o ⊔ ℓ)
+  is-strong-separator s = ∀ {x} → is-strong-epi (Elts.match s x λ e → e)
+
+  strong-separator→separator
+    : ∀ {s}
+    → is-strong-separator s
+    → is-separator s
+  strong-separator→separator strong =
+    epi→separator copowers (strong .fst)
+```
+
+```agda
+  strong-separator→conservative
+    : ∀ {s}
+    → is-strong-separator s
+    → is-conservative (Hom-from C s)
+  strong-separator→conservative {s = s} strong {A = a} {B = b} {f = f} f∘-inv =
+    strong-epi-mono→is-invertible
+      f-mono
+      f-strong-epi
+    where
+      module f∘- = Equiv (f ∘_ , is-invertible→is-equiv f∘-inv)
+
+      f-mono : is-monic f
+      f-mono u v p =
+        strong-separator→separator strong λ e →
+        f∘-.injective (extendl p)
+
+      f' : Hom (Elts.ΣF s b) a
+      f' = Elts.match s b λ e → f∘-.from e
+
+      f'-factors : f ∘ f' ≡ Elts.match s b (λ e → e)
+      f'-factors = Elts.unique s b _ λ e →
+        (f ∘ f') ∘ Elts.ι _ _ e ≡⟨ pullr (Elts.commute s b) ⟩
+        f ∘ f∘-.from e          ≡⟨ f∘-.ε e ⟩
+        e                       ∎
+
+      f-strong-epi : is-strong-epi f
+      f-strong-epi =
+        strong-epi-cancell f f' $
+        subst is-strong-epi (sym f'-factors) strong
+```
+
+```agda
+  finitely-complete+conservative→strong-separator
+    : ∀ {s}
+    → Finitely-complete C
+    → is-conservative (Hom-from C s)
+    → is-strong-separator s
+  finitely-complete+conservative→strong-separator lex f∘-conservative =
+    is-extremal-epi→is-strong-epi lex λ m i p →
+    f∘-conservative $
+    is-equiv→is-invertible $
+    is-iso→is-equiv $ iso
+      (λ e → i ∘ Elts.ι _ _ e)
+      (λ f' → pulll (sym p) ∙ Elts.commute _ _)
+      (λ e → m .monic _ _ (pulll (sym p) ∙ Elts.commute _ _))
+```
 
 
 # Dense separators

--- a/src/Cat/Diagram/Separator/Regular.lagda.md
+++ b/src/Cat/Diagram/Separator/Regular.lagda.md
@@ -1,0 +1,108 @@
+---
+description: |
+  Regular separators.
+---
+<!--
+```agda
+open import Cat.Diagram.Coequaliser.RegularEpi
+open import Cat.Diagram.Coproduct.Indexed
+open import Cat.Diagram.Coproduct.Copower
+open import Cat.Diagram.Coequaliser
+open import Cat.Prelude
+
+import Cat.Morphism.StrongEpi
+import Cat.Diagram.Separator
+import Cat.Reasoning
+```
+-->
+```agda
+module Cat.Diagram.Separator.Regular {o ℓ} (C : Precategory o ℓ) where
+```
+
+<!--
+```agda
+open Cat.Morphism.StrongEpi
+open Cat.Diagram.Separator C
+open Cat.Reasoning C
+```
+-->
+
+# Regular separators
+
+```agda
+module _
+  (copowers : (I : Set ℓ) → has-coproducts-indexed-by C ∣ I ∣)
+  where
+  open Copowers copowers
+
+  is-regular-separator : Ob → Type (o ⊔ ℓ)
+  is-regular-separator s = ∀ {x} → is-regular-epi C (⊗!.match (Hom s x) s λ e → e)
+
+  is-regular-separating-family
+    : ∀ (Idx : Set ℓ)
+    → (sᵢ : ∣ Idx ∣ → Ob)
+    → Type (o ⊔ ℓ)
+  is-regular-separating-family Idx sᵢ =
+    ∀ {x} → is-regular-epi C (∐!.match (Σ[ i ∈ ∣ Idx ∣ ] (Hom (sᵢ i) x)) (sᵢ ⊙ fst) snd)
+```
+
+```agda
+  regular-separator→separator
+    : ∀ {s}
+    → is-regular-separator s
+    → is-separator s
+  regular-separator→separator regular =
+    epi→separator copowers $
+    is-regular-epi→is-epic regular
+
+  regular-separating-family→separating-family
+    : ∀ (Idx : Set ℓ) (sᵢ : ∣ Idx ∣ → Ob)
+    → is-regular-separating-family Idx sᵢ
+    → is-separating-family sᵢ
+  regular-separating-family→separating-family Idx sᵢ regular =
+    epi→separating-family copowers Idx sᵢ $
+    is-regular-epi→is-epic regular
+```
+
+```agda
+module _
+  (copowers : (I : Set ℓ) → has-coproducts-indexed-by C ∣ I ∣)
+  where
+  open Copowers copowers
+
+  dense-separator→regular-separator
+    : ∀ {s}
+    → is-dense-separator s
+    → is-regular-separator copowers s
+  dense-separator→regular-separator {s = s} dense {x} = regular where
+    module dense = is-dense-separator dense
+    open is-regular-epi
+    open is-coequaliser
+
+    regular : is-regular-epi C (⊗!.match (Hom s x) s λ e → e)
+    regular .r = Hom s x ⊗! s
+    regular .arr₁ = id
+    regular .arr₂ = id
+    regular .has-is-coeq .coequal = refl
+    regular .has-is-coeq .universal {e' = e'} _ =
+      dense.universal λ e → e' ∘ ⊗!.ι (Hom s x) s e
+    regular .has-is-coeq .factors {e' = e'} {p = p} =
+      ⊗!.unique₂ (Hom s x) s λ e →
+        (dense.universal _ ∘ ⊗!.match _ _ _) ∘ ⊗!.ι _ _ e ≡⟨ pullr (⊗!.commute _ _) ⟩
+        dense.universal _ ∘ e                             ≡⟨ dense.commute ⟩
+        e' ∘ ⊗!.ι _ _ e                                   ∎
+    regular .has-is-coeq .unique {e' = e'} {colim = h} p =
+      dense.unique _ λ e →
+        h ∘ e                           ≡˘⟨ ap (h ∘_) (⊗!.commute (Hom s x) s) ⟩
+        h ∘ ⊗!.match _ _ _ ∘ ⊗!.ι _ _ e ≡⟨ pulll p ⟩
+        e' ∘ ⊗!.ι _ _ e                 ∎
+```
+
+```agda
+  regular-separator→strong-separator
+    : ∀ {s}
+    → is-regular-separator copowers s
+    → is-strong-separator copowers s
+  regular-separator→strong-separator {s} regular {x} =
+    is-regular-epi→is-strong-epi C _ regular
+```

--- a/src/Cat/Diagram/Separator/Regular.lagda.md
+++ b/src/Cat/Diagram/Separator/Regular.lagda.md
@@ -5,8 +5,8 @@ description: |
 <!--
 ```agda
 open import Cat.Diagram.Coequaliser.RegularEpi
-open import Cat.Diagram.Coproduct.Indexed
 open import Cat.Diagram.Coproduct.Copower
+open import Cat.Diagram.Coproduct.Indexed
 open import Cat.Diagram.Coequaliser
 open import Cat.Prelude
 

--- a/src/Cat/Diagram/Separator/Regular.lagda.md
+++ b/src/Cat/Diagram/Separator/Regular.lagda.md
@@ -10,99 +10,146 @@ open import Cat.Diagram.Coproduct.Indexed
 open import Cat.Diagram.Coequaliser
 open import Cat.Prelude
 
+import Cat.Diagram.Separator.Strong
 import Cat.Morphism.StrongEpi
 import Cat.Diagram.Separator
 import Cat.Reasoning
 ```
 -->
 ```agda
-module Cat.Diagram.Separator.Regular {o ℓ} (C : Precategory o ℓ) where
+module Cat.Diagram.Separator.Regular
+  {o ℓ}
+  (C : Precategory o ℓ)
+  (coprods : (I : Set ℓ) → has-coproducts-indexed-by C ∣ I ∣)
+  where
 ```
 
 <!--
 ```agda
-open Cat.Morphism.StrongEpi
+open Cat.Morphism.StrongEpi C
+open Cat.Diagram.Separator.Strong C coprods
 open Cat.Diagram.Separator C
 open Cat.Reasoning C
+open Copowers coprods
+
+private variable
+  s : Ob
 ```
 -->
 
 # Regular separators
 
+:::{.definition #strong-separator}
+Let $\cC$ be a category with [[set-indexed coproducts|indexed-coproduct]].
+An object $S$ is a **regular separator** if the canonical map $\coprod_{\cC(S,X)} S \to X$
+is a [[regular epi]].
+:::
+
 ```agda
-module _
-  (copowers : (I : Set ℓ) → has-coproducts-indexed-by C ∣ I ∣)
-  where
-  open Copowers copowers
-
-  is-regular-separator : Ob → Type (o ⊔ ℓ)
-  is-regular-separator s = ∀ {x} → is-regular-epi C (⊗!.match (Hom s x) s λ e → e)
-
-  is-regular-separating-family
-    : ∀ (Idx : Set ℓ)
-    → (sᵢ : ∣ Idx ∣ → Ob)
-    → Type (o ⊔ ℓ)
-  is-regular-separating-family Idx sᵢ =
-    ∀ {x} → is-regular-epi C (∐!.match (Σ[ i ∈ ∣ Idx ∣ ] (Hom (sᵢ i) x)) (sᵢ ⊙ fst) snd)
+is-regular-separator : Ob → Type (o ⊔ ℓ)
+is-regular-separator s = ∀ {x} → is-regular-epi C (⊗!.match (Hom s x) s λ e → e)
 ```
 
-```agda
-  regular-separator→separator
-    : ∀ {s}
-    → is-regular-separator s
-    → is-separator s
-  regular-separator→separator regular =
-    epi→separator copowers $
-    is-regular-epi→is-epic regular
+:::{.definition #strong-separating-family}
+A family of objects $S_i$ is a **regular separating family** if the
+canonical map $\coprod_{\Sigma(i : I), \cC(S_i, X)} S_i \to X$
+is a [[regular epi]].
+:::
 
-  regular-separating-family→separating-family
-    : ∀ (Idx : Set ℓ) (sᵢ : ∣ Idx ∣ → Ob)
-    → is-regular-separating-family Idx sᵢ
-    → is-separating-family sᵢ
-  regular-separating-family→separating-family Idx sᵢ regular =
-    epi→separating-family copowers Idx sᵢ $
-    is-regular-epi→is-epic regular
+```agda
+is-regular-separating-family
+  : ∀ (Idx : Set ℓ)
+  → (sᵢ : ∣ Idx ∣ → Ob)
+  → Type (o ⊔ ℓ)
+is-regular-separating-family Idx sᵢ =
+  ∀ {x} → is-regular-epi C (∐!.match (Σ[ i ∈ ∣ Idx ∣ ] (Hom (sᵢ i) x)) (sᵢ ⊙ fst) snd)
 ```
 
+To motivate this definition, note that [[dense separators]] are extremely
+rare, as it imposes a strong discreteness condition on $\cC$. Instead, it
+is slightly more reasonable to assume that every object of $\cC$ arises
+via some *quotient* of a bunch of points. It this intuition is what regular
+separators codify.
+
+As the name suggests, regular separators and regular separating families
+are separators and separating families, resp. This follows directly
+from the fact that regular epis are epis.
+
 ```agda
-module _
-  (copowers : (I : Set ℓ) → has-coproducts-indexed-by C ∣ I ∣)
-  where
-  open Copowers copowers
+regular-separator→separator
+  : ∀ {s}
+  → is-regular-separator s
+  → is-separator s
+regular-separator→separator regular =
+  epi→separator coprods $
+  is-regular-epi→is-epic regular
 
-  dense-separator→regular-separator
-    : ∀ {s}
-    → is-dense-separator s
-    → is-regular-separator copowers s
-  dense-separator→regular-separator {s = s} dense {x} = regular where
-    module dense = is-dense-separator dense
-    open is-regular-epi
-    open is-coequaliser
-
-    regular : is-regular-epi C (⊗!.match (Hom s x) s λ e → e)
-    regular .r = Hom s x ⊗! s
-    regular .arr₁ = id
-    regular .arr₂ = id
-    regular .has-is-coeq .coequal = refl
-    regular .has-is-coeq .universal {e' = e'} _ =
-      dense.universal λ e → e' ∘ ⊗!.ι (Hom s x) s e
-    regular .has-is-coeq .factors {e' = e'} {p = p} =
-      ⊗!.unique₂ (Hom s x) s λ e →
-        (dense.universal _ ∘ ⊗!.match _ _ _) ∘ ⊗!.ι _ _ e ≡⟨ pullr (⊗!.commute _ _) ⟩
-        dense.universal _ ∘ e                             ≡⟨ dense.commute ⟩
-        e' ∘ ⊗!.ι _ _ e                                   ∎
-    regular .has-is-coeq .unique {e' = e'} {colim = h} p =
-      dense.unique _ λ e →
-        h ∘ e                           ≡˘⟨ ap (h ∘_) (⊗!.commute (Hom s x) s) ⟩
-        h ∘ ⊗!.match _ _ _ ∘ ⊗!.ι _ _ e ≡⟨ pulll p ⟩
-        e' ∘ ⊗!.ι _ _ e                 ∎
+regular-separating-family→separating-family
+  : ∀ (Idx : Set ℓ) (sᵢ : ∣ Idx ∣ → Ob)
+  → is-regular-separating-family Idx sᵢ
+  → is-separating-family sᵢ
+regular-separating-family→separating-family Idx sᵢ regular =
+  epi→separating-family coprods Idx sᵢ $
+  is-regular-epi→is-epic regular
 ```
 
+## Relations to other separators
+
+Every [[dense separator]] is regular.
+
 ```agda
-  regular-separator→strong-separator
-    : ∀ {s}
-    → is-regular-separator copowers s
-    → is-strong-separator copowers s
-  regular-separator→strong-separator {s} regular {x} =
-    is-regular-epi→is-strong-epi C _ regular
+dense-separator→regular-separator
+  : is-dense-separator s
+  → is-regular-separator s
+```
+
+The proof here mirrors the proof that [colimits yield regular epis in
+the presence of enough coproducts]. More explicitly, the idea is that
+$\cC(S,X) \otimes S$ is already a sufficient approximation of $X$, so
+we do not need to perform any quotienting. In other words, $(\id, \id)$
+ought to be a coequalising pair.
+
+[colimits yield regular epis in the presence of enough coproducts]:
+  Cat.Diagram.Coequaliser.RegularEpi.html#existence-of-regular-epis
+
+```agda
+dense-separator→regular-separator {s = s} dense {x} = regular where
+  module dense = is-dense-separator dense
+  open is-regular-epi
+  open is-coequaliser
+
+  regular : is-regular-epi C (⊗!.match (Hom s x) s λ e → e)
+  regular .r = Hom s x ⊗! s
+  regular .arr₁ = id
+  regular .arr₂ = id
+  regular .has-is-coeq .coequal = refl
+```
+
+This is straightforward enough to prove with sufficient elbow grease.
+
+```agda
+  regular .has-is-coeq .universal {e' = e'} _ =
+    dense.universal λ e → e' ∘ ⊗!.ι (Hom s x) s e
+  regular .has-is-coeq .factors {e' = e'} {p = p} =
+    ⊗!.unique₂ (Hom s x) s λ e →
+      (dense.universal _ ∘ ⊗!.match _ _ _) ∘ ⊗!.ι _ _ e ≡⟨ pullr (⊗!.commute _ _) ⟩
+      dense.universal _ ∘ e                             ≡⟨ dense.commute ⟩
+      e' ∘ ⊗!.ι _ _ e                                   ∎
+  regular .has-is-coeq .unique {e' = e'} {colim = h} p =
+    dense.unique _ λ e →
+      h ∘ e                           ≡˘⟨ ap (h ∘_) (⊗!.commute (Hom s x) s) ⟩
+      h ∘ ⊗!.match _ _ _ ∘ ⊗!.ι _ _ e ≡⟨ pulll p ⟩
+      e' ∘ ⊗!.ι _ _ e                 ∎
+```
+
+Additionally, note that every regular separator is a [[strong separator]];
+this follows directly from the fact that every regular epi is strong.
+
+```agda
+regular-separator→strong-separator
+  : ∀ {s}
+  → is-regular-separator s
+  → is-strong-separator s
+regular-separator→strong-separator {s} regular {x} =
+  is-regular-epi→is-strong-epi _ regular
 ```

--- a/src/Cat/Diagram/Separator/Strong.lagda.md
+++ b/src/Cat/Diagram/Separator/Strong.lagda.md
@@ -1,0 +1,343 @@
+---
+description: |
+  Strong separators.
+---
+<!--
+```agda
+open import Cat.Diagram.Coequaliser.RegularEpi
+open import Cat.Diagram.Coproduct.Copower
+open import Cat.Diagram.Coproduct.Indexed
+open import Cat.Diagram.Limit.Finite
+open import Cat.Functor.Conservative
+open import Cat.Instances.Sets
+open import Cat.Functor.Joint
+open import Cat.Functor.Hom
+open import Cat.Prelude
+
+import Cat.Morphism.StrongEpi
+import Cat.Diagram.Separator
+import Cat.Reasoning
+```
+-->
+```agda
+module Cat.Diagram.Separator.Strong
+  {o ℓ}
+  (C : Precategory o ℓ)
+  (coprods : (I : Set ℓ) → has-coproducts-indexed-by C ∣ I ∣)
+  where
+```
+
+<!--
+```agda
+open Cat.Morphism.StrongEpi C
+open Cat.Diagram.Separator C
+open Cat.Reasoning C
+open Copowers coprods
+
+private variable
+  s : Ob
+```
+-->
+
+# Strong separators
+
+Recall that a [[separating object]] $S$ lets us determine equality of
+morphisms solely by examining $S$-generalized objects. This leads to
+the a natural question: what other properties of morphisms can we compute
+like this? In our case: can we determine if a map $f : \cC(X,Y)$ is
+[[invertible]] by restricting to generalized objects? Generally speaking,
+the answer is no, but it is possible if we strengthen our notion of
+separating object.
+
+:::{.definition #strong-separator}
+Let $\cC$ be a category with [[set-indexed coproducts|indexed-coproduct]].
+An object $S$ is a **strong separator** if the canonical map $\coprod_{\cC(S,X)} S \to X$
+is a [[strong epi]].
+:::
+
+```agda
+is-strong-separator : Ob → Type (o ⊔ ℓ)
+is-strong-separator s = ∀ {x} → is-strong-epi (⊗!.match (Hom s x) s λ e → e)
+```
+
+We can also weaken this definition to a family of objects.
+
+:::{.definition #strong-separating-family}
+A family of objects $S_i$ is a **strong separating family** if the
+canonical map $\coprod_{\Sigma(i : I), \cC(S_i, X)} S_i \to X$
+is a [[strong epi]].
+:::
+
+```agda
+is-strong-separating-family
+  : ∀ (Idx : Set ℓ)
+  → (sᵢ : ∣ Idx ∣ → Ob)
+  → Type (o ⊔ ℓ)
+is-strong-separating-family Idx sᵢ =
+  ∀ {x} → is-strong-epi (∐!.match (Σ[ i ∈ ∣ Idx ∣ ] (Hom (sᵢ i) x)) (sᵢ ⊙ fst) snd)
+```
+
+Strong separators are [[separatings]]. This follows from the fact
+that an object $S$ is a separator if and only if the canonical map
+$\coprod_{\cC(S,X)} S \to X$ is an epi.
+
+```agda
+strong-separator→separator
+  : is-strong-separator s
+  → is-separator s
+strong-separator→separator strong =
+  epi→separator coprods (strong .fst)
+```
+
+A similar line of reasoning shows that strong separating families are
+separating families.
+
+```agda
+strong-separating-family→separating-family
+  : ∀ (Idx : Set ℓ) (sᵢ : ∣ Idx ∣ → Ob)
+  → is-strong-separating-family Idx sᵢ
+  → is-separating-family sᵢ
+strong-separating-family→separating-family Idx sᵢ strong =
+  epi→separating-family coprods Idx sᵢ (strong .fst)
+```
+
+# Extremal separators
+
+For reasons that we will see shortly, it is useful to weaken the notion
+of strong separators to [[extremal epimorphisms]].
+
+:::{.definition #extremal-separator}
+Let $\cC$ be a category with [[set-indexed coproducts|indexed-coproduct]].
+An object $S$ is a **strong separator** if the canonical map $\coprod_{\cC(S,X)} S \to X$
+is an [[extremal epi]].
+:::
+
+```agda
+is-extremal-separator : Ob → Type (o ⊔ ℓ)
+is-extremal-separator s = ∀ {x} → is-extremal-epi (⊗!.match (Hom s x) s λ e → e)
+```
+
+:::{.definition #extremal-separating-family}
+A family of objects $S_i$ is a **extremal separating family** if the
+canonical map $\coprod_{\Sigma(i : I), \cC(S_i, X)} S_i \to X$
+is a [[strong epi]].
+:::
+
+```agda
+is-extremal-separating-family
+  : ∀ (Idx : Set ℓ)
+  → (sᵢ : ∣ Idx ∣ → Ob)
+  → Type (o ⊔ ℓ)
+is-extremal-separating-family Idx sᵢ =
+  ∀ {x} → is-extremal-epi (∐!.match (Σ[ i ∈ ∣ Idx ∣ ] (Hom (sᵢ i) x)) (sᵢ ⊙ fst) snd)
+```
+
+Via a general result involving strong and extremal epis, strong separators
+are extremal.
+
+```agda
+strong-separator→extremal-separator
+  : is-strong-separator s
+  → is-extremal-separator s
+strong-separator→extremal-separator strong =
+  is-strong-epi→is-extremal-epi strong
+
+strong-separating-family→extremal-separating-family
+  : ∀ (Idx : Set ℓ)
+  → (sᵢ : ∣ Idx ∣ → Ob)
+  → is-strong-separating-family Idx sᵢ
+  → is-extremal-separating-family Idx sᵢ
+strong-separating-family→extremal-separating-family Idx sᵢ strong =
+  is-strong-epi→is-extremal-epi strong
+```
+
+Moreover, if $\cC$ has all [[finite limits]], then extremal separators
+are strong.
+
+```agda
+lex+extremal-separator→strong-separator
+  : Finitely-complete C
+  → is-extremal-separator s
+  → is-strong-separator s
+lex+extremal-separator→strong-separator lex extremal =
+  is-extremal-epi→is-strong-epi lex extremal
+
+lex+extremal-separating-family→strong-separating-family
+  : ∀ (Idx : Set ℓ)
+  → (sᵢ : ∣ Idx ∣ → Ob)
+  → Finitely-complete C
+  → is-extremal-separating-family Idx sᵢ
+  → is-strong-separating-family Idx sᵢ
+lex+extremal-separating-family→strong-separating-family Idx sᵢ lex extremal =
+  is-extremal-epi→is-strong-epi lex extremal
+```
+
+## Functorial definitions
+
+We shall now prover our claim that a strong separator $S$ allows us to
+distinguish invertible morphisms purely by checking invertibility at
+$S$-generalized elements. More precisely, if $S$ is a strong separator,
+then $\cC(S,-)$ is [[conservative]].
+
+```agda
+strong-separator→conservative
+  : ∀ {s}
+  → is-strong-separator s
+  → is-conservative (Hom-from C s)
+```
+
+Suppose that $f : \cC(X,Y)$ is a morphism such that $f \circ e$ is invertible
+for every $e : \cC(S,X)$. We shall show that $f$ itself is invertible
+by showing that it is both a strong epi and a monomorphism.
+
+```agda
+strong-separator→conservative {s = s} strong {A = a} {B = b} {f = f} f∘-inv =
+  strong-epi+mono→is-invertible
+    f-mono
+    f-strong-epi
+  where
+    module f∘- = Equiv (f ∘_ , is-invertible→is-equiv f∘-inv)
+```
+
+Showing that $f$ is monic is pretty straightforward. Suppose that
+we have $u, v : \cC(X, A)$ such that $f \circ u = f \circ v$.
+Because $S$ is a separator, we can show that $u = v$ by showing
+that $u \circ e = v \circ e$ for some $S$-generalized element $e$.
+Moreover, postcomposition with $f$ is injective on morphisms with domain
+$S$ so it suffices to prove that $f \circ u \circ e = f \circ v \circ e$;
+this follows directly from our hypothesis.
+
+```agda
+    f-mono : is-monic f
+    f-mono u v p =
+      strong-separator→separator strong λ e →
+      f∘-.injective (extendl p)
+```
+
+Proving that $f$ is a strong epi is a bit more work. First, note that
+we can construct a map $f^* : \coprod_{\cC(S,B)} \to A$ by applying
+the inverse of $f \circ - : \cC(S,A) \to \cC(S,B)$; moreover, this
+map factorizes the canonical map $\coprod_{\cC(S,B)} S \to B$.
+
+```agda
+    f* : Hom ((Hom s b) ⊗! s) a
+    f* = ⊗!.match (Hom s b) s λ e → f∘-.from e
+
+    f*-factors : f ∘ f* ≡ ⊗!.match (Hom s b) s (λ e → e)
+    f*-factors = ⊗!.unique _ _ _ λ e →
+      (f ∘ f*) ∘ ⊗!.ι (Hom s b) s e ≡⟨ pullr (⊗!.commute (Hom s b) s) ⟩
+      f ∘ f∘-.from e                ≡⟨ f∘-.ε e ⟩
+      e                             ∎
+```
+
+By definition, the canonical map $\coprod_{\cC(S,B)} S \to B$ is a strong
+epi. Moreover, if a composite $f \circ g$ is a strong epi, then $f$
+is a strong epi. If we apply this observation to our factorization, we
+immediately see that $f$ is a strong epi.
+
+```agda
+    f-strong-epi : is-strong-epi f
+    f-strong-epi =
+      strong-epi-cancell f f* $
+      subst is-strong-epi (sym f*-factors) strong
+```
+
+Conversely, if $\cC(S,-)$ is conservative, then $S$ is an extremal
+separator. The proof here is some basic data manipulation, so we
+do not dwell on it too deeply.
+
+```agda
+conservative→extremal-separator
+  : ∀ {s}
+  → is-conservative (Hom-from C s)
+  → is-extremal-separator s
+conservative→extremal-separator f∘-conservative m f p =
+  f∘-conservative $
+  is-equiv→is-invertible $
+  is-iso→is-equiv $ iso
+    (λ e → f ∘ ⊗!.ι _ _ e)
+    (λ f* → pulll (sym p) ∙ ⊗!.commute _ _)
+    (λ e → m .monic _ _ (pulll (sym p) ∙ ⊗!.commute _ _))
+```
+
+In particular, if $\cC$ is finitely complete, then conservativity
+of $\cC(S,-)$ implies that $S$ is a strong separator.
+
+```agda
+lex+conservative→strong-separator
+  : ∀ {s}
+  → Finitely-complete C
+  → is-conservative (Hom-from C s)
+  → is-strong-separator s
+lex+conservative→strong-separator lex f∘-conservative =
+  is-extremal-epi→is-strong-epi lex $
+  conservative→extremal-separator f∘-conservative
+```
+
+We can generalize these results to separating families by considering
+[[jointly conservative functors]].
+
+```agda
+strong-separating-family→jointly-conservative
+  : ∀ (Idx : Set ℓ) (sᵢ : ∣ Idx ∣ → Ob)
+  → is-strong-separating-family Idx sᵢ
+  → is-jointly-conservative (λ i → Hom-from C (sᵢ i))
+
+jointly-conservative→extremal-separating-family
+  : ∀ (Idx : Set ℓ) (sᵢ : ∣ Idx ∣ → Ob)
+  → Finitely-complete C
+  → is-jointly-conservative (λ i → Hom-from C (sᵢ i))
+  → is-extremal-separating-family Idx sᵢ
+
+lex+jointly-conservative→strong-separating-family
+  : ∀ (Idx : Set ℓ) (sᵢ : ∣ Idx ∣ → Ob)
+  → Finitely-complete C
+  → is-jointly-conservative (λ i → Hom-from C (sᵢ i))
+  → is-strong-separating-family Idx sᵢ
+```
+
+<details>
+<summary>The proofs are identical to their non-familial counterparts,
+so we omit the details.
+</summary>
+```agda
+strong-separating-family→jointly-conservative Idx sᵢ strong {x = a} {y = b} {f = f} f∘ᵢ-inv =
+  strong-epi+mono→is-invertible
+    f-mono
+    f-strong-epi
+  where
+    module f∘- {i : ∣ Idx ∣} = Equiv (_ , is-invertible→is-equiv (f∘ᵢ-inv i))
+
+    f-mono : is-monic f
+    f-mono u v p =
+      strong-separating-family→separating-family Idx sᵢ strong λ eᵢ →
+      f∘-.injective (extendl p)
+
+    f* : Hom (∐! (Σ[ i ∈ ∣ Idx ∣ ] (Hom (sᵢ i) b)) (sᵢ ⊙ fst)) a
+    f* = ∐!.match _ _ (f∘-.from ⊙ snd)
+
+    f*-factors : f ∘ f* ≡ ∐!.match (Σ[ i ∈ ∣ Idx ∣ ] (Hom (sᵢ i) b)) (sᵢ ⊙ fst) snd
+    f*-factors =
+      ∐!.unique _ _ _ λ (i , eᵢ) →
+      (f ∘ f*) ∘ ∐!.ι _ _ (i , eᵢ) ≡⟨ pullr (∐!.commute _ _) ⟩
+      f ∘ f∘-.from eᵢ              ≡⟨ f∘-.ε eᵢ ⟩
+      eᵢ                           ∎
+
+    f-strong-epi : is-strong-epi f
+    f-strong-epi =
+      strong-epi-cancell f f* $
+      subst is-strong-epi (sym f*-factors) strong
+
+jointly-conservative→extremal-separating-family Idx sᵢ lex f∘-conservative m f p =
+  f∘-conservative $ λ i →
+  is-equiv→is-invertible $
+  is-iso→is-equiv $ iso
+    (λ eᵢ → f ∘ ∐!.ι _ _ (i , eᵢ))
+    (λ f* → pulll (sym p) ∙ ∐!.commute _ _)
+    (λ eᵢ → m .monic _ _ (pulll (sym p) ∙ ∐!.commute _ _))
+
+lex+jointly-conservative→strong-separating-family Idx sᵢ lex f∘-conservative =
+  is-extremal-epi→is-strong-epi lex $
+  jointly-conservative→extremal-separating-family Idx sᵢ lex f∘-conservative
+```
+</details>

--- a/src/Cat/Diagram/Zero.lagda.md
+++ b/src/Cat/Diagram/Zero.lagda.md
@@ -20,7 +20,7 @@ module _ {o h} (C : Precategory o h) where
 ```
 -->
 
-# Zero objects
+# Zero objects {defines="zero-object"}
 
 In some categories, `Initial`{.Agda} and `Terminal`{.Agda} objects
 coincide. When this occurs, we call the object a **zero object**.

--- a/src/Cat/Functor/FullSubcategory.lagda.md
+++ b/src/Cat/Functor/FullSubcategory.lagda.md
@@ -185,7 +185,7 @@ module _ {ℓi} {Idx : Type ℓi} (Xᵢ : Idx → C.Ob) where
   Family : Precategory ℓi h
   Family .Ob = Idx
   Family .Hom i j = C.Hom (Xᵢ i) (Xᵢ j)
-  Family .Hom-set = hlevel!
+  Family .Hom-set _ _ = hlevel 2
   Family .id = C.id
   Family ._∘_ = C._∘_
   Family .idr = C.idr
@@ -193,7 +193,7 @@ module _ {ℓi} {Idx : Type ℓi} (Xᵢ : Idx → C.Ob) where
   Family .assoc = C.assoc
 ```
 
-There is an evident functor from $X_i \to \cC$ that takes each $i$ to 
+There is an evident functor from $X_i \to \cC$ that takes each $i$ to
 $X_i$.
 
 ```

--- a/src/Cat/Functor/FullSubcategory.lagda.md
+++ b/src/Cat/Functor/FullSubcategory.lagda.md
@@ -173,3 +173,36 @@ module _ {P : C.Ob → Type ℓ} where
   Forget-full-subcat-is-ff : is-fully-faithful Forget-full-subcat
   Forget-full-subcat-is-ff = id-equiv
 ```
+
+## From families of objects
+
+Finally, we can construct a full subcategory by giving a family of
+objects $X_i : I \to Ob$ of $\cC$ by forming a modified version of
+$\cC$ whose objects have been replaced by elements of $I$.
+
+```agda
+module _ {ℓi} {Idx : Type ℓi} (Xᵢ : Idx → C.Ob) where
+  Family : Precategory ℓi h
+  Family .Ob = Idx
+  Family .Hom i j = C.Hom (Xᵢ i) (Xᵢ j)
+  Family .Hom-set = hlevel!
+  Family .id = C.id
+  Family ._∘_ = C._∘_
+  Family .idr = C.idr
+  Family .idl = C.idl
+  Family .assoc = C.assoc
+```
+
+There is an evident functor from $X_i \to \cC$ that takes each $i$ to 
+$X_i$.
+
+```
+  Forget-family : Functor Family C
+  Forget-family .Functor.F₀ = Xᵢ
+  Forget-family .Functor.F₁ f = f
+  Forget-family .Functor.F-id = refl
+  Forget-family .Functor.F-∘ _ _ = refl
+
+  Forget-family-ff : is-fully-faithful Forget-family
+  Forget-family-ff = id-equiv
+```

--- a/src/Cat/Functor/Hom/Coyoneda.lagda.md
+++ b/src/Cat/Functor/Hom/Coyoneda.lagda.md
@@ -28,7 +28,7 @@ open _=>_
 ```
 -->
 
-## The Coyoneda lemma
+## The Coyoneda lemma {defines="coyoneda coyoneda-lemma"}
 
 The Coyoneda lemma is, like its dual, a statement about presheaves.  It
 states that "every presheaf is a colimit of representables", which, in

--- a/src/Cat/Functor/Joint.lagda.md
+++ b/src/Cat/Functor/Joint.lagda.md
@@ -1,0 +1,202 @@
+---
+description: |
+  We generalize properties of functors to families of functors.
+---
+<!--
+```agda
+open import Cat.Functor.Conservative
+open import Cat.Functor.Naturality
+open import Cat.Functor.Properties
+open import Cat.Functor.Base
+open import Cat.Prelude
+
+import Cat.Reasoning
+```
+-->
+```agda
+module Cat.Functor.Joint where
+```
+
+<!--
+```agda
+private variable
+  o h o₁ h₁ iℓ : Level
+  C D K : Precategory o h
+  Idx : Type iℓ
+open Functor
+open _=>_
+```
+-->
+
+# Families of functors
+
+This module generalizes properties of functors (fullness, faithfulness,
+conservativity, etc.) to families of functors $F_i : \cC \to \cD$.
+For the rest of this section we will fix a family of functors
+$F_i : \cC \to \cD$.
+
+```agda
+Swap : Functor K Cat[ C , D ] → Functor C Cat[ K , D ]
+Swap F .F₀ c .F₀ k = F .F₀ k .F₀ c
+Swap F .F₀ c .F₁ f = F .F₁ f .η c
+Swap F .F₀ c .F-id = F .F-id ηₚ c
+Swap F .F₀ c .F-∘ f g = F .F-∘ f g ηₚ c
+Swap F .F₁ f .η k = F .F₀ k .F₁ f
+Swap F .F₁ f .is-natural x y g = sym (F .F₁ g .is-natural _ _ f)
+Swap F .F-id = ext λ k → F .F₀ k .F-id
+Swap F .F-∘ f g = ext λ k → F .F₀ k .F-∘ f g 
+
+module _
+  {oc ℓc od ℓd}
+  {C : Precategory oc ℓc}
+  {D : Precategory od ℓd}
+  where
+  private
+    module C = Cat.Reasoning C
+    module D = Cat.Reasoning D
+```
+
+:::{.definition #jointly-faithful-functors}
+A family of functors $F_i : \cC \to \cD$ is **jointly faithful** when:
+- For any $f, g : \cC(x,y)$, if $F_i(f) = F_i(g)$ for every $I$, then
+$f = g$
+:::
+
+```agda
+  is-jointly-faithful : (Idx → Functor C D) → Type _
+  is-jointly-faithful Fᵢ =
+    ∀ {x y} {f g : C.Hom x y} → (∀ i → Fᵢ i .F₁ f ≡ Fᵢ i .F₁ g) → f ≡ g
+```
+
+The canonical example of a family of jointly faithful functors are the
+family of hom-functors $\hat{C}(\yo(A), -)$, indexed by objects of $A$:
+this is a restatment of the [[coyoneda lemma]].
+
+Note that every functor $F : \cI \to [\cC, \cD]$ induces a family of
+functors via the mapping on objects: this family is jointly faithful
+precisely when $\hat{F} : \cC \to [\cI, \cD]$ is faithful.
+
+```agda
+  swap-faithful→jointly-faithful
+    : (F : Functor K Cat[ C , D ])
+    → is-faithful (Swap F)
+    → is-jointly-faithful (F .F₀)
+  swap-faithful→jointly-faithful F faithful p = faithful (ext p)
+  
+  jointly-faithful→swap-faithful
+    : (F : Functor K Cat[ C , D ])
+    → is-jointly-faithful (F .F₀)
+    → is-faithful (Swap F)
+  jointly-faithful→swap-faithful F joint p = joint (λ i → p ηₚ i)
+```
+
+## Jointly conservative functors
+
+:::{.definition #jointly-conservative-functors}
+A family of functors $F_i : \cC \to \cD$ is **jointly conservative** when:
+- For $f : \cC(x,y)$, if $F_i(f)$ is an iso for every $i$, then $f$ is an iso.
+:::
+
+```agda
+  is-jointly-conservative : (Idx → Functor C D) → Type _
+  is-jointly-conservative Fᵢ =
+    ∀ {x y} {f : C.Hom x y} → (∀ i → D.is-invertible (Fᵢ i .F₁ f)) → C.is-invertible f
+```
+
+We can also rephrase joint-conservativity as a property of a diagram
+$F : \cI \to [ \cC, \cD ]$.
+
+```agda
+  swap-conservative→jointly-conservative
+    : (F : Functor K Cat[ C , D ])
+    → is-conservative (Swap F)
+    → is-jointly-conservative (F .F₀)
+  swap-conservative→jointly-conservative F reflect-iso isos =
+    reflect-iso (invertible→invertibleⁿ (Swap F .F₁ _) isos)
+  
+  jointly-conservative→swap-conservative
+    : (F : Functor K Cat[ C , D ])
+    → is-jointly-conservative (F .F₀)
+    → is-conservative (Swap F)
+  jointly-conservative→swap-conservative F reflect-iso isos =
+    reflect-iso (λ i → is-invertibleⁿ→is-invertible isos i)
+```
+
+
+## Jointly full functors
+
+:::{.definition #jointly-full-functors}
+A diagram of functors $F : \cI \to [\cC, \cD]$ is **jointly full** when
+the functor $\hat{F} : \cC \to [\cI, \cD]$ is full. Explicitly, $F$ is
+jointly full if a family of morphisms $g_i : \cD(F(i)(x), F(i)(y))$ that is
+natural in $i$ implies the mere existence of a $f : \cC(x,y)$ with
+$F_i(f) = g_i$.
+:::
+
+Note that joint fullness *must* be a property of a diagram of functors,
+due to the naturality constraint. This
+
+<!--
+```agda
+module _
+  {oc ℓc od ℓd ok ℓk}
+  {C : Precategory oc ℓc}
+  {D : Precategory od ℓd}
+  {K : Precategory ok ℓk}
+  where
+  private
+    module C = Cat.Reasoning C
+    module D = Cat.Reasoning D
+    module K = Cat.Reasoning K
+```
+-->
+
+```agda
+  is-jointly-full : Functor K Cat[ C , D ] → Type _
+  is-jointly-full F = is-full (Swap F)
+
+  jointly-full-fibre
+    : ∀ {x y}
+    → (F : Functor K Cat[ C , D ])
+    → is-jointly-full F
+    → (gᵢ : ∀ i → D.Hom (F .F₀ i .F₀ x) (F .F₀ i .F₀ y))
+    → (∀ {i j} (f : K.Hom i j) → gᵢ j D.∘ F .F₁ f .η x ≡ F .F₁ f .η y D.∘ gᵢ i)
+    → ∃[ f ∈ C.Hom x y ] (∀ i → F .F₀ i .F₁ f ≡ gᵢ i)
+  jointly-full-fibre F joint-full gᵢ gᵢ-nat =
+    ∥-∥-map (Σ-map₂ λ p i → p ηₚ i) (joint-full (NT gᵢ λ i j f → gᵢ-nat f))
+```
+
+
+## Jointly fully faithful functors
+
+:::{.definition #jointly-fully-faithful-functors}
+A diagram of functors $F : \cI \to [\cC, \cD]$ is **jointly fully faithful** when
+the functor $\hat{F} : \cC \to [\cI, \cD]$ is fully faithful. Explicitly, $F$ is
+jointly faully faithful if there is an equivalence of natural transformations
+$\hat{F}(x) \to \hat{F}(y)$ and morphisms $\cC(x,y)$.
+:::
+
+```agda
+  is-jointly-fully-faithful : Functor K Cat[ C , D ] → Type _
+  is-jointly-fully-faithful F = is-fully-faithful (Swap F)
+```
+
+If a diagram of functors is jointly fully and jointly faithful, then it is jointly
+fully faithful.
+
+```agda
+  jointly-full+jointly-faithful→jointly-ff
+    : (F : Functor K Cat[ C , D ])
+    → is-jointly-full F
+    → is-jointly-faithful (F .F₀)
+    → is-jointly-fully-faithful F
+  jointly-full+jointly-faithful→jointly-ff F full faithful {x} {y} .is-eqv α =
+    is-prop∙→is-contr img-is-prop $
+    ∥-∥-elim (λ _ → img-is-prop) (Σ-map₂ (λ p → ext p)) $
+    jointly-full-fibre F full (λ i → α .η i) (λ f → α .is-natural _ _ f)
+    where
+      img-is-prop : is-prop (Σ[ f ∈ C.Hom x y ] (Swap F .F₁ f ≡ α))
+      img-is-prop (f , p) (g , q) =
+        Σ-prop-path (λ f → Nat-is-set (Swap F .F₁ f) α)
+          (faithful (λ i → p ηₚ i ∙ sym (q ηₚ i)))
+```

--- a/src/Cat/Functor/Joint.lagda.md
+++ b/src/Cat/Functor/Joint.lagda.md
@@ -44,7 +44,7 @@ Swap F .F₀ c .F-∘ f g = F .F-∘ f g ηₚ c
 Swap F .F₁ f .η k = F .F₀ k .F₁ f
 Swap F .F₁ f .is-natural x y g = sym (F .F₁ g .is-natural _ _ f)
 Swap F .F-id = ext λ k → F .F₀ k .F-id
-Swap F .F-∘ f g = ext λ k → F .F₀ k .F-∘ f g 
+Swap F .F-∘ f g = ext λ k → F .F₀ k .F-∘ f g
 
 module _
   {oc ℓc od ℓd}
@@ -82,7 +82,7 @@ precisely when $\hat{F} : \cC \to [\cI, \cD]$ is faithful.
     → is-faithful (Swap F)
     → is-jointly-faithful (F .F₀)
   swap-faithful→jointly-faithful F faithful p = faithful (ext p)
-  
+
   jointly-faithful→swap-faithful
     : (F : Functor K Cat[ C , D ])
     → is-jointly-faithful (F .F₀)
@@ -113,7 +113,7 @@ $F : \cI \to [ \cC, \cD ]$.
     → is-jointly-conservative (F .F₀)
   swap-conservative→jointly-conservative F reflect-iso isos =
     reflect-iso (invertible→invertibleⁿ (Swap F .F₁ _) isos)
-  
+
   jointly-conservative→swap-conservative
     : (F : Functor K Cat[ C , D ])
     → is-jointly-conservative (F .F₀)

--- a/src/Cat/Instances/Comma.lagda.md
+++ b/src/Cat/Instances/Comma.lagda.md
@@ -1,6 +1,9 @@
 <!--
 ```agda
 open import Cat.Instances.Shape.Terminal
+open import Cat.Functor.Constant
+open import Cat.Functor.Compose
+open import Cat.Functor.Base
 open import Cat.Groupoid
 open import Cat.Morphism
 open import Cat.Prelude
@@ -237,7 +240,13 @@ square.
     ↓-is-pregroupoid f .inverses .invr = ↓Hom-path (A-grpd (f .α) .invr) (B-grpd (f .β) .invr)
 
 module _ {A : Precategory ao ah} {B : Precategory bo bh} where
-  private module A = Precategory A
+  private
+    module A = Precategory A
+    module B = Precategory B
+    variable
+      F : Functor A B
+  open ↓Obj
+  open ↓Hom
 
   infix 5 _↙_ _↘_
   _↙_ : A.Ob → Functor B A → Precategory _ _
@@ -245,6 +254,15 @@ module _ {A : Precategory ao ah} {B : Precategory bo bh} where
 
   _↘_ : Functor B A → A.Ob → Precategory _ _
   S ↘ X = S ↓ !Const X
+
+  θ↘ : ∀ {X} → F F∘ Dom F (!Const X) => Const X
+  θ↘ ._=>_.η f = f .map
+  θ↘ ._=>_.is-natural _ _ γ = γ .sq
+
+  θ↙ : ∀ {X} → Const X => F F∘ Cod (!Const X) F
+  θ↙ ._=>_.η f = f .map
+  θ↙ ._=>_.is-natural _ _ γ = γ .sq
+
 
 module ↙-compose
     {oc ℓc od ℓd oe ℓe}
@@ -273,6 +291,7 @@ module ↙-compose
 
   ↙>-id : ∀ {c} {f : Ob (c ↙ G F∘ F)} → ↓obj (f .map) ↙> ↓obj 𝒟.id ≡ f
   ↙>-id = ↓Obj-path _ _ refl refl (G.eliml refl)
+
 
 -- Outside the main module to make instance search work.
 module _ where

--- a/src/Cat/Instances/Sets.lagda.md
+++ b/src/Cat/Instances/Sets.lagda.md
@@ -47,6 +47,28 @@ only difference between these types can be patched by
     where module x = Sets._≅_ x
 ```
 
+<!--
+```agda
+  is-invertible→is-equiv
+    : {A B : Set ℓ} {f : ∣ A ∣ → ∣ B ∣}
+    → Sets.is-invertible {A} {B} f
+    → is-equiv f
+  is-invertible→is-equiv x =
+    is-iso→is-equiv $ iso x.inv (happly x.invl) (happly x.invr)
+    where module x = Sets.is-invertible x
+
+  is-equiv→is-invertible
+    : {A B : Set ℓ} {f : ∣ A ∣ → ∣ B ∣}
+    → is-equiv f
+    → Sets.is-invertible {A} {B} f
+  is-equiv→is-invertible f-eqv =
+    Sets.make-invertible
+      (equiv→inverse f-eqv)
+      (funext (equiv→counit f-eqv))
+      (funext (equiv→unit f-eqv))
+```
+-->
+
 Using univalence for $n$-types, function extensionality and the
 computation rule for univalence, it is almost trivial to show that
 categorical isomorphisms of sets are an [[identity system]].

--- a/src/Cat/Morphism/StrongEpi.lagda.md
+++ b/src/Cat/Morphism/StrongEpi.lagda.md
@@ -150,11 +150,11 @@ given $zw = vf$ to lift $f$ against $z$. We don't have a $u$ as before,
 but we can take $u = wg$ to get a lift $t$.
 
 ```agda
-strong-epi-cancel-l
+strong-epi-cancell
   : ∀ {a b c} (f : Hom b c) (g : Hom a b)
   → is-strong-epi (f ∘ g)
   → is-strong-epi f
-strong-epi-cancel-l g f (gf-epi , gf-str) = lifts→is-strong-epi epi lifts where
+strong-epi-cancell g f (gf-epi , gf-str) = lifts→is-strong-epi epi lifts where
   epi : is-epic g
   epi α β p = gf-epi α β (extendl p)
 

--- a/src/Cat/Morphism/StrongEpi.lagda.md
+++ b/src/Cat/Morphism/StrongEpi.lagda.md
@@ -170,9 +170,9 @@ be, in particular, left orthogonal to _itself_, and the only
 self-orthogonal maps are isos.
 
 ```agda
-strong-epi-mono→is-invertible
+strong-epi+mono→is-invertible
   : ∀ {a b} {f : Hom a b} → is-monic f → is-strong-epi f → is-invertible f
-strong-epi-mono→is-invertible mono (_ , epi) =
+strong-epi+mono→is-invertible mono (_ , epi) =
   self-orthogonal→is-iso C _ (epi (record { monic = mono }))
 ```
 

--- a/src/Cat/Morphism/StrongEpi.lagda.md
+++ b/src/Cat/Morphism/StrongEpi.lagda.md
@@ -24,6 +24,8 @@ module Cat.Morphism.StrongEpi {o ℓ} (C : Precategory o ℓ) where
 open Cat.Reasoning C
 ```
 
+# Strong epimorphisms {defines="strong-epi strong-epimorphism"}
+
 A **strong epimorphism** is an epimorphism which is, additionally, left
 [orthogonal] to every monomorphism. Unfolding that definition, for $f :
 a \epi b$ to be a strong epimorphism means that, given $g : c \mono b$
@@ -396,7 +398,7 @@ is epic, this means we have $u = v$ --- exactly what we wanted!
     in e-epi u v ker.equal
 ```
 
-## Extremal epimorphisms
+## Extremal epimorphisms {defines="extremal-epi extremal-epimorphism"}
 
 Another well-behaved subclass of epimorphism are the **extremal**
 epimorphisms: An epimorphism $e : A \epi B$ is extremal if when, given a
@@ -405,10 +407,16 @@ is an isomorphism. In a [[finitely complete category]], every extremal
 epimorphism is strong; the converse is immediate.
 
 ```agda
+is-extremal-epi : ∀ {a b} → Hom a b → Type _
+is-extremal-epi {a} {b} e =
+  ∀ {c} (m : c ↪ b) (g : Hom a c)
+  → e ≡ m .mor ∘ g
+  → is-invertible (m .mor)
+
 is-extremal-epi→is-strong-epi
   : ∀ {a b} {e : Hom a b}
   → Finitely-complete C
-  → (∀ {c} (m : c ↪ b) (g : Hom a c) → e ≡ m .mor ∘ g → is-invertible (m .mor))
+  → is-extremal-epi e
   → is-strong-epi e
 is-extremal-epi→is-strong-epi {a} {b} {e} lex extremal =
   equaliser-lifts→is-strong-epi lex.equalisers λ w → Mk.the-lift w where

--- a/src/Data/Dec/Base.lagda.md
+++ b/src/Data/Dec/Base.lagda.md
@@ -53,7 +53,10 @@ recover {A = A} ⦃ no ¬x ⦄ x = go (¬x x) where
 ```
 -->
 
-A type is _discrete_ if it has decidable equality.
+:::{.definition #discrete}
+A type is **discrete** if it has decidable equality.
+:::
+
 
 ```agda
 Discrete : ∀ {ℓ} → Type ℓ → Type ℓ


### PR DESCRIPTION
# Description

This PR defines a bunch of classes of [separators](https://ncatlab.org/nlab/show/separator), and proves some various properties. In particular, this PR covers the following results from Borceux Vol 1, 4.5.

* 4.5.1:
  * is-separating-family
  * is-separator
* 4.5.2:
  * (⇒) separating-family→epic
  * (⇐) epic→separating-family
* 4.5.3
  * is-strong-separating-family
  * is-regular-separating-family
* 4.5.4:
  * is-dense-separating-family
  * is-dense-separator
* 4.5.5:
  * dense-separator→regular-separator
  * regular-separator→strong-separator
* 4.5.7:
  * is-jointly-faithful
  * is-jointly-conservative
* 4.5.8:
  * (⇒) separating-family→jointly-faithful
  * (⇐) jointly-faithful→separating-family
* 4.5.9:
  * (⇒) separator→faithful
  * (⇐) faithful→separator
* 4.5.10:
  * (⇒) strong-separating-family→jointly-conservative
  * (⇐) lex+jointly-conservative→strong-separating-family
* 4.5.11:
  * (⇒) strong-separator→conservative
  * (⇐) lex+conservative→strong-separator
* 4.5.12: equalisers+jointly-conservative→separating-family
* 4.5.13: N/A
* 4.5.14
  * (⇒) dense-separating-family→jointly-ff
  * (⇐) jointly-ff→dense-separating-family
* 4.5.16: zero+separating-family→separator

## Checklist

Before submitting a merge request, please check the items below:

- [ ] I've read [the contributing guidelines](https://github.com/plt-amy/1lab/blob/main/CONTRIBUTING.md).
- [ ] The imports of new modules have been sorted with `support/sort-imports.hs` (or `nix run --experimental-features nix-command -f . sort-imports`).
- [ ] All new code blocks have "agda" as their language.

If your change affects many files without adding substantial content, and
you don't want your name to appear on those pages (for example, treewide
refactorings or reformattings), start the commit message and PR title with `chore:`.
