### PR TITLE
Biproducts and semiadditive categories

### DIFF
--- a/src/Algebra/Group/Ab/Sum.lagda.md
+++ b/src/Algebra/Group/Ab/Sum.lagda.md
@@ -83,7 +83,7 @@ limits][rapl]).
   Direct-sum-is-product .⟨_,_⟩ f g .preserves .pres-⋆ x y =
     Σ-pathp (f .preserves .pres-⋆ x y) (g .preserves .pres-⋆ x y)
 
-  Direct-sum-is-product .π₁∘factor = trivial!
-  Direct-sum-is-product .π₂∘factor = trivial!
-  Direct-sum-is-product .unique other p q = ext λ x → p #ₚ x , q #ₚ x
+  Direct-sum-is-product .π₁∘⟨⟩ = trivial!
+  Direct-sum-is-product .π₂∘⟨⟩ = trivial!
+  Direct-sum-is-product .unique p q = ext λ x → p #ₚ x , q #ₚ x
 ```

--- a/src/Algebra/Group/Cat/FinitelyComplete.lagda.md
+++ b/src/Algebra/Group/Cat/FinitelyComplete.lagda.md
@@ -129,9 +129,9 @@ Direct-product-is-product {G} {H} = p where
   open is-product
   p : is-product _ _ _
   p .⟨_,_⟩ = factor
-  p .π₁∘factor = Grp↪Sets-is-faithful refl
-  p .π₂∘factor = Grp↪Sets-is-faithful refl
-  p .unique other p q = Grp↪Sets-is-faithful (funext λ x →
+  p .π₁∘⟨⟩ = Grp↪Sets-is-faithful refl
+  p .π₂∘⟨⟩ = Grp↪Sets-is-faithful refl
+  p .unique p q = Grp↪Sets-is-faithful (funext λ x →
     ap₂ _,_ (happly (ap hom p) x) (happly (ap hom q) x))
 ```
 

--- a/src/Algebra/Ring/Module/Category.lagda.md
+++ b/src/Algebra/Ring/Module/Category.lagda.md
@@ -259,9 +259,9 @@ path-mangling, but it's nothing _too_ bad:
   prod .has-is-product .⟨_,_⟩ f g .hom x = f # x , g # x
   prod .has-is-product .⟨_,_⟩ f g .preserves .linear r m s =
     Σ-pathp (f .preserves .linear _ _ _) (g .preserves .linear _ _ _)
-  prod .has-is-product .π₁∘factor = trivial!
-  prod .has-is-product .π₂∘factor = trivial!
-  prod .has-is-product .unique other p q = ext λ x → p #ₚ x , q #ₚ x
+  prod .has-is-product .π₁∘⟨⟩ = trivial!
+  prod .has-is-product .π₂∘⟨⟩ = trivial!
+  prod .has-is-product .unique p q = ext λ x → p #ₚ x , q #ₚ x
 ```
 
 <!-- TODO [Amy 2022-09-15]

--- a/src/Cat/Abelian/Base.lagda.md
+++ b/src/Cat/Abelian/Base.lagda.md
@@ -247,15 +247,15 @@ comultiplication.
     open is-coproduct
     coprod : Coproduct C A B
     coprod .coapex = apex
-    coprod .in₀ = ⟨ id , 0m ⟩
-    coprod .in₁ = ⟨ 0m , id ⟩
+    coprod .ι₁ = ⟨ id , 0m ⟩
+    coprod .ι₂ = ⟨ 0m , id ⟩
     coprod .has-is-coproduct .[_,_] f g = f ∘ π₁ + g ∘ π₂
-    coprod .has-is-coproduct .in₀∘factor {inj0 = f} {g} =
+    coprod .has-is-coproduct .[]∘ι₁ {inj0 = f} {g} =
       (f ∘ π₁ + g ∘ π₂) ∘ ⟨ id , 0m ⟩ ≡⟨ sym (∘-linear-l _ _ _) ⟩
       (f ∘ π₁) ∘ ⟨ id , 0m ⟩ + _      ≡⟨ Hom.elimr (pullr π₂∘⟨⟩ ∙ ∘-zero-r) ⟩
       (f ∘ π₁) ∘ ⟨ id , 0m ⟩          ≡⟨ cancelr π₁∘⟨⟩ ⟩
       f                               ∎
-    coprod .has-is-coproduct .in₁∘factor {inj0 = f} {g} =
+    coprod .has-is-coproduct .[]∘ι₂ {inj0 = f} {g} =
       (f ∘ π₁ + g ∘ π₂) ∘ ⟨ 0m , id ⟩ ≡⟨ sym (∘-linear-l _ _ _) ⟩
       _ + (g ∘ π₂) ∘ ⟨ 0m , id ⟩      ≡⟨ Hom.eliml (pullr π₁∘⟨⟩ ∙ ∘-zero-r) ⟩
       (g ∘ π₂) ∘ ⟨ 0m , id ⟩          ≡⟨ cancelr π₂∘⟨⟩ ⟩
@@ -267,7 +267,7 @@ morphisms and the universal property of the product to establish the
 desired equation. Check it out:
 
 ```agda
-    coprod .has-is-coproduct .unique {inj0 = f} {g} other p q = sym $
+    coprod .has-is-coproduct .unique {inj0 = f} {g} {other} p q = sym $
       f ∘ π₁ + g ∘ π₂                                         ≡⟨ ap₂ _+_ (pushl (sym p)) (pushl (sym q)) ⟩
       (other ∘ ⟨ id , 0m ⟩ ∘ π₁) + (other ∘ ⟨ 0m , id ⟩ ∘ π₂) ≡⟨ ∘-linear-r _ _ _ ⟩
       other ∘ (⟨ id , 0m ⟩ ∘ π₁ + ⟨ 0m , id ⟩ ∘ π₂)           ≡⟨ elimr lemma ⟩
@@ -296,18 +296,18 @@ Thus every additive category is [[semiadditive|semiadditive category]].
     bp .Biproduct.biapex = A ⊗₀ B
     bp .Biproduct.π₁ = π₁
     bp .Biproduct.π₂ = π₂
-    bp .Biproduct.ι₁ = in₀
-    bp .Biproduct.ι₂ = in₁
+    bp .Biproduct.ι₁ = ι₁
+    bp .Biproduct.ι₂ = ι₂
     bp .Biproduct.has-is-biproduct .has-is-product = Prod.has-is-product
     bp .Biproduct.has-is-biproduct .has-is-coproduct = Coprod.has-is-coproduct
     bp .Biproduct.has-is-biproduct .πι₁ = π₁∘⟨⟩
     bp .Biproduct.has-is-biproduct .πι₂ = π₂∘⟨⟩
     bp .Biproduct.has-is-biproduct .ιπ-comm =
-      in₀ ∘ π₁ ∘ in₁ ∘ π₂ ≡⟨ refl⟩∘⟨ pulll π₁∘⟨⟩ ⟩
-      in₀ ∘ 0m ∘ π₂       ≡⟨ pulll ∘-zero-r ∙ ∘-zero-l ⟩
-      0m                  ≡˘⟨ pulll ∘-zero-r ∙ ∘-zero-l ⟩
-      in₁ ∘ 0m ∘ π₁       ≡˘⟨ refl⟩∘⟨ pulll π₂∘⟨⟩ ⟩
-      in₁ ∘ π₂ ∘ in₀ ∘ π₁ ∎
+      ι₁ ∘ π₁ ∘ ι₂ ∘ π₂ ≡⟨ refl⟩∘⟨ pulll π₁∘⟨⟩ ⟩
+      ι₁ ∘ 0m ∘ π₂      ≡⟨ pulll ∘-zero-r ∙ ∘-zero-l ⟩
+      0m                ≡˘⟨ pulll ∘-zero-r ∙ ∘-zero-l ⟩
+      ι₂ ∘ 0m ∘ π₁      ≡˘⟨ refl⟩∘⟨ pulll π₂∘⟨⟩ ⟩
+      ι₂ ∘ π₂ ∘ ι₁ ∘ π₁ ∎
 
   open is-semiadditive additive→semiadditive hiding (∘-linear-l; ∘-linear-r)
 ```
@@ -360,7 +360,7 @@ module _ {o ℓ} (C : Precategory o ℓ) (semiadditive : is-semiadditive C) wher
     ab .Ab-category.∘-linear-r _ _ _ = ∘-linear-r
 
   semiadditive+group→additive inv invl .is-additive.has-terminal = terminal
-  semiadditive+group→additive inv invl .is-additive.has-prods _ _ = biproduct.product
+  semiadditive+group→additive inv invl .is-additive.has-prods _ _ = Biprod.product
 ```
 
 ## Pre-abelian & abelian categories {defines="pre-abelian-category abelian-category"}

--- a/src/Cat/Bi/Instances/Relations.lagda.md
+++ b/src/Cat/Bi/Instances/Relations.lagda.md
@@ -493,7 +493,7 @@ but keep in mind that they are not commented.
 
 ∘-rel-idr f = Sub-antisym fid≤f f≤fid where
   fid≤f : ∘-rel f id-rel ≤ₘ f
-  fid≤f = Im-universal _ _ {e = ∘-rel.inter f id-rel .p₂} $ sym $ ⟨⟩-unique _
+  fid≤f = Im-universal _ _ {e = ∘-rel.inter f id-rel .p₂} $ sym $ ⟨⟩-unique
     (sym (∘-rel.inter f id-rel .square ∙ sym (assoc _ _ _)) ∙ eliml π₂∘⟨⟩ ∙ introl π₁∘⟨⟩)
     (assoc _ _ _)
 
@@ -501,13 +501,13 @@ but keep in mind that they are not commented.
   f≤fid .map = factor _ .mediate ∘
     ∘-rel.inter f id-rel .universal {p₁' = Relation.src f} {p₂' = id}
       (eliml π₂∘⟨⟩ ∙ intror refl)
-  f≤fid .sq = idl _ ∙ sym (pulll (sym (factor _ .factors)) ∙ ⟨⟩∘ _ ∙ sym (⟨⟩-unique _
+  f≤fid .sq = idl _ ∙ sym (pulll (sym (factor _ .factors)) ∙ ⟨⟩∘ _ ∙ sym (⟨⟩-unique
     (sym (ap₂ _∘_ (eliml π₁∘⟨⟩) refl ∙ ∘-rel.inter _ _ .p₁∘universal))
     (sym (pullr (∘-rel.inter _ _ .p₂∘universal) ∙ idr _))))
 
 ∘-rel-idl f = Sub-antisym idf≤f f≤idf where
   idf≤f : ∘-rel id-rel f ≤ₘ f
-  idf≤f = Im-universal _ _ {e = ∘-rel.inter id-rel f .p₁} $ sym $ ⟨⟩-unique _
+  idf≤f = Im-universal _ _ {e = ∘-rel.inter id-rel f .p₁} $ sym $ ⟨⟩-unique
     (assoc _ _ _)
     (assoc _ _ _ ∙ ∘-rel.inter id-rel f .square ∙ eliml π₁∘⟨⟩ ∙ introl π₂∘⟨⟩)
 
@@ -515,7 +515,7 @@ but keep in mind that they are not commented.
   f≤idf .map = factor _ .mediate ∘
     ∘-rel.inter id-rel f .universal {p₁' = id} {p₂' = Relation.tgt f}
       (idr _ ∙ sym (eliml π₁∘⟨⟩))
-  f≤idf .sq = idl _ ∙ sym (pulll (sym (factor _ .factors)) ∙ ⟨⟩∘ _ ∙ sym (⟨⟩-unique _
+  f≤idf .sq = idl _ ∙ sym (pulll (sym (factor _ .factors)) ∙ ⟨⟩∘ _ ∙ sym (⟨⟩-unique
     (sym (pullr (∘-rel.inter id-rel f .p₁∘universal) ∙ idr _))
     (sym (pullr (∘-rel.inter id-rel f .p₂∘universal) ∙ eliml π₂∘⟨⟩))))
 

--- a/src/Cat/CartesianClosed/Instances/PSh.agda
+++ b/src/Cat/CartesianClosed/Instances/PSh.agda
@@ -103,9 +103,9 @@ module _ {o ℓ κ} {C : Precategory o ℓ} where
     prod .has-is-product .⟨_,_⟩ f g =
       NT (λ i x → f .η i x , g .η i x) λ x y h i a →
         f .is-natural x y h i a , g .is-natural x y h i a
-    prod .has-is-product .π₁∘factor = trivial!
-    prod .has-is-product .π₂∘factor = trivial!
-    prod .has-is-product .unique h p q = ext λ i x → unext p i x , unext q i x
+    prod .has-is-product .π₁∘⟨⟩ = trivial!
+    prod .has-is-product .π₂∘⟨⟩ = trivial!
+    prod .has-is-product .unique p q = ext λ i x → unext p i x , unext q i x
 
   {-# TERMINATING #-}
   PSh-coproducts : (A B : PSh.Ob) → Coproduct (PSh κ C) A B
@@ -125,18 +125,18 @@ module _ {o ℓ κ} {C : Precategory o ℓ} where
     coprod .coapex .F-∘ f g = funext λ where
       (inl x) → ap inl (happly (A.F-∘ f g) x)
       (inr x) → ap inr (happly (B.F-∘ f g) x)
-    coprod .in₀ .η _ x = inl x
-    coprod .in₀ .is-natural x y f i a = inl (A.₁ f a)
-    coprod .in₁ .η _ x = inr x
-    coprod .in₁ .is-natural x y f i b = inr (B.₁ f b)
+    coprod .ι₁ .η _ x = inl x
+    coprod .ι₁ .is-natural x y f i a = inl (A.₁ f a)
+    coprod .ι₂ .η _ x = inr x
+    coprod .ι₂ .is-natural x y f i b = inr (B.₁ f b)
     coprod .has-is-coproduct .is-coproduct.[_,_] f g .η _ (inl x) = f .η _ x
     coprod .has-is-coproduct .is-coproduct.[_,_] f g .η _ (inr x) = g .η _ x
     coprod .has-is-coproduct .is-coproduct.[_,_] f g .is-natural x y h = funext λ where
       (inl x) → f .is-natural _ _ _ $ₚ _
       (inr x) → g .is-natural _ _ _ $ₚ _
-    coprod .has-is-coproduct .in₀∘factor = trivial!
-    coprod .has-is-coproduct .in₁∘factor = trivial!
-    coprod .has-is-coproduct .unique other p q = ext λ where
+    coprod .has-is-coproduct .[]∘ι₁ = trivial!
+    coprod .has-is-coproduct .[]∘ι₂ = trivial!
+    coprod .has-is-coproduct .unique p q = ext λ where
       a (inl x) → unext p a x
       a (inr x) → unext q a x
 

--- a/src/Cat/CartesianClosed/Lambda.lagda.md
+++ b/src/Cat/CartesianClosed/Lambda.lagda.md
@@ -312,7 +312,7 @@ tag.
 ⟦⟧-∘ʳ (drop ρ) σ = pushl (⟦⟧-∘ʳ ρ σ)
 ⟦⟧-∘ʳ (keep ρ) stop = introl refl
 ⟦⟧-∘ʳ (keep ρ) (drop σ) = pushl (⟦⟧-∘ʳ ρ σ) ∙ sym (pullr π₁∘⟨⟩)
-⟦⟧-∘ʳ (keep ρ) (keep σ) = sym $ Product.unique (fp _ _) _
+⟦⟧-∘ʳ (keep ρ) (keep σ) = sym $ Product.unique (fp _ _)
   (pulll π₁∘⟨⟩ ∙ pullr π₁∘⟨⟩ ∙ pulll (sym (⟦⟧-∘ʳ ρ σ)))
   (pulll π₂∘⟨⟩ ∙ pullr π₂∘⟨⟩ ∙ idl _)
 
@@ -593,7 +593,7 @@ establishing that $\sem{\reify v} = h$ when $v$ tracks $h$.
 
 ```agda
 reifyᵖ-correct {τ = τ `× σ} (a , b) = sym $
-  Product.unique (fp _ _) _ (sym (reifyᵖ-correct a)) (sym (reifyᵖ-correct b))
+  Product.unique (fp _ _) (sym (reifyᵖ-correct a)) (sym (reifyᵖ-correct b))
 reifyᵖ-correct {τ = τ `⇒ σ} {h = h} ν =
   let
     p : ⟦ reifyᵖ (ν (drop stop) (reflectᵖ (var stop))) ⟧ₙ ≡ ev ∘ ⟨ h ∘ id ∘ π₁ , π₂ ⟩
@@ -611,7 +611,7 @@ reifyᵖ-correct {τ = ` x} d = d .snd
 
 ⟦⟧ˢ-correct : ∀ {Γ Δ h} (ρ : Subᵖ Γ Δ h) → ⟦ ρ ⟧ˢ ≡ h
 ⟦⟧ˢ-correct ∅       = Terminal.!-unique term _
-⟦⟧ˢ-correct (ρ , x) = sym (Product.unique (fp _ _) _ (sym (⟦⟧ˢ-correct ρ)) (sym (reifyᵖ-correct x)))
+⟦⟧ˢ-correct (ρ , x) = sym (Product.unique (fp _ _) (sym (⟦⟧ˢ-correct ρ)) (sym (reifyᵖ-correct x)))
 ```
 -->
 
@@ -643,7 +643,7 @@ baseᵖ {τ = τ `× τ₁} x c     =
     tyᵖ⟨ sym (assoc _ _ _) ⟩ (baseᵖ (π₁ ∘ x) c)
   , tyᵖ⟨ sym (assoc _ _ _) ⟩ (baseᵖ (π₂ ∘ x) c)
 
-baseᵖ {τ = τ `⇒ σ} {h' = h'} h c ρ {α} a = tyᵖ⟨ pullr (Product.unique (fp _ _) _ (pulll π₁∘⟨⟩ ∙ extendr π₁∘⟨⟩) (pulll π₂∘⟨⟩ ∙ π₂∘⟨⟩)) ⟩
+baseᵖ {τ = τ `⇒ σ} {h' = h'} h c ρ {α} a = tyᵖ⟨ pullr (Product.unique (fp _ _) (pulll π₁∘⟨⟩ ∙ extendr π₁∘⟨⟩) (pulll π₂∘⟨⟩ ∙ π₂∘⟨⟩)) ⟩
   (baseᵖ (ev ∘ ⟨ h ∘ π₁ , π₂ ⟩) (
     subᵖ⟨ sym π₁∘⟨⟩ ⟩ (ren-subᵖ ρ c), tyᵖ⟨ sym π₂∘⟨⟩ ⟩ a))
 
@@ -676,7 +676,7 @@ exprᵖ {h = h} (`λ f) ρ σ {m} a = tyᵖ⟨ fixup ⟩ (exprᵖ f
   where abstract
   fixup : ⟦ f ⟧ᵉ ∘ ⟨ h ∘ ⟦ σ ⟧ʳ , m ⟩ ≡ ev ∘ ⟨ (⟦ `λ f ⟧ᵉ ∘ h) ∘ ⟦ σ ⟧ʳ , m ⟩
   fixup = sym $
-    ev ∘ ⟨ (⟦ `λ f ⟧ᵉ ∘ h) ∘ ⟦ σ ⟧ʳ , m ⟩     ≡˘⟨ ap₂ _∘_ refl (Product.unique (fp _ _) _ (pulll π₁∘⟨⟩ ∙ extendr π₁∘⟨⟩) (pulll π₂∘⟨⟩ ·· pullr π₂∘⟨⟩ ·· eliml refl)) ⟩
+    ev ∘ ⟨ (⟦ `λ f ⟧ᵉ ∘ h) ∘ ⟦ σ ⟧ʳ , m ⟩     ≡˘⟨ ap₂ _∘_ refl (Product.unique (fp _ _) (pulll π₁∘⟨⟩ ∙ extendr π₁∘⟨⟩) (pulll π₂∘⟨⟩ ·· pullr π₂∘⟨⟩ ·· eliml refl)) ⟩
     ev ∘ ⟦ `λ f ⟧ᵉ ⊗₁ id ∘ ⟨ h ∘ ⟦ σ ⟧ʳ , m ⟩ ≡⟨ pulll (is-exponential.commutes has-is-exp _) ⟩
     ⟦ f ⟧ᵉ ∘ ⟨ h ∘ ⟦ σ ⟧ʳ , m ⟩               ∎
 ```

--- a/src/Cat/Diagram/Biproduct.lagda.md
+++ b/src/Cat/Diagram/Biproduct.lagda.md
@@ -1,0 +1,473 @@
+<!--
+```agda
+open import Algebra.Group.Ab
+
+open import Cat.Monoidal.Instances.Cartesian
+open import Cat.Functor.Naturality
+open import Cat.Monoidal.Diagonals
+open import Cat.Diagram.Coproduct
+open import Cat.Diagram.Terminal
+open import Cat.Diagram.Initial
+open import Cat.Diagram.Product
+open import Cat.Monoidal.Base
+open import Cat.Diagram.Zero
+open import Cat.Prelude
+
+import Cat.Reasoning
+
+open _=>_
+```
+-->
+
+```agda
+module Cat.Diagram.Biproduct where
+```
+
+<!--
+```agda
+module _ {o ℓ} (C : Precategory o ℓ) where
+  open Cat.Reasoning C
+```
+-->
+
+# Biproducts {defines="biproduct"}
+
+Recall that, in an [[$\Ab$-enriched category]], [[products]] and
+[[coproducts]] automatically coincide: these are called **biproducts**
+and written $A \oplus B$.
+
+~~~{.quiver}
+\[\begin{tikzcd}
+  A & {A \oplus B} & B
+  \arrow["{\iota_1}", shift left, from=1-1, to=1-2]
+  \arrow["{\pi_1}", shift left, from=1-2, to=1-1]
+  \arrow["{\pi_2}"', shift right, from=1-2, to=1-3]
+  \arrow["{\iota_2}"', shift right, from=1-3, to=1-2]
+\end{tikzcd}\]
+~~~
+
+Following [@KarvonenBiproducts], we can define what it means to be a
+biproduct in a general category:
+we say that a diagram like the one above is a biproduct diagram if
+$(A \oplus B, \pi_1, \pi_2)$ is a product diagram, $(A \oplus B, \iota_1, \iota_2)$
+is a coproduct diagram, and the following equations relating the product
+projections and coproduct injections hold:
+
+$$
+\begin{align*}
+\pi_1 \circ \iota_1 &\equiv \id_A \\
+\pi_2 \circ \iota_2 &\equiv \id_B \\
+\iota_1 \circ \pi_1 \circ \iota_2 \circ \pi_2 &\equiv \iota_2 \circ \pi_2 \circ \iota_1 \circ \pi_1
+\end{align*}
+$$
+
+```agda
+  record is-biproduct {A B P}
+    (π₁ : Hom P A) (π₂ : Hom P B)
+    (ι₁ : Hom A P) (ι₂ : Hom B P)
+    : Type (o ⊔ ℓ) where
+    field
+      has-is-product   : is-product C π₁ π₂
+      has-is-coproduct : is-coproduct C ι₁ ι₂
+      πι₁ : π₁ ∘ ι₁ ≡ id
+      πι₂ : π₂ ∘ ι₂ ≡ id
+      ιπ-comm : ι₁ ∘ π₁ ∘ ι₂ ∘ π₂ ≡ ι₂ ∘ π₂ ∘ ι₁ ∘ π₁
+
+  record Biproduct (A B : Ob) : Type (o ⊔ ℓ) where
+    field
+      biapex : Ob
+      π₁ : Hom biapex A
+      π₂ : Hom biapex B
+      ι₁ : Hom A biapex
+      ι₂ : Hom B biapex
+      has-is-biproduct : is-biproduct π₁ π₂ ι₁ ι₂
+
+    open is-biproduct has-is-biproduct public
+
+    product : Product C A B
+    product = record
+      { apex = biapex ; π₁ = π₁ ; π₂ = π₂ ; has-is-product = has-is-product }
+
+    coproduct : Coproduct C A B
+    coproduct = record
+      { coapex = biapex ; in₀ = ι₁ ; in₁ = ι₂ ; has-is-coproduct = has-is-coproduct }
+
+    open Product product public
+      hiding (π₁; π₂)
+      renaming (unique₂ to ⟨⟩-unique₂)
+    open Coproduct coproduct public
+      hiding (in₀; in₁)
+      renaming (unique₂ to []-unique₂)
+```
+
+## Semiadditive categories {defines="semiadditive-category"}
+
+Just like [[terminal objects]] (resp. [[initial objects]]) are 0-ary
+products (resp. coproducts), [[zero objects]] are 0-ary biproducts.
+A category with a zero object and binary biproducts (hence all finite
+biproducts) is called **semiadditive**.
+
+```agda
+  record is-semiadditive : Type (o ⊔ ℓ) where
+    field
+      has-zero : Zero C
+      has-biproducts : ∀ {A B} → Biproduct A B
+```
+
+As the name hints, every [[additive category]] is semiadditive.
+However, quite surprisingly, it turns out that the structure^[Really *property*, in a univalent category.]
+of a semiadditive category is already enough to define an enrichment of
+$\cC$ in *commutative monoids*!
+
+<!--
+```agda
+    open Zero has-zero public
+    module Biprod {A B} = Biproduct (has-biproducts {A} {B})
+    open Biprod using (πι₁; πι₂; ιπ-comm)
+
+    open Binary-products C (λ _ _ → Biprod.product)
+    open Binary-coproducts C (λ _ _ → Biprod.coproduct) renaming (in₀ to ι₁; in₁ to ι₂)
+
+    open Monoidal-category (Cartesian-monoidal (λ _ _ → Biprod.product) terminal) using (associator; module ⊗)
+    open Diagonals (Cartesian-diagonal (λ _ _ → Biprod.product) terminal) hiding (δ)
+```
+-->
+
+We define the addition of morphisms $f + g : A \to B$ by the following diagram,
+where $\delta$ (resp. $\nabla$) is the diagonal map (resp. codiagonal map).
+
+~~~{.quiver}
+\[\begin{tikzcd}
+  A & {A \oplus A} & {B \oplus B} & B
+  \arrow["\delta", from=1-1, to=1-2]
+  \arrow["{f \oplus g}", from=1-2, to=1-3]
+  \arrow["\nabla", from=1-3, to=1-4]
+\end{tikzcd}\]
+~~~
+
+```agda
+    _+→_ : ∀ {x y} → Hom x y → Hom x y → Hom x y
+    f +→ g = ∇ ∘ (f ⊗₁ g) ∘ δ
+```
+
+We start by noticing a few properties of finite biproducts. First, while
+we are of course justified in writing $A \oplus B$ without ambiguity
+for *objects*, we must prove that $f \times_1 g \equiv f +_1 g$ so that we
+can write $f \oplus g$ without ambiguity for *morphisms*.
+
+<details>
+<summary>
+To that end, we start by showing that $\pi_1 \circ \iota_2$ and
+$\pi_2 \circ \iota_1$ are [[zero morphisms]].
+
+```agda
+    π₁-ι₂ : ∀ {a b} → π₁ {a} {b} ∘ ι₂ ≡ zero→
+    π₂-ι₁ : ∀ {a b} → π₂ {a} {b} ∘ ι₁ ≡ zero→
+```
+
+The proofs follow [@KarvonenBiproducts] and are unenlightening.
+</summary>
+
+```agda
+    π₁-ι₂ = zero-unique λ f g →
+      let h = ⟨ π₁ ∘ ι₂ ∘ g , f ⟩ in
+      (π₁ ∘ ι₂) ∘ f                   ≡⟨ insertl πι₁ ⟩
+      π₁ ∘ ι₁ ∘ (π₁ ∘ ι₂) ∘ f         ≡˘⟨ refl⟩∘⟨ refl⟩∘⟨ assoc _ _ _ ∙ (refl⟩∘⟨ π₂∘⟨⟩) ⟩
+      π₁ ∘ ι₁ ∘ π₁ ∘ ι₂ ∘ π₂ ∘ h      ≡⟨ refl⟩∘⟨ pulll4 ιπ-comm ⟩
+      π₁ ∘ (ι₂ ∘ π₂ ∘ ι₁ ∘ π₁) ∘ h    ≡⟨ refl⟩∘⟨ pullr (pullr (pullr π₁∘⟨⟩)) ⟩
+      π₁ ∘ ι₂ ∘ π₂ ∘ ι₁ ∘ π₁ ∘ ι₂ ∘ g ≡˘⟨ refl⟩∘⟨ extendl4 ιπ-comm ⟩
+      π₁ ∘ ι₁ ∘ π₁ ∘ ι₂ ∘ π₂ ∘ ι₂ ∘ g ≡⟨ cancell πι₁ ⟩
+      π₁ ∘ ι₂ ∘ π₂ ∘ ι₂ ∘ g           ≡⟨ pushr (refl⟩∘⟨ cancell πι₂) ⟩
+      (π₁ ∘ ι₂) ∘ g                   ∎
+
+    π₂-ι₁ = zero-unique λ f g →
+      let h = ⟨ f , π₂ ∘ ι₁ ∘ g ⟩ in
+      (π₂ ∘ ι₁) ∘ f                   ≡⟨ insertl πι₂ ⟩
+      π₂ ∘ ι₂ ∘ (π₂ ∘ ι₁) ∘ f         ≡˘⟨ refl⟩∘⟨ refl⟩∘⟨ assoc _ _ _ ∙ (refl⟩∘⟨ π₁∘⟨⟩) ⟩
+      π₂ ∘ ι₂ ∘ π₂ ∘ ι₁ ∘ π₁ ∘ h      ≡˘⟨ refl⟩∘⟨ pushl4 ιπ-comm ⟩
+      π₂ ∘ (ι₁ ∘ π₁ ∘ ι₂ ∘ π₂) ∘ h    ≡⟨ refl⟩∘⟨ pullr (pullr (pullr π₂∘⟨⟩)) ⟩
+      π₂ ∘ ι₁ ∘ π₁ ∘ ι₂ ∘ π₂ ∘ ι₁ ∘ g ≡⟨ refl⟩∘⟨ extendl4 ιπ-comm ⟩
+      π₂ ∘ ι₂ ∘ π₂ ∘ ι₁ ∘ π₁ ∘ ι₁ ∘ g ≡⟨ cancell πι₂ ⟩
+      π₂ ∘ ι₁ ∘ π₁ ∘ ι₁ ∘ g           ≡⟨ pushr (refl⟩∘⟨ cancell πι₁) ⟩
+      (π₂ ∘ ι₁) ∘ g                   ∎
+```
+</details>
+
+Next, we note that maps $f : A \oplus B \to C \oplus D$ are uniquely determined,
+thanks to the universal properties of the product and coproduct, by the
+four components $\pi_i \circ f \circ \iota_j$ for $i, j : \{1, 2\}$.
+In other words, $f$ admits a unique *matrix representation*
+
+$$
+\begin{bmatrix}
+f_{11} & f_{12} \\
+f_{21} & f_{22}
+\end{bmatrix}
+$$
+
+```agda
+    unique-matrix
+      : ∀ {a b c d} {f g : Hom (a ⊕₀ b) (c ⊕₀ d)}
+      → (π₁ ∘ f ∘ ι₁ ≡ π₁ ∘ g ∘ ι₁)
+      → (π₂ ∘ f ∘ ι₁ ≡ π₂ ∘ g ∘ ι₁)
+      → (π₁ ∘ f ∘ ι₂ ≡ π₁ ∘ g ∘ ι₂)
+      → (π₂ ∘ f ∘ ι₂ ≡ π₂ ∘ g ∘ ι₂)
+      → f ≡ g
+    unique-matrix p₁₁ p₁₂ p₂₁ p₂₂ = Biprod.[]-unique₂ _
+      (Biprod.⟨⟩-unique₂ p₁₁ p₁₂ refl refl)
+      (Biprod.⟨⟩-unique₂ p₂₁ p₂₂ refl refl)
+      _ refl refl
+```
+
+This implies that $f \times_1 g$ and $f +_1 g$ are equal, as they both have
+the same matrix representation:
+
+$$
+\begin{bmatrix}
+\mathrm{id} & 0 \\
+0 & \mathrm{id}
+\end{bmatrix}
+$$
+
+```agda
+    ⊕₁≡⊗₁ : ∀ {a b c d} {f : Hom a b} {g : Hom c d} → f ⊕₁ g ≡ f ⊗₁ g
+    ⊕₁≡⊗₁ = unique-matrix
+      ((refl⟩∘⟨ in₀∘[]) ∙ cancell πι₁ ∙ sym (pulll π₁∘⟨⟩ ∙ cancelr πι₁))
+      ((refl⟩∘⟨ in₀∘[]) ∙ pulll π₂-ι₁ ∙ zero-∘r _ ∙ sym (pulll π₂∘⟨⟩ ∙ pullr π₂-ι₁ ∙ zero-∘l _))
+      ((refl⟩∘⟨ in₁∘[]) ∙ pulll π₁-ι₂ ∙ zero-∘r _ ∙ sym (pulll π₁∘⟨⟩ ∙ pullr π₁-ι₂ ∙ zero-∘l _))
+      ((refl⟩∘⟨ in₁∘[]) ∙ cancell πι₂ ∙ sym (pulll π₂∘⟨⟩ ∙ cancelr πι₂))
+```
+
+<details>
+<summary>
+Similarly, we show that the associators and braidings for products and
+coproducts coincide.
+
+```agda
+    coassoc≡assoc : ∀ {a b c} → ⊕-assoc {a} {b} {c} ≡ ×-assoc
+    coswap≡swap : ∀ {a b} → coswap {a} {b} ≡ swap
+```
+</summary>
+
+```agda
+    coassoc≡assoc = unique-matrix
+      ((refl⟩∘⟨ in₀∘[]) ∙ cancell πι₁ ∙ sym (pulll π₁∘⟨⟩ ∙ Biprod.⟨⟩-unique₂
+        (pulll π₁∘⟨⟩ ∙ πι₁)
+        (pulll π₂∘⟨⟩ ∙ pullr π₂-ι₁ ∙ zero-∘l _)
+        πι₁ π₂-ι₁))
+      ((refl⟩∘⟨ in₀∘[]) ∙ pulll π₂-ι₁ ∙ zero-∘r _ ∙ sym (pulll π₂∘⟨⟩ ∙ pullr π₂-ι₁ ∙ zero-∘l _))
+      ((refl⟩∘⟨ in₁∘[]) ∙ unique-matrix
+        ((refl⟩∘⟨ pullr in₀∘[] ∙ cancell πι₁) ∙ π₁-ι₂ ∙ sym (pulll (pulll π₁∘⟨⟩) ∙ (π₁-ι₂ ⟩∘⟨refl) ∙ zero-∘r _))
+        ((refl⟩∘⟨ pullr in₀∘[] ∙ cancell πι₁) ∙ πι₂ ∙ sym (pulll (pulll π₂∘⟨⟩) ∙ (cancelr πι₂ ⟩∘⟨refl) ∙ πι₁))
+        ((refl⟩∘⟨ pullr in₁∘[] ∙ π₁-ι₂) ∙ zero-∘l _ ∙ sym (pulll (pulll π₁∘⟨⟩) ∙ (π₁-ι₂ ⟩∘⟨refl) ∙ zero-∘r _))
+        ((refl⟩∘⟨ pullr in₁∘[] ∙ π₁-ι₂) ∙ zero-∘l _ ∙ sym (pulll (pulll π₂∘⟨⟩) ∙ (cancelr πι₂ ⟩∘⟨refl) ∙ π₁-ι₂))
+      ∙ sym (pulll π₁∘⟨⟩))
+      ((refl⟩∘⟨ in₁∘[]) ∙ Biprod.[]-unique₂
+        _
+        (pullr in₀∘[] ∙ pulll π₂-ι₁ ∙ zero-∘r _)
+        (pullr in₁∘[] ∙ πι₂)
+        _
+        ((cancelr πι₂ ⟩∘⟨refl) ∙ π₂-ι₁)
+        ((cancelr πι₂ ⟩∘⟨refl) ∙ πι₂)
+      ∙ sym (pulll π₂∘⟨⟩))
+
+    coswap≡swap = ⟨⟩-unique _
+      (Biprod.[]-unique₂
+        _ (pullr in₀∘[] ∙ π₁-ι₂) (pullr in₁∘[] ∙ πι₁)
+        _ π₂-ι₁ πι₂)
+      (Biprod.[]-unique₂
+        _ (pullr in₀∘[] ∙ πι₂) (pullr in₁∘[] ∙ π₂-ι₁)
+        _ πι₁ π₁-ι₂)
+```
+</details>
+
+We are finally ready to show that addition of morphisms is associative,
+commutative and unital. These properties essentially follow from the
+corresponding properties of biproducts. For associativity, we use the
+following diagram:
+
+~~~{.quiver}
+\[\begin{tikzcd}
+  && {(A \oplus A) \oplus A} & {(B \oplus B) \oplus B} \\
+  A & {A \oplus A} &&& {B \oplus B} & B \\
+  && {A \oplus (A \oplus A)} & {B \oplus (B \oplus B)}
+  \arrow["{(f \oplus g) \oplus h}", from=1-3, to=1-4]
+  \arrow["\alpha"', from=1-3, to=3-3]
+  \arrow["{\nabla \oplus B}", from=1-4, to=2-5]
+  \arrow["\alpha", from=1-4, to=3-4]
+  \arrow["\delta", from=2-1, to=2-2]
+  \arrow["{\delta \oplus A}", from=2-2, to=1-3]
+  \arrow["{A \oplus \delta}"', from=2-2, to=3-3]
+  \arrow["\nabla", from=2-5, to=2-6]
+  \arrow["{f \oplus (g \oplus h)}"', from=3-3, to=3-4]
+  \arrow["{B \oplus \nabla}"', from=3-4, to=2-5]
+\end{tikzcd}\]
+~~~
+
+```agda
+    +-assoc : ∀ {x y} {f g h : Hom x y} → f +→ (g +→ h) ≡ (f +→ g) +→ h
+    +-assoc {f = f} {g} {h} =
+      ∇ ∘ (f ⊗₁ (∇ ∘ (g ⊗₁ h) ∘ δ)) ∘ δ                           ≡˘⟨ refl⟩∘⟨ ⊗.pulll3 (idl _ ∙ idr _ ,ₚ refl) ⟩
+      ∇ ∘ (id ⊗₁ ∇) ∘ (f ⊗₁ (g ⊗₁ h)) ∘ (id ⊗₁ δ) ∘ δ             ≡˘⟨ refl⟩∘⟨ ⊕₁≡⊗₁ ⟩∘⟨refl ⟩
+      ∇ ∘ (id ⊕₁ ∇) ∘ (f ⊗₁ (g ⊗₁ h)) ∘ (id ⊗₁ δ) ∘ δ             ≡˘⟨ pushl ∇-assoc ⟩
+      (∇ ∘ (∇ ⊕₁ id) ∘ ⊕-assoc) ∘ (f ⊗₁ (g ⊗₁ h)) ∘ (id ⊗₁ δ) ∘ δ ≡⟨ (refl⟩∘⟨ ⊕₁≡⊗₁ ⟩∘⟨refl) ⟩∘⟨refl ⟩
+      (∇ ∘ (∇ ⊗₁ id) ∘ ⊕-assoc) ∘ (f ⊗₁ (g ⊗₁ h)) ∘ (id ⊗₁ δ) ∘ δ ≡⟨ pullr (pullr (coassoc≡assoc ⟩∘⟨refl)) ⟩
+      ∇ ∘ (∇ ⊗₁ id) ∘ ×-assoc ∘ (f ⊗₁ (g ⊗₁ h)) ∘ (id ⊗₁ δ) ∘ δ   ≡⟨ refl⟩∘⟨ refl⟩∘⟨ extendl (associator .Isoⁿ.from .is-natural _ _ _) ⟩
+      ∇ ∘ (∇ ⊗₁ id) ∘ ((f ⊗₁ g) ⊗₁ h) ∘ ×-assoc ∘ (id ⊗₁ δ) ∘ δ   ≡⟨ refl⟩∘⟨ refl⟩∘⟨ refl⟩∘⟨ assoc-δ ⟩
+      ∇ ∘ (∇ ⊗₁ id) ∘ ((f ⊗₁ g) ⊗₁ h) ∘ (δ ⊗₁ id) ∘ δ             ≡⟨ refl⟩∘⟨ ⊗.pulll3 (refl ,ₚ idl _ ∙ idr _) ⟩
+      ∇ ∘ ((∇ ∘ (f ⊗₁ g) ∘ δ) ⊗₁ h) ∘ δ                           ∎
+```
+
+Commutativity follows from the following diagram, where $\beta$ is the
+[[braiding]]:
+
+~~~{.quiver}
+\[\begin{tikzcd}
+  & {A \oplus A} & {B \oplus B} \\
+  A &&& B \\
+  & {A \oplus A} & {B \oplus B}
+  \arrow["{f \oplus g}", from=1-2, to=1-3]
+  \arrow["\beta"', from=1-2, to=3-2]
+  \arrow["\nabla", from=1-3, to=2-4]
+  \arrow["\beta", from=1-3, to=3-3]
+  \arrow["\delta", from=2-1, to=1-2]
+  \arrow["\delta"', from=2-1, to=3-2]
+  \arrow["{g \oplus f}"', from=3-2, to=3-3]
+  \arrow["\nabla"', from=3-3, to=2-4]
+\end{tikzcd}\]
+~~~
+
+```agda
+    +-comm : ∀ {x y} {f g : Hom x y} → f +→ g ≡ g +→ f
+    +-comm {f = f} {g} =
+      ∇ ∘ (f ⊗₁ g) ∘ δ          ≡˘⟨ pulll ∇-coswap ⟩
+      ∇ ∘ coswap ∘ (f ⊗₁ g) ∘ δ ≡⟨ refl⟩∘⟨ coswap≡swap ⟩∘⟨refl ⟩
+      ∇ ∘ swap ∘ (f ⊗₁ g) ∘ δ   ≡˘⟨ refl⟩∘⟨ extendl (swap-natural _) ⟩
+      ∇ ∘ (g ⊗₁ f) ∘ swap ∘ δ   ≡⟨ refl⟩∘⟨ refl⟩∘⟨ swap-δ ⟩
+      ∇ ∘ (g ⊗₁ f) ∘ δ          ∎
+```
+
+Since addition is commutative, it suffices to show that the zero morphism
+is a left unit. We again use the analogous property of biproducts,
+which is that the [[zero object]] is a left unit for $\oplus$.
+
+~~~{.quiver}
+\[\begin{tikzcd}
+  A & {A \oplus A} & {B \oplus B} & B \\
+  && {0 \oplus B}
+  \arrow["\delta", from=1-1, to=1-2]
+  \arrow["{0 \oplus f}", from=1-2, to=1-3]
+  \arrow["{! \oplus f}"', from=1-2, to=2-3]
+  \arrow["\nabla", from=1-3, to=1-4]
+  \arrow["{\text{\textexclamdown} \oplus B}"', from=2-3, to=1-3]
+  \arrow["{\pi_2}"', from=2-3, to=1-4]
+\end{tikzcd}\]
+~~~
+
+```agda
+    ∇-¡l : ∀ {a} → ∇ {a} ∘ (¡ ⊕₁ id) ≡ π₂
+    ∇-¡l = Biprod.[]-unique₂
+      _ (¡-unique₂ _ _) (pullr in₁∘[] ∙ cancell in₁∘[])
+      _ refl πι₂
+
+    +-idl : ∀ {x y} {f : Hom x y} → zero→ +→ f ≡ f
+    +-idl {f = f} =
+      ∇ ∘ (zero→ ⊗₁ f) ∘ δ         ≡⟨ refl⟩∘⟨ ⊗.pushl (refl ,ₚ sym (idl _)) ⟩
+      ∇ ∘ (¡ ⊗₁ id) ∘ (! ⊗₁ f) ∘ δ ≡˘⟨ refl⟩∘⟨ ⊕₁≡⊗₁ ⟩∘⟨refl ⟩
+      ∇ ∘ (¡ ⊕₁ id) ∘ (! ⊗₁ f) ∘ δ ≡⟨ pulll ∇-¡l ⟩
+      π₂ ∘ (! ⊗₁ f) ∘ δ            ≡⟨ pulll π₂∘⟨⟩ ⟩
+      (f ∘ π₂) ∘ δ                 ≡⟨ cancelr π₂∘⟨⟩ ⟩
+      f                            ∎
+
+    +-idr : ∀ {x y} {f : Hom x y} → f +→ zero→ ≡ f
+    +-idr = +-comm ∙ +-idl
+```
+
+Naturality of the (co)diagonals implies that composition is bilinear
+with respect to our defined addition.
+
+```agda
+    ∘-linear-l
+      : ∀ {a b c} {f g : Hom b c} {h : Hom a b}
+      → f ∘ h +→ g ∘ h ≡ (f +→ g) ∘ h
+    ∘-linear-l {f = f} {g} {h} =
+      ∇ ∘ ((f ∘ h) ⊗₁ (g ∘ h)) ∘ δ ≡⟨ refl⟩∘⟨ ⊗.pushl refl ⟩
+      ∇ ∘ (f ⊗₁ g) ∘ (h ⊗₁ h) ∘ δ  ≡˘⟨ pullr (pullr (diagonals .is-natural _ _ _)) ⟩
+      (∇ ∘ (f ⊗₁ g) ∘ δ) ∘ h       ∎
+
+    ∘-linear-r
+      : ∀ {a b c} {f g : Hom a b} {h : Hom b c}
+      → h ∘ f +→ h ∘ g ≡ h ∘ (f +→ g)
+    ∘-linear-r {f = f} {g} {h} =
+      ∇ ∘ ((h ∘ f) ⊗₁ (h ∘ g)) ∘ δ ≡⟨ refl⟩∘⟨ ⊗.pushl refl ⟩
+      ∇ ∘ (h ⊗₁ h) ∘ (f ⊗₁ g) ∘ δ  ≡˘⟨ refl⟩∘⟨ ⊕₁≡⊗₁ ⟩∘⟨refl ⟩
+      ∇ ∘ (h ⊕₁ h) ∘ (f ⊗₁ g) ∘ δ  ≡⟨ extendl (∇-natural _ _ _) ⟩
+      h ∘ ∇ ∘ (f ⊗₁ g) ∘ δ         ∎
+```
+
+This provides an alternative route to defining [[additive categories]]:
+instead of starting with an [[$\Ab$-enriched category]] and requiring
+finite (co)products, we can start with a semiadditive category and
+require that every $\hom$-monoid be a group.
+
+We provide a helpful way to construct a semiadditive category from a category
+with a [[zero object]], binary [[products]] and [[coproducts]]: it
+suffices to require that the map $A + B \to A \times B$ defined by
+the matrix representation
+
+$$
+\begin{bmatrix}
+\mathrm{id} & 0 \\
+0 & \mathrm{id}
+\end{bmatrix}
+$$
+
+is invertible.
+
+```agda
+  record make-semiadditive : Type (o ⊔ ℓ) where
+    field
+      has-zero : Zero C
+      has-coprods : ∀ a b → Coproduct C a b
+      has-prods : ∀ a b → Product C a b
+
+    open Zero has-zero
+    open Binary-products C has-prods
+    open Binary-coproducts C has-coprods
+
+    coproduct→product : ∀ {a b} → Hom (a ⊕₀ b) (a ⊗₀ b)
+    coproduct→product = ⟨ [ id , zero→ ]
+                        , [ zero→ , id ] ⟩
+
+    field
+      coproduct≅product : ∀ {a b} → is-invertible (coproduct→product {a} {b})
+```
+
+If that is the case, then the coproduct $A + B$ is a biproduct
+when equipped with the projections $[\id, 0]$ and $[0, \id]$.
+
+```agda
+    has-biproducts : ∀ {a b} → Biproduct a b
+    has-biproducts {a} {b} .Biproduct.biapex = a ⊕₀ b
+    has-biproducts .Biproduct.π₁ = [ id , zero→ ]
+    has-biproducts .Biproduct.π₂ = [ zero→ , id ]
+    has-biproducts .Biproduct.ι₁ = in₀
+    has-biproducts .Biproduct.ι₂ = in₁
+    has-biproducts .Biproduct.has-is-biproduct .is-biproduct.has-is-product =
+        is-product-iso-apex coproduct≅product π₁∘⟨⟩ π₂∘⟨⟩ has-is-product
+    has-biproducts .Biproduct.has-is-biproduct .is-biproduct.has-is-coproduct = has-is-coproduct
+    has-biproducts .Biproduct.has-is-biproduct .is-biproduct.πι₁ = in₀∘[]
+    has-biproducts .Biproduct.has-is-biproduct .is-biproduct.πι₂ = in₁∘[]
+    has-biproducts .Biproduct.has-is-biproduct .is-biproduct.ιπ-comm =
+      in₀ ∘ [ id , zero→ ] ∘ in₁ ∘ [ zero→ , id ] ≡⟨ refl⟩∘⟨ pulll in₁∘[] ⟩
+      in₀ ∘ zero→ ∘ [ zero→ , id ]                ≡⟨ pulll (zero-∘l _) ∙ zero-∘r _ ⟩
+      zero→                                       ≡˘⟨ pulll (zero-∘l _) ∙ zero-∘r _ ⟩
+      in₁ ∘ zero→ ∘ [ id , zero→ ]                ≡˘⟨ refl⟩∘⟨ pulll in₀∘[] ⟩
+      in₁ ∘ [ zero→ , id ] ∘ in₀ ∘ [ id , zero→ ] ∎
+
+  open make-semiadditive
+
+  to-semiadditive : make-semiadditive → is-semiadditive
+  to-semiadditive mk .is-semiadditive.has-zero = has-zero mk
+  to-semiadditive mk .is-semiadditive.has-biproducts = has-biproducts mk
+```

--- a/src/Cat/Diagram/Biproduct.lagda.md
+++ b/src/Cat/Diagram/Biproduct.lagda.md
@@ -90,13 +90,13 @@ $$
 
     coproduct : Coproduct C A B
     coproduct = record
-      { coapex = biapex ; in₀ = ι₁ ; in₁ = ι₂ ; has-is-coproduct = has-is-coproduct }
+      { coapex = biapex ; ι₁ = ι₁ ; ι₂ = ι₂ ; has-is-coproduct = has-is-coproduct }
 
     open Product product public
       hiding (π₁; π₂)
       renaming (unique₂ to ⟨⟩-unique₂)
     open Coproduct coproduct public
-      hiding (in₀; in₁)
+      hiding (ι₁; ι₂)
       renaming (unique₂ to []-unique₂)
 ```
 
@@ -126,7 +126,7 @@ $\cC$ in *commutative monoids*!
     open Biprod using (πι₁; πι₂; ιπ-comm)
 
     open Binary-products C (λ _ _ → Biprod.product)
-    open Binary-coproducts C (λ _ _ → Biprod.coproduct) renaming (in₀ to ι₁; in₁ to ι₂)
+    open Binary-coproducts C (λ _ _ → Biprod.coproduct)
 
     open Monoidal-category (Cartesian-monoidal (λ _ _ → Biprod.product) terminal) using (associator; module ⊗)
     open Diagonals (Cartesian-diagonal (λ _ _ → Biprod.product) terminal) hiding (δ)
@@ -213,10 +213,10 @@ $$
       → (π₁ ∘ f ∘ ι₂ ≡ π₁ ∘ g ∘ ι₂)
       → (π₂ ∘ f ∘ ι₂ ≡ π₂ ∘ g ∘ ι₂)
       → f ≡ g
-    unique-matrix p₁₁ p₁₂ p₂₁ p₂₂ = Biprod.[]-unique₂ _
+    unique-matrix p₁₁ p₁₂ p₂₁ p₂₂ = Biprod.[]-unique₂
       (Biprod.⟨⟩-unique₂ p₁₁ p₁₂ refl refl)
       (Biprod.⟨⟩-unique₂ p₂₁ p₂₂ refl refl)
-      _ refl refl
+      refl refl
 ```
 
 This implies that $f \times_1 g$ and $f +_1 g$ are equal, as they both have
@@ -232,10 +232,10 @@ $$
 ```agda
     ⊕₁≡⊗₁ : ∀ {a b c d} {f : Hom a b} {g : Hom c d} → f ⊕₁ g ≡ f ⊗₁ g
     ⊕₁≡⊗₁ = unique-matrix
-      ((refl⟩∘⟨ in₀∘[]) ∙ cancell πι₁ ∙ sym (pulll π₁∘⟨⟩ ∙ cancelr πι₁))
-      ((refl⟩∘⟨ in₀∘[]) ∙ pulll π₂-ι₁ ∙ zero-∘r _ ∙ sym (pulll π₂∘⟨⟩ ∙ pullr π₂-ι₁ ∙ zero-∘l _))
-      ((refl⟩∘⟨ in₁∘[]) ∙ pulll π₁-ι₂ ∙ zero-∘r _ ∙ sym (pulll π₁∘⟨⟩ ∙ pullr π₁-ι₂ ∙ zero-∘l _))
-      ((refl⟩∘⟨ in₁∘[]) ∙ cancell πι₂ ∙ sym (pulll π₂∘⟨⟩ ∙ cancelr πι₂))
+      ((refl⟩∘⟨ []∘ι₁) ∙ cancell πι₁ ∙ sym (pulll π₁∘⟨⟩ ∙ cancelr πι₁))
+      ((refl⟩∘⟨ []∘ι₁) ∙ pulll π₂-ι₁ ∙ zero-∘r _ ∙ sym (pulll π₂∘⟨⟩ ∙ pullr π₂-ι₁ ∙ zero-∘l _))
+      ((refl⟩∘⟨ []∘ι₂) ∙ pulll π₁-ι₂ ∙ zero-∘r _ ∙ sym (pulll π₁∘⟨⟩ ∙ pullr π₁-ι₂ ∙ zero-∘l _))
+      ((refl⟩∘⟨ []∘ι₂) ∙ cancell πι₂ ∙ sym (pulll π₂∘⟨⟩ ∙ cancelr πι₂))
 ```
 
 <details>
@@ -251,33 +251,31 @@ coproducts coincide.
 
 ```agda
     coassoc≡assoc = unique-matrix
-      ((refl⟩∘⟨ in₀∘[]) ∙ cancell πι₁ ∙ sym (pulll π₁∘⟨⟩ ∙ Biprod.⟨⟩-unique₂
+      ((refl⟩∘⟨ []∘ι₁) ∙ cancell πι₁ ∙ sym (pulll π₁∘⟨⟩ ∙ Biprod.⟨⟩-unique₂
         (pulll π₁∘⟨⟩ ∙ πι₁)
         (pulll π₂∘⟨⟩ ∙ pullr π₂-ι₁ ∙ zero-∘l _)
         πι₁ π₂-ι₁))
-      ((refl⟩∘⟨ in₀∘[]) ∙ pulll π₂-ι₁ ∙ zero-∘r _ ∙ sym (pulll π₂∘⟨⟩ ∙ pullr π₂-ι₁ ∙ zero-∘l _))
-      ((refl⟩∘⟨ in₁∘[]) ∙ unique-matrix
-        ((refl⟩∘⟨ pullr in₀∘[] ∙ cancell πι₁) ∙ π₁-ι₂ ∙ sym (pulll (pulll π₁∘⟨⟩) ∙ (π₁-ι₂ ⟩∘⟨refl) ∙ zero-∘r _))
-        ((refl⟩∘⟨ pullr in₀∘[] ∙ cancell πι₁) ∙ πι₂ ∙ sym (pulll (pulll π₂∘⟨⟩) ∙ (cancelr πι₂ ⟩∘⟨refl) ∙ πι₁))
-        ((refl⟩∘⟨ pullr in₁∘[] ∙ π₁-ι₂) ∙ zero-∘l _ ∙ sym (pulll (pulll π₁∘⟨⟩) ∙ (π₁-ι₂ ⟩∘⟨refl) ∙ zero-∘r _))
-        ((refl⟩∘⟨ pullr in₁∘[] ∙ π₁-ι₂) ∙ zero-∘l _ ∙ sym (pulll (pulll π₂∘⟨⟩) ∙ (cancelr πι₂ ⟩∘⟨refl) ∙ π₁-ι₂))
+      ((refl⟩∘⟨ []∘ι₁) ∙ pulll π₂-ι₁ ∙ zero-∘r _ ∙ sym (pulll π₂∘⟨⟩ ∙ pullr π₂-ι₁ ∙ zero-∘l _))
+      ((refl⟩∘⟨ []∘ι₂) ∙ unique-matrix
+        ((refl⟩∘⟨ pullr []∘ι₁ ∙ cancell πι₁) ∙ π₁-ι₂ ∙ sym (pulll (pulll π₁∘⟨⟩) ∙ (π₁-ι₂ ⟩∘⟨refl) ∙ zero-∘r _))
+        ((refl⟩∘⟨ pullr []∘ι₁ ∙ cancell πι₁) ∙ πι₂ ∙ sym (pulll (pulll π₂∘⟨⟩) ∙ (cancelr πι₂ ⟩∘⟨refl) ∙ πι₁))
+        ((refl⟩∘⟨ pullr []∘ι₂ ∙ π₁-ι₂) ∙ zero-∘l _ ∙ sym (pulll (pulll π₁∘⟨⟩) ∙ (π₁-ι₂ ⟩∘⟨refl) ∙ zero-∘r _))
+        ((refl⟩∘⟨ pullr []∘ι₂ ∙ π₁-ι₂) ∙ zero-∘l _ ∙ sym (pulll (pulll π₂∘⟨⟩) ∙ (cancelr πι₂ ⟩∘⟨refl) ∙ π₁-ι₂))
       ∙ sym (pulll π₁∘⟨⟩))
-      ((refl⟩∘⟨ in₁∘[]) ∙ Biprod.[]-unique₂
-        _
-        (pullr in₀∘[] ∙ pulll π₂-ι₁ ∙ zero-∘r _)
-        (pullr in₁∘[] ∙ πι₂)
-        _
+      ((refl⟩∘⟨ []∘ι₂) ∙ Biprod.[]-unique₂
+        (pullr []∘ι₁ ∙ pulll π₂-ι₁ ∙ zero-∘r _)
+        (pullr []∘ι₂ ∙ πι₂)
         ((cancelr πι₂ ⟩∘⟨refl) ∙ π₂-ι₁)
         ((cancelr πι₂ ⟩∘⟨refl) ∙ πι₂)
       ∙ sym (pulll π₂∘⟨⟩))
 
-    coswap≡swap = ⟨⟩-unique _
+    coswap≡swap = ⟨⟩-unique
       (Biprod.[]-unique₂
-        _ (pullr in₀∘[] ∙ π₁-ι₂) (pullr in₁∘[] ∙ πι₁)
-        _ π₂-ι₁ πι₂)
+        (pullr []∘ι₁ ∙ π₁-ι₂) (pullr []∘ι₂ ∙ πι₁)
+        π₂-ι₁ πι₂)
       (Biprod.[]-unique₂
-        _ (pullr in₀∘[] ∙ πι₂) (pullr in₁∘[] ∙ π₂-ι₁)
-        _ πι₁ π₁-ι₂)
+        (pullr []∘ι₁ ∙ πι₂) (pullr []∘ι₂ ∙ π₂-ι₁)
+        πι₁ π₁-ι₂)
 ```
 </details>
 
@@ -367,8 +365,8 @@ which is that the [[zero object]] is a left unit for $\oplus$.
 ```agda
     ∇-¡l : ∀ {a} → ∇ {a} ∘ (¡ ⊕₁ id) ≡ π₂
     ∇-¡l = Biprod.[]-unique₂
-      _ (¡-unique₂ _ _) (pullr in₁∘[] ∙ cancell in₁∘[])
-      _ refl πι₂
+      (¡-unique₂ _ _) (pullr []∘ι₂ ∙ cancell []∘ι₂)
+      refl πι₂
 
     +-idl : ∀ {x y} {f : Hom x y} → zero→ +→ f ≡ f
     +-idl {f = f} =
@@ -451,19 +449,19 @@ when equipped with the projections $[\id, 0]$ and $[0, \id]$.
     has-biproducts {a} {b} .Biproduct.biapex = a ⊕₀ b
     has-biproducts .Biproduct.π₁ = [ id , zero→ ]
     has-biproducts .Biproduct.π₂ = [ zero→ , id ]
-    has-biproducts .Biproduct.ι₁ = in₀
-    has-biproducts .Biproduct.ι₂ = in₁
+    has-biproducts .Biproduct.ι₁ = ι₁
+    has-biproducts .Biproduct.ι₂ = ι₂
     has-biproducts .Biproduct.has-is-biproduct .is-biproduct.has-is-product =
         is-product-iso-apex coproduct≅product π₁∘⟨⟩ π₂∘⟨⟩ has-is-product
     has-biproducts .Biproduct.has-is-biproduct .is-biproduct.has-is-coproduct = has-is-coproduct
-    has-biproducts .Biproduct.has-is-biproduct .is-biproduct.πι₁ = in₀∘[]
-    has-biproducts .Biproduct.has-is-biproduct .is-biproduct.πι₂ = in₁∘[]
+    has-biproducts .Biproduct.has-is-biproduct .is-biproduct.πι₁ = []∘ι₁
+    has-biproducts .Biproduct.has-is-biproduct .is-biproduct.πι₂ = []∘ι₂
     has-biproducts .Biproduct.has-is-biproduct .is-biproduct.ιπ-comm =
-      in₀ ∘ [ id , zero→ ] ∘ in₁ ∘ [ zero→ , id ] ≡⟨ refl⟩∘⟨ pulll in₁∘[] ⟩
-      in₀ ∘ zero→ ∘ [ zero→ , id ]                ≡⟨ pulll (zero-∘l _) ∙ zero-∘r _ ⟩
-      zero→                                       ≡˘⟨ pulll (zero-∘l _) ∙ zero-∘r _ ⟩
-      in₁ ∘ zero→ ∘ [ id , zero→ ]                ≡˘⟨ refl⟩∘⟨ pulll in₀∘[] ⟩
-      in₁ ∘ [ zero→ , id ] ∘ in₀ ∘ [ id , zero→ ] ∎
+      ι₁ ∘ [ id , zero→ ] ∘ ι₂ ∘ [ zero→ , id ] ≡⟨ refl⟩∘⟨ pulll []∘ι₂ ⟩
+      ι₁ ∘ zero→ ∘ [ zero→ , id ]               ≡⟨ pulll (zero-∘l _) ∙ zero-∘r _ ⟩
+      zero→                                     ≡˘⟨ pulll (zero-∘l _) ∙ zero-∘r _ ⟩
+      ι₂ ∘ zero→ ∘ [ id , zero→ ]               ≡˘⟨ refl⟩∘⟨ pulll []∘ι₁ ⟩
+      ι₂ ∘ [ zero→ , id ] ∘ ι₁ ∘ [ id , zero→ ] ∎
 
   open make-semiadditive
 

--- a/src/Cat/Diagram/Biproduct.lagda.md
+++ b/src/Cat/Diagram/Biproduct.lagda.md
@@ -4,7 +4,6 @@ open import Algebra.Group.Ab
 
 open import Cat.Monoidal.Instances.Cartesian
 open import Cat.Functor.Naturality
-open import Cat.Monoidal.Diagonals
 open import Cat.Diagram.Coproduct
 open import Cat.Diagram.Terminal
 open import Cat.Diagram.Initial
@@ -34,7 +33,7 @@ module _ {o ℓ} (C : Precategory o ℓ) where
 
 Recall that, in an [[$\Ab$-enriched category]], [[products]] and
 [[coproducts]] automatically coincide: these are called **biproducts**
-and written $A \oplus B$.
+and are written $A \oplus B$.
 
 ~~~{.quiver}
 \[\begin{tikzcd}
@@ -81,7 +80,10 @@ $$
       ι₁ : Hom A biapex
       ι₂ : Hom B biapex
       has-is-biproduct : is-biproduct π₁ π₂ ι₁ ι₂
+```
 
+<!--
+```agda
     open is-biproduct has-is-biproduct public
 
     product : Product C A B
@@ -99,6 +101,7 @@ $$
       hiding (ι₁; ι₂)
       renaming (unique₂ to []-unique₂)
 ```
+-->
 
 ## Semiadditive categories {defines="semiadditive-category"}
 
@@ -129,7 +132,6 @@ $\cC$ in *commutative monoids*!
     open Binary-coproducts C (λ _ _ → Biprod.coproduct)
 
     open Monoidal-category (Cartesian-monoidal (λ _ _ → Biprod.product) terminal) using (associator; module ⊗)
-    open Diagonals (Cartesian-diagonal (λ _ _ → Biprod.product) terminal) hiding (δ)
 ```
 -->
 
@@ -390,7 +392,7 @@ with respect to our defined addition.
       → f ∘ h +→ g ∘ h ≡ (f +→ g) ∘ h
     ∘-linear-l {f = f} {g} {h} =
       ∇ ∘ ((f ∘ h) ⊗₁ (g ∘ h)) ∘ δ ≡⟨ refl⟩∘⟨ ⊗.pushl refl ⟩
-      ∇ ∘ (f ⊗₁ g) ∘ (h ⊗₁ h) ∘ δ  ≡˘⟨ pullr (pullr (diagonals .is-natural _ _ _)) ⟩
+      ∇ ∘ (f ⊗₁ g) ∘ (h ⊗₁ h) ∘ δ  ≡˘⟨ pullr (pullr (δ-natural _ _ _)) ⟩
       (∇ ∘ (f ⊗₁ g) ∘ δ) ∘ h       ∎
 
     ∘-linear-r
@@ -408,8 +410,8 @@ instead of starting with an [[$\Ab$-enriched category]] and requiring
 finite (co)products, we can start with a semiadditive category and
 require that every $\hom$-monoid be a group.
 
-We provide a helpful way to construct a semiadditive category from a category
-with a [[zero object]], binary [[products]] and [[coproducts]]: it
+In order to *construct* a semiadditive category from a category
+with a [[zero object]], binary [[products]] and [[coproducts]], it
 suffices to require that the map $A + B \to A \times B$ defined by
 the matrix representation
 

--- a/src/Cat/Diagram/Colimit/Coproduct.lagda.md
+++ b/src/Cat/Diagram/Colimit/Coproduct.lagda.md
@@ -59,9 +59,9 @@ is-coproduct→is-colimit {x = x} {F} {eta} coprod =
     mc .ψ j = eta .η j
     mc .commutes f = eta .is-natural _ _ _ ∙ idl _
     mc .universal eta _ = coprod.[ eta true , eta false ]
-    mc .factors {true} eta _ = coprod.in₀∘factor
-    mc .factors {false} eta _ = coprod.in₁∘factor
-    mc .unique eta p other q = coprod.unique other (q true) (q false)
+    mc .factors {true} eta _ = coprod.[]∘ι₁
+    mc .factors {false} eta _ = coprod.[]∘ι₂
+    mc .unique eta p other q = coprod.unique (q true) (q false)
 
 is-colimit→is-coproduct
   : ∀ {a b} {K : Functor ⊤Cat C}
@@ -91,9 +91,9 @@ is-colimit→is-coproduct {a} {b} {K} {eta} colim = coprod where
 
   coprod : is-coproduct C (eta .η true) (eta .η false)
   coprod .[_,_] f g = colim.universal (copair f g) copair-commutes
-  coprod .in₀∘factor {_} {p1'} {p2'} = colim.factors (copair p1' p2') copair-commutes
-  coprod .in₁∘factor {_} {p1'} {p2'} = colim.factors (copair p1' p2') copair-commutes
-  coprod .unique other p q = colim.unique _ _ other λ where
+  coprod .[]∘ι₁ {_} {p1'} {p2'} = colim.factors (copair p1' p2') copair-commutes
+  coprod .[]∘ι₂ {_} {p1'} {p2'} = colim.factors (copair p1' p2') copair-commutes
+  coprod .unique p q = colim.unique _ _ _ λ where
     true → p
     false → q
 
@@ -102,8 +102,8 @@ Coproduct→Colimit coprod = to-colimit (is-coproduct→is-colimit {eta = 2-obje
 
 Colimit→Coproduct : ∀ {a b} → Colimit (2-object-diagram a b) → Coproduct C a b
 Colimit→Coproduct colim .coapex = Colimit.coapex colim
-Colimit→Coproduct colim .in₀ = Colimit.cocone colim .η true
-Colimit→Coproduct colim .in₁ = Colimit.cocone colim .η false
+Colimit→Coproduct colim .ι₁ = Colimit.cocone colim .η true
+Colimit→Coproduct colim .ι₂ = Colimit.cocone colim .η false
 Colimit→Coproduct colim .has-is-coproduct =
   is-colimit→is-coproduct (Colimit.has-colimit colim)
 ```

--- a/src/Cat/Diagram/Colimit/Finite.lagda.md
+++ b/src/Cat/Diagram/Colimit/Finite.lagda.md
@@ -126,15 +126,15 @@ of $in_0f$ and $in_1g$.
     po .square = sym (assoc _ _ _) ∙ cq.coequal ∙ assoc _ _ _
     po .universal {i₁' = i₁'} {i₂'} p =
       cq.universal {e' = cp.[ i₁' , i₂' ]} (
-        cp.[ i₁' , i₂' ] ∘ (in1 ∘ f) ≡⟨ pulll cp.in₀∘factor ⟩
+        cp.[ i₁' , i₂' ] ∘ (in1 ∘ f) ≡⟨ pulll cp.[]∘ι₁ ⟩
         i₁' ∘ f                      ≡⟨ p ⟩
-        i₂' ∘ g                      ≡˘⟨ pulll cp.in₁∘factor ⟩
+        i₂' ∘ g                      ≡˘⟨ pulll cp.[]∘ι₂ ⟩
         cp.[ i₁' , i₂' ] ∘ (in2 ∘ g) ∎
       )
-    po .i₁∘universal = pulll cq.factors ∙ cp.in₀∘factor
-    po .i₂∘universal = pulll cq.factors ∙ cp.in₁∘factor
+    po .universal∘i₁ = pulll cq.factors ∙ cp.[]∘ι₁
+    po .universal∘i₂ = pulll cq.factors ∙ cp.[]∘ι₂
     po .unique p q =
-      cq.unique ((cp.unique _ (sym (assoc _ _ _) ∙ p) (sym (assoc _ _ _) ∙ q)))
+      cq.unique ((cp.unique (sym (assoc _ _ _) ∙ p) (sym (assoc _ _ _) ∙ q)))
 ```
 
 Thus, if a category has an initial object, binary coproducts, and
@@ -153,7 +153,7 @@ binary coequalisers, it is finitely cocomplete.
     record { has-is-po = coproduct-coequaliser→pushout Copr.has-is-coproduct Coequ.has-is-coeq }
     where
       module Copr = Coproduct (copr A B)
-      module Coequ = Coequaliser (coeq (Copr.in₀ ∘ f) (Copr.in₁ ∘ g))
+      module Coequ = Coequaliser (coeq (Copr.ι₁ ∘ f) (Copr.ι₂ ∘ g))
 ```
 
 ## With pushouts
@@ -170,9 +170,9 @@ A coproduct is a pushout under a span whose vertex is the initial object.
       coprod : is-coproduct C in1 in2
       coprod .is-coproduct.[_,_] in1' in2' =
         Po.universal {i₁' = in1'} {i₂' = in2'} (is-contr→is-prop (init _) _ _)
-      coprod .is-coproduct.in₀∘factor = Po.i₁∘universal
-      coprod .is-coproduct.in₁∘factor = Po.i₂∘universal
-      coprod .is-coproduct.unique other p q = Po.unique p q
+      coprod .is-coproduct.[]∘ι₁ = Po.universal∘i₁
+      coprod .is-coproduct.[]∘ι₂ = Po.universal∘i₂
+      coprod .is-coproduct.unique p q = Po.unique p q
 
   with-pushouts
     : Initial C
@@ -225,38 +225,38 @@ limits]].
       coequ .coapex = Po.coapex
       coequ .coeq = Po.i₁
       coequ .has-is-coeq .coequal =
-        Po.i₁ ∘ f                 ≡˘⟨ ap (Po.i₁ ∘_) A+A.in₀∘factor ⟩
-        Po.i₁ ∘ [f,g] ∘ A+A.in₀   ≡⟨ assoc _ _ _ ∙ ap (_∘ A+A.in₀) Po.square ⟩
-        (Po.i₂ ∘ [id,id]) ∘ A+A.in₀ ≡⟨ sym (assoc _ _ _) ∙ pushr (A+A.in₀∘factor ∙ sym A+A.in₁∘factor) ⟩
-        (Po.i₂ ∘ [id,id]) ∘ A+A.in₁ ≡⟨ ap (_∘ A+A.in₁) (sym Po.square) ⟩
-        (Po.i₁ ∘ [f,g]) ∘ A+A.in₁   ≡⟨ sym (assoc _ _ _) ∙ ap (Po.i₁ ∘_) A+A.in₁∘factor ⟩
-        Po.i₁ ∘ g                 ∎
+        Po.i₁ ∘ f                  ≡˘⟨ ap (Po.i₁ ∘_) A+A.[]∘ι₁ ⟩
+        Po.i₁ ∘ [f,g] ∘ A+A.ι₁     ≡⟨ assoc _ _ _ ∙ ap (_∘ A+A.ι₁) Po.square ⟩
+        (Po.i₂ ∘ [id,id]) ∘ A+A.ι₁ ≡⟨ sym (assoc _ _ _) ∙ pushr (A+A.[]∘ι₁ ∙ sym A+A.[]∘ι₂) ⟩
+        (Po.i₂ ∘ [id,id]) ∘ A+A.ι₂ ≡⟨ ap (_∘ A+A.ι₂) (sym Po.square) ⟩
+        (Po.i₁ ∘ [f,g]) ∘ A+A.ι₂   ≡⟨ sym (assoc _ _ _) ∙ ap (Po.i₁ ∘_) A+A.[]∘ι₂ ⟩
+        Po.i₁ ∘ g                  ∎
       coequ .has-is-coeq .universal {e' = e'} p =
-        Po.universal (A+A.unique₂ _ refl refl _ (in1) (in2))
+        Po.universal (A+A.unique₂ refl refl (in1) (in2))
         where
-          in1 : ((e' ∘ f) ∘ [id,id]) ∘ A+A.in₀ ≡ (e' ∘ [f,g]) ∘ A+A.in₀
+          in1 : ((e' ∘ f) ∘ [id,id]) ∘ A+A.ι₁ ≡ (e' ∘ [f,g]) ∘ A+A.ι₁
           in1 =
-            ((e' ∘ f) ∘ [id,id]) ∘ A+A.in₀ ≡⟨ cancelr A+A.in₀∘factor ⟩ -- ≡⟨ cancell A+A.in₀∘factor ⟩
-            e' ∘ f                     ≡˘⟨ pullr A+A.in₀∘factor ⟩ -- ≡˘⟨ pulll A+A.in₀∘factor ⟩
-            (e' ∘ [f,g]) ∘ A+A.in₀       ∎
+            ((e' ∘ f) ∘ [id,id]) ∘ A+A.ι₁ ≡⟨ cancelr A+A.[]∘ι₁ ⟩ -- ≡⟨ cancell A+A.[]∘ι₁ ⟩
+            e' ∘ f                        ≡˘⟨ pullr A+A.[]∘ι₁ ⟩ -- ≡˘⟨ pulll A+A.[]∘ι₁ ⟩
+            (e' ∘ [f,g]) ∘ A+A.ι₁         ∎
 
-          in2 : ((e' ∘ f) ∘ [id,id]) ∘ A+A.in₁ ≡ (e' ∘ [f,g]) ∘ A+A.in₁
+          in2 : ((e' ∘ f) ∘ [id,id]) ∘ A+A.ι₂ ≡ (e' ∘ [f,g]) ∘ A+A.ι₂
           in2 =
-            ((e' ∘ f) ∘ [id,id]) ∘ A+A.in₁  ≡⟨ cancelr A+A.in₁∘factor ⟩
-            e' ∘ f                     ≡⟨ p ⟩
-            e' ∘ g                     ≡˘⟨ pullr A+A.in₁∘factor ⟩
-            (e' ∘ [f,g]) ∘ A+A.in₁        ∎
+            ((e' ∘ f) ∘ [id,id]) ∘ A+A.ι₂ ≡⟨ cancelr A+A.[]∘ι₂ ⟩
+            e' ∘ f                        ≡⟨ p ⟩
+            e' ∘ g                        ≡˘⟨ pullr A+A.[]∘ι₂ ⟩
+            (e' ∘ [f,g]) ∘ A+A.ι₂         ∎
 
-      coequ .has-is-coeq .factors = Po.i₁∘universal
+      coequ .has-is-coeq .factors = Po.universal∘i₁
       coequ .has-is-coeq .unique {F} {e' = e'} {colim = colim} e'=col∘i₁ =
         Po.unique e'=col∘i₁ path
         where
           path : colim ∘ Po.i₂ ≡ e' ∘ f
           path =
-            colim ∘ Po.i₂                         ≡⟨ insertr A+A.in₀∘factor ⟩
-            ((colim ∘ Po.i₂) ∘ [id,id]) ∘ A+A.in₀ ≡⟨ ap (_∘ A+A.in₀) (extendr (sym Po.square)) ⟩
-            ((colim ∘ Po.i₁) ∘ [f,g]) ∘ A+A.in₀   ≡⟨ ap (_∘ A+A.in₀) (ap (_∘ [f,g]) e'=col∘i₁) ⟩
-            (e' ∘ [f,g]) ∘ A+A.in₀                ≡⟨ pullr A+A.in₀∘factor ⟩
+            colim ∘ Po.i₂                        ≡⟨ insertr A+A.[]∘ι₁ ⟩
+            ((colim ∘ Po.i₂) ∘ [id,id]) ∘ A+A.ι₁ ≡⟨ ap (_∘ A+A.ι₁) (extendr (sym Po.square)) ⟩
+            ((colim ∘ Po.i₁) ∘ [f,g]) ∘ A+A.ι₁   ≡⟨ ap (_∘ A+A.ι₁) (ap (_∘ [f,g]) e'=col∘i₁) ⟩
+            (e' ∘ [f,g]) ∘ A+A.ι₁                ≡⟨ pullr A+A.[]∘ι₁ ⟩
             e' ∘ f           ∎
 
     fcc : Finitely-cocomplete
@@ -276,9 +276,9 @@ limits]].
     po : is-pushout C _ _ _ _
     po .square = is-contr→is-prop (i _) _ _
     po .universal _ = r .is-coproduct.[_,_] _ _
-    po .i₁∘universal = r .is-coproduct.in₀∘factor
-    po .i₂∘universal = r .is-coproduct.in₁∘factor
-    po .unique p q = r .is-coproduct.unique _ p q
+    po .universal∘i₁ = r .is-coproduct.[]∘ι₁
+    po .universal∘i₂ = r .is-coproduct.[]∘ι₂
+    po .unique p q = r .is-coproduct.unique p q
 ```
 -->
 

--- a/src/Cat/Diagram/Congruence.lagda.md
+++ b/src/Cat/Diagram/Congruence.lagda.md
@@ -201,12 +201,12 @@ Here's the data of a congruence. Get ready, because there's a lot of it:
   trans-p₁ : rel₁ ∘ has-trans ≡ rel₁ ∘ A×A×A.p₂
   trans-p₁ =
     pullr (sym trans-factors)
-    ∙ A×A.π₁∘factor
+    ∙ A×A.π₁∘⟨⟩
 
   trans-p₂ : rel₂ ∘ has-trans ≡ rel₂ ∘ A×A×A.p₁
   trans-p₂ =
     pullr (sym trans-factors)
-    ∙ A×A.π₂∘factor
+    ∙ A×A.π₂∘⟨⟩
 
   unpair-trans
     : ∀ {X} {p₁' p₂' : Hom X R}
@@ -245,9 +245,9 @@ calculation, where we use that $\id = \pi_1 \circ \Delta$.
 ```agda
 diagonal-is-monic : ∀ {A} → is-monic (diagonal {A})
 diagonal-is-monic {A} g h p =
-  g                       ≡⟨ introl A×A.π₁∘factor ⟩
+  g                       ≡⟨ introl A×A.π₁∘⟨⟩ ⟩
   (A×A.π₁ ∘ diagonal) ∘ g ≡⟨ extendr p ⟩
-  (A×A.π₁ ∘ diagonal) ∘ h ≡⟨ eliml A×A.π₁∘factor ⟩
+  (A×A.π₁ ∘ diagonal) ∘ h ≡⟨ eliml A×A.π₁∘⟨⟩ ⟩
   h                       ∎
   where module A×A = Product (fc.products A A)
 ```
@@ -268,16 +268,16 @@ diagonal-congruence {A} = cong where
   cong : is-congruence _
   cong .has-is-monic = diagonal-is-monic
   cong .has-refl = id
-  cong .refl-p₁ = eliml A×A.π₁∘factor
-  cong .refl-p₂ = eliml A×A.π₂∘factor
+  cong .refl-p₁ = eliml A×A.π₁∘⟨⟩
+  cong .refl-p₂ = eliml A×A.π₂∘⟨⟩
   cong .has-sym = id
-  cong .sym-p₁ = eliml A×A.π₁∘factor ∙ sym A×A.π₂∘factor
-  cong .sym-p₂ = eliml A×A.π₂∘factor ∙ sym A×A.π₁∘factor
+  cong .sym-p₁ = eliml A×A.π₁∘⟨⟩ ∙ sym A×A.π₂∘⟨⟩
+  cong .sym-p₂ = eliml A×A.π₂∘⟨⟩ ∙ sym A×A.π₁∘⟨⟩
   cong .has-trans = Pb.p₁
   cong .trans-factors = A×A.unique₂
-    (A×A.π₁∘factor ∙ eliml A×A.π₁∘factor) (A×A.π₂∘factor ∙ eliml A×A.π₂∘factor)
-    (assoc _ _ _ ∙ Pb.square ∙ eliml A×A.π₂∘factor)
-    (cancell A×A.π₂∘factor)
+    (A×A.π₁∘⟨⟩ ∙ eliml A×A.π₁∘⟨⟩) (A×A.π₂∘⟨⟩ ∙ eliml A×A.π₂∘⟨⟩)
+    (assoc _ _ _ ∙ Pb.square ∙ eliml A×A.π₂∘⟨⟩)
+    (cancell A×A.π₂∘⟨⟩)
 ```
 
 # Effective congruences
@@ -304,8 +304,8 @@ module _ {a b} (f : Hom a b) where
   kernel-pair-is-monic : is-monic kernel-pair
   kernel-pair-is-monic g h p = Kp.unique₂ {p = extendl Kp.square}
     refl refl
-    (sym (pulll a×a.π₁∘factor) ∙ ap₂ _∘_ refl (sym p) ∙ pulll a×a.π₁∘factor)
-    (sym (pulll a×a.π₂∘factor) ∙ ap₂ _∘_ refl (sym p) ∙ pulll a×a.π₂∘factor)
+    (sym (pulll a×a.π₁∘⟨⟩) ∙ ap₂ _∘_ refl (sym p) ∙ pulll a×a.π₁∘⟨⟩)
+    (sym (pulll a×a.π₂∘⟨⟩) ∙ ap₂ _∘_ refl (sym p) ∙ pulll a×a.π₂∘⟨⟩)
 ```
 
 We build the congruence in parts.
@@ -324,8 +324,8 @@ diagrammatically, that $f(x) = f(x)$.
 
 ```agda
     cg .has-refl = Kp.universal {p₁' = id} {p₂' = id} refl
-    cg .refl-p₁ = ap (_∘ Kp.universal refl) a×a.π₁∘factor ∙ Kp.p₁∘universal
-    cg .refl-p₂ = ap (_∘ Kp.universal refl) a×a.π₂∘factor ∙ Kp.p₂∘universal
+    cg .refl-p₁ = ap (_∘ Kp.universal refl) a×a.π₁∘⟨⟩ ∙ Kp.p₁∘universal
+    cg .refl-p₂ = ap (_∘ Kp.universal refl) a×a.π₂∘⟨⟩ ∙ Kp.p₂∘universal
 ```
 
 Symmetry is witnessed by the map $(A \times_B A) \to (A \times_B A)$
@@ -333,10 +333,10 @@ which swaps the components. This one's pretty simple.
 
 ```agda
     cg .has-sym = Kp.universal {p₁' = Kp.p₂} {p₂' = Kp.p₁} (sym Kp.square)
-    cg .sym-p₁ = ap (_∘ Kp.universal (sym Kp.square)) a×a.π₁∘factor
-               ∙ sym (a×a.π₂∘factor ∙ sym Kp.p₁∘universal)
-    cg .sym-p₂ = ap (_∘ Kp.universal (sym Kp.square)) a×a.π₂∘factor
-               ∙ sym (a×a.π₁∘factor ∙ sym Kp.p₂∘universal)
+    cg .sym-p₁ = ap (_∘ Kp.universal (sym Kp.square)) a×a.π₁∘⟨⟩
+               ∙ sym (a×a.π₂∘⟨⟩ ∙ sym Kp.p₁∘universal)
+    cg .sym-p₂ = ap (_∘ Kp.universal (sym Kp.square)) a×a.π₂∘⟨⟩
+               ∙ sym (a×a.π₁∘⟨⟩ ∙ sym Kp.p₂∘universal)
 ```
 
 <details>
@@ -350,9 +350,9 @@ Understanding the transitivity map is left as an exercise to the reader.
       where abstract
         path : f ∘ Kp.p₁ ∘ rel.p₂ ≡ f ∘ Kp.p₂ ∘ rel.p₁
         path =
-          f ∘ Kp.p₁ ∘ rel.p₂                  ≡⟨ extendl (Kp.square ∙ ap (f ∘_) (sym a×a.π₂∘factor)) ⟩
+          f ∘ Kp.p₁ ∘ rel.p₂                  ≡⟨ extendl (Kp.square ∙ ap (f ∘_) (sym a×a.π₂∘⟨⟩)) ⟩
           f ∘ (a×a.π₂ ∘ kernel-pair) ∘ rel.p₂ ≡⟨ ap (f ∘_) (sym rel.square) ⟩
-          f ∘ (a×a.π₁ ∘ kernel-pair) ∘ rel.p₁ ≡⟨ extendl (ap (f ∘_) a×a.π₁∘factor ∙ Kp.square) ⟩
+          f ∘ (a×a.π₁ ∘ kernel-pair) ∘ rel.p₁ ≡⟨ extendl (ap (f ∘_) a×a.π₁∘⟨⟩ ∙ Kp.square) ⟩
           f ∘ Kp.p₂ ∘ rel.p₁                  ∎
 
     cg .trans-factors =
@@ -360,8 +360,8 @@ Understanding the transitivity map is left as an exercise to the reader.
         kernel-pair ∘ Kp.universal _
       ≡⟨ a×a.⟨⟩∘ _ ⟩
         a×a.⟨ Kp.p₁ ∘ Kp.universal _ , Kp.p₂ ∘ Kp.universal _ ⟩
-      ≡⟨ ap₂ a×a.⟨_,_⟩ (Kp.p₁∘universal ∙ ap₂ _∘_ (sym a×a.π₁∘factor) refl)
-                       (Kp.p₂∘universal ∙ ap₂ _∘_ (sym a×a.π₂∘factor) refl) ⟩
+      ≡⟨ ap₂ a×a.⟨_,_⟩ (Kp.p₁∘universal ∙ ap₂ _∘_ (sym a×a.π₁∘⟨⟩) refl)
+                       (Kp.p₂∘universal ∙ ap₂ _∘_ (sym a×a.π₂∘⟨⟩) refl) ⟩
         a×a.⟨ (a×a.π₁ ∘ kernel-pair) ∘ rel.p₂ , (a×a.π₂ ∘ kernel-pair) ∘ rel.p₁ ⟩
       ∎)
 
@@ -456,8 +456,8 @@ kernel-pair-is-effective {a = a} {b} {f} quot = epi where
   epi .has-quotient = quot
   epi .has-kernel-pair =
     transport
-      (λ i → is-pullback C (a×a.π₁∘factor {p1 = pb.p₁} {p2 = pb.p₂} (~ i)) f
-                           (a×a.π₂∘factor {p1 = pb.p₁} {p2 = pb.p₂} (~ i)) f)
+      (λ i → is-pullback C (a×a.π₁∘⟨⟩ {p1 = pb.p₁} {p2 = pb.p₂} (~ i)) f
+                           (a×a.π₂∘⟨⟩ {p1 = pb.p₁} {p2 = pb.p₂} (~ i)) f)
       pb.has-is-pb
 
 kp-effective-congruence→effective-epi

--- a/src/Cat/Diagram/Coproduct.lagda.md
+++ b/src/Cat/Diagram/Coproduct.lagda.md
@@ -42,23 +42,23 @@ $Q$. This is best explained by a commutative diagram:
 ~~~
 
 ```agda
-record is-coproduct {A B P} (in₀ : Hom A P) (in₁ : Hom B P) : Type (o ⊔ h) where
+record is-coproduct {A B P} (ι₁ : Hom A P) (ι₂ : Hom B P) : Type (o ⊔ h) where
   field
-    [_,_]      : ∀ {Q} (inj0 : Hom A Q) (inj1 : Hom B Q) → Hom P Q
-    in₀∘factor : ∀ {Q} {inj0 : Hom A Q} {inj1} → [ inj0 , inj1 ] ∘ in₀ ≡ inj0
-    in₁∘factor : ∀ {Q} {inj0 : Hom A Q} {inj1} → [ inj0 , inj1 ] ∘ in₁ ≡ inj1
+    [_,_] : ∀ {Q} (inj0 : Hom A Q) (inj1 : Hom B Q) → Hom P Q
+    []∘ι₁ : ∀ {Q} {inj0 : Hom A Q} {inj1} → [ inj0 , inj1 ] ∘ ι₁ ≡ inj0
+    []∘ι₂ : ∀ {Q} {inj0 : Hom A Q} {inj1} → [ inj0 , inj1 ] ∘ ι₂ ≡ inj1
 
     unique : ∀ {Q} {inj0 : Hom A Q} {inj1}
-           → (other : Hom P Q)
-           → other ∘ in₀ ≡ inj0
-           → other ∘ in₁ ≡ inj1
+           → {other : Hom P Q}
+           → other ∘ ι₁ ≡ inj0
+           → other ∘ ι₂ ≡ inj1
            → other ≡ [ inj0 , inj1 ]
 
   unique₂ : ∀ {Q} {inj0 : Hom A Q} {inj1}
-          → ∀ o1 (p1 : o1 ∘ in₀  ≡ inj0) (q1 : o1 ∘ in₁ ≡ inj1)
-          → ∀ o2 (p2 : o2 ∘ in₀  ≡ inj0) (q2 : o2 ∘ in₁ ≡ inj1)
+          → ∀ {o1} (p1 : o1 ∘ ι₁ ≡ inj0) (q1 : o1 ∘ ι₂ ≡ inj1)
+          → ∀ {o2} (p2 : o2 ∘ ι₁ ≡ inj0) (q2 : o2 ∘ ι₂ ≡ inj1)
           → o1 ≡ o2
-  unique₂ o1 p1 q1 o2 p2 q2 = unique o1 p1 q1 ∙ sym (unique o2 p2 q2)
+  unique₂ p1 q1 p2 q2 = unique p1 q1 ∙ sym (unique p2 q2)
 ```
 
 A coproduct of $A$ and $B$ is an explicit choice of coproduct diagram:
@@ -67,9 +67,9 @@ A coproduct of $A$ and $B$ is an explicit choice of coproduct diagram:
 record Coproduct (A B : Ob) : Type (o ⊔ h) where
   field
     coapex : Ob
-    in₀ : Hom A coapex
-    in₁ : Hom B coapex
-    has-is-coproduct : is-coproduct in₀ in₁
+    ι₁ : Hom A coapex
+    ι₂ : Hom B coapex
+    has-is-coproduct : is-coproduct ι₁ ι₂
 
   open is-coproduct has-is-coproduct public
 ```
@@ -94,26 +94,26 @@ module _ where
       module c2 = Coproduct c2
 
       c1→c2 : Hom (coapex c1) (coapex c2)
-      c1→c2 = c1.[ c2.in₀ , c2.in₁ ]
+      c1→c2 = c1.[ c2.ι₁ , c2.ι₂ ]
 
       c2→c1 : Hom (coapex c2) (coapex c1)
-      c2→c1 = c2.[ c1.in₀ , c1.in₁ ]
+      c2→c1 = c2.[ c1.ι₁ , c1.ι₂ ]
 ```
 
 ```agda
       c1→c2→c1 : c1→c2 ∘ c2→c1 ≡ id
       c1→c2→c1 =
-        c2.unique₂ _
-          (pullr c2.in₀∘factor ∙ c1.in₀∘factor)
-          (pullr c2.in₁∘factor ∙ c1.in₁∘factor)
-          id (idl _) (idl _)
+        c2.unique₂
+          (pullr c2.[]∘ι₁ ∙ c1.[]∘ι₁)
+          (pullr c2.[]∘ι₂ ∙ c1.[]∘ι₂)
+          (idl _) (idl _)
 
       c2→c1→c2 : c2→c1 ∘ c1→c2 ≡ id
       c2→c1→c2 =
-        c1.unique₂ _
-          (pullr c1.in₀∘factor ∙ c2.in₀∘factor)
-          (pullr c1.in₁∘factor ∙ c2.in₁∘factor)
-          id (idl _) (idl _)
+        c1.unique₂
+          (pullr c1.[]∘ι₁ ∙ c2.[]∘ι₁)
+          (pullr c1.[]∘ι₂ ∙ c2.[]∘ι₂)
+          (idl _) (idl _)
 ```
 
 # Categories with all binary coproducts
@@ -130,7 +130,7 @@ module Binary-coproducts (all-coproducts : has-coproducts) where
   module coproduct {a} {b} = Coproduct (all-coproducts a b)
 
   open coproduct renaming
-    (unique to []-unique; in₀∘factor to in₀∘[]; in₁∘factor to in₁∘[]) public
+    (unique to []-unique) public
   open Functor
 
   infixr 7 _⊕₀_
@@ -140,42 +140,40 @@ module Binary-coproducts (all-coproducts : has-coproducts) where
   a ⊕₀ b = coproduct.coapex {a} {b}
 
   _⊕₁_ : ∀ {a b x y} → Hom a x → Hom b y → Hom (a ⊕₀ b) (x ⊕₀ y)
-  f ⊕₁ g = [ in₀ ∘ f , in₁ ∘ g ]
+  f ⊕₁ g = [ ι₁ ∘ f , ι₂ ∘ g ]
 
   ⊕-functor : Functor (C ×ᶜ C) C
   ⊕-functor .F₀ (a , b) = a ⊕₀ b
   ⊕-functor .F₁ (f , g) = f ⊕₁ g
-  ⊕-functor .F-id = sym $ []-unique id id-comm-sym id-comm-sym
+  ⊕-functor .F-id = sym $ []-unique id-comm-sym id-comm-sym
   ⊕-functor .F-∘ (f , g) (h , i) =
-    sym $ []-unique (f ⊕₁ g ∘ h ⊕₁ i)
-      (pullr in₀∘[] ∙ extendl in₀∘[])
-      (pullr in₁∘[] ∙ extendl in₁∘[])
+    sym $ []-unique
+      (pullr []∘ι₁ ∙ extendl []∘ι₁)
+      (pullr []∘ι₂ ∙ extendl []∘ι₂)
 
   ∇ : ∀ {a} → Hom (a ⊕₀ a) a
   ∇ = [ id , id ]
 
   coswap : ∀ {a b} → Hom (a ⊕₀ b) (b ⊕₀ a)
-  coswap = [ in₁ , in₀ ]
+  coswap = [ ι₂ , ι₁ ]
 
   ⊕-assoc : ∀ {a b c} → Hom (a ⊕₀ (b ⊕₀ c)) ((a ⊕₀ b) ⊕₀ c)
-  ⊕-assoc = [ in₀ ∘ in₀ , [ in₀ ∘ in₁ , in₁ ] ]
+  ⊕-assoc = [ ι₁ ∘ ι₁ , [ ι₁ ∘ ι₂ , ι₂ ] ]
 
   ∇-coswap : ∀ {a} → ∇ ∘ coswap ≡ ∇ {a}
-  ∇-coswap = []-unique _ (pullr in₀∘[] ∙ in₁∘[]) (pullr in₁∘[] ∙ in₀∘[])
+  ∇-coswap = []-unique (pullr []∘ι₁ ∙ []∘ι₂) (pullr []∘ι₂ ∙ []∘ι₁)
 
   ∇-assoc : ∀ {a} → ∇ {a} ∘ (∇ {a} ⊕₁ id) ∘ ⊕-assoc ≡ ∇ ∘ (id ⊕₁ ∇)
   ∇-assoc = unique₂
-    _
-    (pullr (pullr in₀∘[]) ∙ (refl⟩∘⟨ pulll in₀∘[]) ∙ pulll (pulll in₀∘[]) ∙ pullr in₀∘[])
-    (pullr (pullr in₁∘[]) ∙ []-unique _
-      (pullr (pullr in₀∘[]) ∙ extend-inner in₀∘[] ∙ cancell in₀∘[] ∙ in₁∘[])
-      (pullr (pullr in₁∘[]) ∙ (refl⟩∘⟨ in₁∘[]) ∙ pulll in₁∘[] ∙ idl _))
-    _
-    (pullr in₀∘[] ∙ pulll in₀∘[])
-    (pullr in₁∘[] ∙ pulll in₁∘[] ∙ idl _)
+    (pullr (pullr []∘ι₁) ∙ (refl⟩∘⟨ pulll []∘ι₁) ∙ pulll (pulll []∘ι₁) ∙ pullr []∘ι₁)
+    (pullr (pullr []∘ι₂) ∙ []-unique
+      (pullr (pullr []∘ι₁) ∙ extend-inner []∘ι₁ ∙ cancell []∘ι₁ ∙ []∘ι₂)
+      (pullr (pullr []∘ι₂) ∙ (refl⟩∘⟨ []∘ι₂) ∙ pulll []∘ι₂ ∙ idl _))
+    (pullr []∘ι₁ ∙ pulll []∘ι₁)
+    (pullr []∘ι₂ ∙ pulll []∘ι₂ ∙ idl _)
 
   ∇-natural : is-natural-transformation (⊕-functor F∘ Cat⟨ Id , Id ⟩) Id λ _ → ∇
   ∇-natural x y f = unique₂
-    _ (pullr in₀∘[] ∙ cancell in₀∘[]) (pullr in₁∘[] ∙ cancell in₁∘[])
-    _ (cancelr in₀∘[]) (cancelr in₁∘[])
+    (pullr []∘ι₁ ∙ cancell []∘ι₁) (pullr []∘ι₂ ∙ cancell []∘ι₂)
+    (cancelr []∘ι₁) (cancelr []∘ι₂)
 ```

--- a/src/Cat/Diagram/Coproduct.lagda.md
+++ b/src/Cat/Diagram/Coproduct.lagda.md
@@ -159,6 +159,14 @@ module Binary-coproducts (all-coproducts : has-coproducts) where
 
   ⊕-assoc : ∀ {a b c} → Hom (a ⊕₀ (b ⊕₀ c)) ((a ⊕₀ b) ⊕₀ c)
   ⊕-assoc = [ ι₁ ∘ ι₁ , [ ι₁ ∘ ι₂ , ι₂ ] ]
+```
+
+<!--
+```agda
+  ∇-natural : is-natural-transformation (⊕-functor F∘ Cat⟨ Id , Id ⟩) Id λ _ → ∇
+  ∇-natural x y f = unique₂
+    (pullr []∘ι₁ ∙ cancell []∘ι₁) (pullr []∘ι₂ ∙ cancell []∘ι₂)
+    (cancelr []∘ι₁) (cancelr []∘ι₂)
 
   ∇-coswap : ∀ {a} → ∇ ∘ coswap ≡ ∇ {a}
   ∇-coswap = []-unique (pullr []∘ι₁ ∙ []∘ι₂) (pullr []∘ι₂ ∙ []∘ι₁)
@@ -168,12 +176,8 @@ module Binary-coproducts (all-coproducts : has-coproducts) where
     (pullr (pullr []∘ι₁) ∙ (refl⟩∘⟨ pulll []∘ι₁) ∙ pulll (pulll []∘ι₁) ∙ pullr []∘ι₁)
     (pullr (pullr []∘ι₂) ∙ []-unique
       (pullr (pullr []∘ι₁) ∙ extend-inner []∘ι₁ ∙ cancell []∘ι₁ ∙ []∘ι₂)
-      (pullr (pullr []∘ι₂) ∙ (refl⟩∘⟨ []∘ι₂) ∙ pulll []∘ι₂ ∙ idl _))
+      (pullr (pullr []∘ι₂) ∙ (refl⟩∘⟨ []∘ι₂) ∙ cancell []∘ι₂))
     (pullr []∘ι₁ ∙ pulll []∘ι₁)
-    (pullr []∘ι₂ ∙ pulll []∘ι₂ ∙ idl _)
-
-  ∇-natural : is-natural-transformation (⊕-functor F∘ Cat⟨ Id , Id ⟩) Id λ _ → ∇
-  ∇-natural x y f = unique₂
-    (pullr []∘ι₁ ∙ cancell []∘ι₁) (pullr []∘ι₂ ∙ cancell []∘ι₂)
-    (cancelr []∘ι₁) (cancelr []∘ι₂)
+    (pullr []∘ι₂ ∙ cancell []∘ι₂)
 ```
+-->

--- a/src/Cat/Diagram/Coproduct.lagda.md
+++ b/src/Cat/Diagram/Coproduct.lagda.md
@@ -1,5 +1,6 @@
 <!--
 ```agda
+open import Cat.Instances.Product
 open import Cat.Prelude
 ```
 -->
@@ -140,4 +141,41 @@ module Binary-coproducts (all-coproducts : has-coproducts) where
 
   _⊕₁_ : ∀ {a b x y} → Hom a x → Hom b y → Hom (a ⊕₀ b) (x ⊕₀ y)
   f ⊕₁ g = [ in₀ ∘ f , in₁ ∘ g ]
+
+  ⊕-functor : Functor (C ×ᶜ C) C
+  ⊕-functor .F₀ (a , b) = a ⊕₀ b
+  ⊕-functor .F₁ (f , g) = f ⊕₁ g
+  ⊕-functor .F-id = sym $ []-unique id id-comm-sym id-comm-sym
+  ⊕-functor .F-∘ (f , g) (h , i) =
+    sym $ []-unique (f ⊕₁ g ∘ h ⊕₁ i)
+      (pullr in₀∘[] ∙ extendl in₀∘[])
+      (pullr in₁∘[] ∙ extendl in₁∘[])
+
+  ∇ : ∀ {a} → Hom (a ⊕₀ a) a
+  ∇ = [ id , id ]
+
+  coswap : ∀ {a b} → Hom (a ⊕₀ b) (b ⊕₀ a)
+  coswap = [ in₁ , in₀ ]
+
+  ⊕-assoc : ∀ {a b c} → Hom (a ⊕₀ (b ⊕₀ c)) ((a ⊕₀ b) ⊕₀ c)
+  ⊕-assoc = [ in₀ ∘ in₀ , [ in₀ ∘ in₁ , in₁ ] ]
+
+  ∇-coswap : ∀ {a} → ∇ ∘ coswap ≡ ∇ {a}
+  ∇-coswap = []-unique _ (pullr in₀∘[] ∙ in₁∘[]) (pullr in₁∘[] ∙ in₀∘[])
+
+  ∇-assoc : ∀ {a} → ∇ {a} ∘ (∇ {a} ⊕₁ id) ∘ ⊕-assoc ≡ ∇ ∘ (id ⊕₁ ∇)
+  ∇-assoc = unique₂
+    _
+    (pullr (pullr in₀∘[]) ∙ (refl⟩∘⟨ pulll in₀∘[]) ∙ pulll (pulll in₀∘[]) ∙ pullr in₀∘[])
+    (pullr (pullr in₁∘[]) ∙ []-unique _
+      (pullr (pullr in₀∘[]) ∙ extend-inner in₀∘[] ∙ cancell in₀∘[] ∙ in₁∘[])
+      (pullr (pullr in₁∘[]) ∙ (refl⟩∘⟨ in₁∘[]) ∙ pulll in₁∘[] ∙ idl _))
+    _
+    (pullr in₀∘[] ∙ pulll in₀∘[])
+    (pullr in₁∘[] ∙ pulll in₁∘[] ∙ idl _)
+
+  ∇-natural : is-natural-transformation (⊕-functor F∘ Cat⟨ Id , Id ⟩) Id λ _ → ∇
+  ∇-natural x y f = unique₂
+    _ (pullr in₀∘[] ∙ cancell in₀∘[]) (pullr in₁∘[] ∙ cancell in₁∘[])
+    _ (cancelr in₀∘[]) (cancelr in₁∘[])
 ```

--- a/src/Cat/Diagram/Duals.lagda.md
+++ b/src/Cat/Diagram/Duals.lagda.md
@@ -52,8 +52,8 @@ $C\op$. We prove these correspondences here:
   is-co-product→is-coproduct isp =
     record
       { [_,_]      = isp.⟨_,_⟩
-      ; in₀∘factor = isp.π₁∘factor
-      ; in₁∘factor = isp.π₂∘factor
+      ; []∘ι₁ = isp.π₁∘⟨⟩
+      ; []∘ι₂ = isp.π₂∘⟨⟩
       ; unique     = isp.unique
       }
     where module isp = is-product isp
@@ -64,8 +64,8 @@ $C\op$. We prove these correspondences here:
   is-coproduct→is-co-product iscop =
     record
       { ⟨_,_⟩     = iscop.[_,_]
-      ; π₁∘factor = iscop.in₀∘factor
-      ; π₂∘factor = iscop.in₁∘factor
+      ; π₁∘⟨⟩ = iscop.[]∘ι₁
+      ; π₂∘⟨⟩ = iscop.[]∘ι₂
       ; unique    = iscop.unique
       }
     where module iscop = is-coproduct iscop
@@ -132,8 +132,8 @@ $C\op$. We prove these correspondences here:
     record
       { square = pb.square
       ; universal = pb.universal
-      ; i₁∘universal = pb.p₁∘universal
-      ; i₂∘universal = pb.p₂∘universal
+      ; universal∘i₁ = pb.p₁∘universal
+      ; universal∘i₂ = pb.p₂∘universal
       ; unique = pb.unique
       }
     where module pb = is-pullback pb
@@ -145,8 +145,8 @@ $C\op$. We prove these correspondences here:
     record
       { square      = po.square
       ; universal    = po.universal
-      ; p₁∘universal = po.i₁∘universal
-      ; p₂∘universal = po.i₂∘universal
+      ; p₁∘universal = po.universal∘i₁
+      ; p₂∘universal = po.universal∘i₂
       ; unique      = po.unique
       }
     where module po = is-pushout po

--- a/src/Cat/Diagram/Equaliser/RegularMono.lagda.md
+++ b/src/Cat/Diagram/Equaliser/RegularMono.lagda.md
@@ -154,9 +154,9 @@ universal map $E \to a$ which commutes with "everything in sight":
       eq .universal {F = F} {e' = e'} p = reg.universal p' where
         p' : reg.arr₁ ∘ e' ≡ reg.arr₂ ∘ e'
         p' =
-          reg.arr₁ ∘ e'       ≡˘⟨ ap (_∘ e') f⊔f.i₁∘universal ⟩
+          reg.arr₁ ∘ e'       ≡˘⟨ ap (_∘ e') f⊔f.universal∘i₁ ⟩
           (phi ∘ f⊔f.i₁) ∘ e' ≡⟨ extendr p ⟩
-          (phi ∘ f⊔f.i₂) ∘ e' ≡⟨ ap (_∘ e') f⊔f.i₂∘universal ⟩
+          (phi ∘ f⊔f.i₂) ∘ e' ≡⟨ ap (_∘ e') f⊔f.universal∘i₂ ⟩
           reg.arr₂ ∘ e'       ∎
       eq .factors = reg.factors
       eq .unique = reg.unique

--- a/src/Cat/Diagram/Exponential.lagda.md
+++ b/src/Cat/Diagram/Exponential.lagda.md
@@ -248,7 +248,7 @@ characterise $-^A$ as the [[right adjoint]] to $- \times A$.
     ev ∘ ƛ (g ∘ ev ∘ ⟨ π₁ , f ∘ π₂ ⟩) ⊗₁ id ∘ ƛ (g' ∘ ev ∘ ⟨ π₁ , f' ∘ π₂ ⟩) ⊗₁ id          ≡⟨ pulll (commutes _) ⟩
     (g ∘ ev ∘ ⟨ π₁ , f ∘ π₂ ⟩) ∘ ƛ (g' ∘ ev ∘ ⟨ π₁ , f' ∘ π₂ ⟩) ⊗₁ id                       ≡⟨ pullr (pullr (ap₂ _∘_ (ap₂ ⟨_,_⟩ (introl refl) refl) refl ∙ sym (Bifunctor.first∘second ×-functor))) ⟩
     g ∘ ev ∘ ƛ (g' ∘ ev ∘ ⟨ π₁ , f' ∘ π₂ ⟩) ⊗₁ id ∘ id ⊗₁ f                                 ≡⟨ refl⟩∘⟨ pulll (commutes _) ⟩
-    g ∘ (g' ∘ ev ∘ ⟨ π₁ , f' ∘ π₂ ⟩) ∘ id ⊗₁ f                                              ≡⟨ pulll refl ∙ extendr (pullr (pullr (Product.unique (fp _ _) _ (pulll π₁∘⟨⟩ ·· π₁∘⟨⟩ ·· idl _) (pulll π₂∘⟨⟩ ∙ extendr π₂∘⟨⟩)))) ⟩
+    g ∘ (g' ∘ ev ∘ ⟨ π₁ , f' ∘ π₂ ⟩) ∘ id ⊗₁ f                                              ≡⟨ pulll refl ∙ extendr (pullr (pullr (Product.unique (fp _ _) (pulll π₁∘⟨⟩ ·· π₁∘⟨⟩ ·· idl _) (pulll π₂∘⟨⟩ ∙ extendr π₂∘⟨⟩)))) ⟩
     (g ∘ g') ∘ ev ∘ ⟨ π₁ , (f' ∘ f) ∘ π₂ ⟩                                                  ∎
 
   product⊣exponential : ∀ {A} → Bifunctor.Left ×-functor A ⊣ Bifunctor.Right [-,-] A

--- a/src/Cat/Diagram/Limit/Finite.lagda.md
+++ b/src/Cat/Diagram/Limit/Finite.lagda.md
@@ -193,15 +193,15 @@ equalisers to factor _that_ as a unique arrow $P' \to X \times_Z Y$.
 ```agda
     pb .universal {p₁' = p₁'} {p₂' = p₂'} p =
       eq.universal {e' = pr.⟨ p₁' , p₂' ⟩} (
-        (f ∘ p1) ∘ pr.⟨ p₁' , p₂' ⟩ ≡⟨ pullr pr.π₁∘factor ⟩
+        (f ∘ p1) ∘ pr.⟨ p₁' , p₂' ⟩ ≡⟨ pullr pr.π₁∘⟨⟩ ⟩
         f ∘ p₁'                     ≡⟨ p ⟩
-        g ∘ p₂'                     ≡˘⟨ pullr pr.π₂∘factor ⟩
+        g ∘ p₂'                     ≡˘⟨ pullr pr.π₂∘⟨⟩ ⟩
         (g ∘ p2) ∘ pr.⟨ p₁' , p₂' ⟩ ∎
       )
-    pb .p₁∘universal = pullr eq.factors ∙ pr.π₁∘factor
-    pb .p₂∘universal = pullr eq.factors ∙ pr.π₂∘factor
+    pb .p₁∘universal = pullr eq.factors ∙ pr.π₁∘⟨⟩
+    pb .p₂∘universal = pullr eq.factors ∙ pr.π₂∘⟨⟩
     pb .unique p q =
-      eq.unique ((pr.unique _ (assoc _ _ _ ∙ p) (assoc _ _ _ ∙ q)))
+      eq.unique (pr.unique (assoc _ _ _ ∙ p) (assoc _ _ _ ∙ q))
 ```
 
 Hence, assuming that a category has a terminal object, binary products
@@ -280,9 +280,9 @@ object $*$.
     prod : is-product C p1 p2
     prod .is-product.⟨_,_⟩ p1' p2' =
       Pb.universal {p₁' = p1'} {p₂' = p2'} (is-contr→is-prop (term _) _ _)
-    prod .is-product.π₁∘factor = Pb.p₁∘universal
-    prod .is-product.π₂∘factor = Pb.p₂∘universal
-    prod .is-product.unique other p q = Pb.unique p q
+    prod .is-product.π₁∘⟨⟩ = Pb.p₁∘universal
+    prod .is-product.π₂∘⟨⟩ = Pb.p₂∘universal
+    prod .is-product.unique p q = Pb.unique p q
 
   with-pullbacks
     : Terminal C
@@ -351,11 +351,11 @@ conclude that $f \circ \rm{equ} = g \circ \rm{equ}$.
       eq .apex = Pb.apex
       eq .equ = Pb.p₂
       eq .has-is-eq .equal =
-        f ∘ Pb.p₂               ≡˘⟨ pulll Bb.π₁∘factor ⟩
+        f ∘ Pb.p₂               ≡˘⟨ pulll Bb.π₁∘⟨⟩ ⟩
         Bb.π₁ ∘ ⟨f,g⟩ ∘ Pb.p₂   ≡⟨ ap (Bb.π₁ ∘_) (sym Pb.square) ⟩
-        Bb.π₁ ∘ ⟨id,id⟩ ∘ Pb.p₁ ≡⟨ pulll Bb.π₁∘factor ∙ sym (pulll Bb.π₂∘factor) ⟩
+        Bb.π₁ ∘ ⟨id,id⟩ ∘ Pb.p₁ ≡⟨ pulll Bb.π₁∘⟨⟩ ∙ sym (pulll Bb.π₂∘⟨⟩) ⟩
         Bb.π₂ ∘ ⟨id,id⟩ ∘ Pb.p₁ ≡⟨ ap (Bb.π₂ ∘_) Pb.square ⟩
-        Bb.π₂ ∘ ⟨f,g⟩ ∘ Pb.p₂   ≡⟨ pulll Bb.π₂∘factor ⟩
+        Bb.π₂ ∘ ⟨f,g⟩ ∘ Pb.p₂   ≡⟨ pulll Bb.π₂∘⟨⟩ ⟩
         g ∘ Pb.p₂               ∎
 ```
 
@@ -391,15 +391,15 @@ is indeed the equaliser of $f$ and $g$.
         where
           p1 : Bb.π₁ ∘ ⟨id,id⟩ ∘ f ∘ e' ≡ Bb.π₁ ∘ ⟨f,g⟩ ∘ e'
           p1 =
-            Bb.π₁ ∘ ⟨id,id⟩ ∘ f ∘ e'   ≡⟨ cancell Bb.π₁∘factor ⟩
-            f ∘ e'                     ≡˘⟨ pulll Bb.π₁∘factor ⟩
+            Bb.π₁ ∘ ⟨id,id⟩ ∘ f ∘ e'   ≡⟨ cancell Bb.π₁∘⟨⟩ ⟩
+            f ∘ e'                     ≡˘⟨ pulll Bb.π₁∘⟨⟩ ⟩
             Bb.π₁ ∘ ⟨f,g⟩ ∘ e'         ∎
 
           p2 : Bb.π₂ ∘ ⟨id,id⟩ ∘ f ∘ e' ≡ Bb.π₂ ∘ ⟨f,g⟩ ∘ e'
           p2 =
-            Bb.π₂ ∘ ⟨id,id⟩ ∘ f ∘ e'   ≡⟨ cancell Bb.π₂∘factor ⟩
+            Bb.π₂ ∘ ⟨id,id⟩ ∘ f ∘ e'   ≡⟨ cancell Bb.π₂∘⟨⟩ ⟩
             f ∘ e'                     ≡⟨ p ⟩
-            g ∘ e'                     ≡˘⟨ pulll Bb.π₂∘factor ⟩
+            g ∘ e'                     ≡˘⟨ pulll Bb.π₂∘⟨⟩ ⟩
             Bb.π₂ ∘ ⟨f,g⟩ ∘ e'         ∎
 
       eq .has-is-eq .factors = Pb.p₂∘universal
@@ -408,10 +408,10 @@ is indeed the equaliser of $f$ and $g$.
         where
           path : Pb.p₁ ∘ other ≡ f ∘ e'
           path =
-            Pb.p₁ ∘ other                   ≡⟨ insertl Bb.π₁∘factor ⟩
+            Pb.p₁ ∘ other                   ≡⟨ insertl Bb.π₁∘⟨⟩ ⟩
             Bb.π₁ ∘ ⟨id,id⟩ ∘ Pb.p₁ ∘ other ≡⟨ ap (Bb.π₁ ∘_) (extendl Pb.square) ⟩
             Bb.π₁ ∘ ⟨f,g⟩ ∘ Pb.p₂ ∘ other   ≡⟨ ap (Bb.π₁ ∘_) (ap (⟨f,g⟩ ∘_) p₂∘l=e') ⟩
-            Bb.π₁ ∘ ⟨f,g⟩ ∘ e'              ≡⟨ pulll Bb.π₁∘factor ⟩
+            Bb.π₁ ∘ ⟨f,g⟩ ∘ e'              ≡⟨ pulll Bb.π₁∘⟨⟩ ⟩
             f ∘ e'                          ∎
 ```
 
@@ -435,9 +435,9 @@ Putting it all together into a record we get our proof of finite completeness:
     pb : is-pullback C _ _ _ _
     pb .square = is-contr→is-prop (t _) _ _
     pb .universal _ = r .is-product.⟨_,_⟩ _ _
-    pb .p₁∘universal = r .is-product.π₁∘factor
-    pb .p₂∘universal = r .is-product.π₂∘factor
-    pb .unique p q = r .is-product.unique _ p q
+    pb .p₁∘universal = r .is-product.π₁∘⟨⟩
+    pb .p₂∘universal = r .is-product.π₂∘⟨⟩
+    pb .unique p q = r .is-product.unique p q
 
   is-complete→finitely
     : ∀ {a b} → is-complete a b C → Finitely-complete

--- a/src/Cat/Diagram/Limit/Product.lagda.md
+++ b/src/Cat/Diagram/Limit/Product.lagda.md
@@ -61,9 +61,9 @@ is-product→is-limit {x = x} {F} {eps} is-prod =
     ml .ψ j = eps .η j
     ml .commutes f = sym (eps .is-natural _ _ _) ∙ idr _
     ml .universal eps _ = is-prod.⟨ eps true , eps false ⟩
-    ml .factors {true} eps _ = is-prod.π₁∘factor
-    ml .factors {false} eps _ = is-prod.π₂∘factor
-    ml .unique eps p other q = is-prod.unique other (q true) (q false)
+    ml .factors {true} eps _ = is-prod.π₁∘⟨⟩
+    ml .factors {false} eps _ = is-prod.π₂∘⟨⟩
+    ml .unique eps p other q = is-prod.unique (q true) (q false)
 
 is-limit→is-product
   : ∀ {a b} {K : Functor ⊤Cat C}
@@ -93,9 +93,9 @@ is-limit→is-product {a} {b} {K} {eps} lim = prod where
 
   prod : is-product C (eps .η true) (eps .η false)
   prod .⟨_,_⟩ f g = lim.universal (pair f g) pair-commutes
-  prod .π₁∘factor {_} {p1'} {p2'} = lim.factors (pair p1' p2') pair-commutes
-  prod .π₂∘factor {_} {p1'} {p2'} = lim.factors (pair p1' p2') pair-commutes
-  prod .unique other p q = lim.unique _ _ other λ where
+  prod .π₁∘⟨⟩ {_} {p1'} {p2'} = lim.factors (pair p1' p2') pair-commutes
+  prod .π₂∘⟨⟩ {_} {p1'} {p2'} = lim.factors (pair p1' p2') pair-commutes
+  prod .unique {other = other} p q = lim.unique _ _ other λ where
     true → p
     false → q
 

--- a/src/Cat/Diagram/Product.lagda.md
+++ b/src/Cat/Diagram/Product.lagda.md
@@ -291,10 +291,40 @@ We also define a handful of common morphisms.
 
 <!--
 ```agda
+  δ-natural : is-natural-transformation Id (×-functor F∘ Cat⟨ Id , Id ⟩) λ _ → δ
+  δ-natural x y f = unique₂
+    (cancell π₁∘⟨⟩) (cancell π₂∘⟨⟩)
+    (pulll π₁∘⟨⟩ ∙ cancelr π₁∘⟨⟩) (pulll π₂∘⟨⟩ ∙ cancelr π₂∘⟨⟩)
+
   swap-is-iso : ∀ {a b} → is-invertible (swap {a} {b})
   swap-is-iso = make-invertible swap
     (unique₂ (pulll π₁∘⟨⟩ ∙ π₂∘⟨⟩) ((pulll π₂∘⟨⟩ ∙ π₁∘⟨⟩)) (idr _) (idr _))
     (unique₂ (pulll π₁∘⟨⟩ ∙ π₂∘⟨⟩) ((pulll π₂∘⟨⟩ ∙ π₁∘⟨⟩)) (idr _) (idr _))
+
+  swap-natural
+    : ∀ {A B C D} ((f , g) : Hom A C × Hom B D)
+    → (g ⊗₁ f) ∘ swap ≡ swap ∘ (f ⊗₁ g)
+  swap-natural (f , g) =
+    (g ⊗₁ f) ∘ swap                       ≡⟨ ⟨⟩∘ _ ⟩
+    ⟨ (g ∘ π₁) ∘ swap , (f ∘ π₂) ∘ swap ⟩ ≡⟨ ap₂ ⟨_,_⟩ (pullr π₁∘⟨⟩) (pullr π₂∘⟨⟩) ⟩
+    ⟨ g ∘ π₂ , f ∘ π₁ ⟩                   ≡˘⟨ ap₂ ⟨_,_⟩ π₂∘⟨⟩ π₁∘⟨⟩ ⟩
+    ⟨ π₂ ∘ (f ⊗₁ g) , π₁ ∘ (f ⊗₁ g) ⟩     ≡˘⟨ ⟨⟩∘ _ ⟩
+    swap ∘ (f ⊗₁ g)                       ∎
+
+  swap-δ : ∀ {A} → swap ∘ δ ≡ δ {A}
+  swap-δ = ⟨⟩-unique (pulll π₁∘⟨⟩ ∙ π₂∘⟨⟩) (pulll π₂∘⟨⟩ ∙ π₁∘⟨⟩)
+
+  assoc-δ : ∀ {a} → ×-assoc ∘ (id ⊗₁ δ {a}) ∘ δ {a} ≡ (δ ⊗₁ id) ∘ δ
+  assoc-δ = unique₂
+    (pulll π₁∘⟨⟩ ∙ unique₂
+      (pulll π₁∘⟨⟩ ∙ pulll π₁∘⟨⟩ ∙ pullr π₁∘⟨⟩)
+      (pulll π₂∘⟨⟩ ∙ pullr (pulll π₂∘⟨⟩) ∙ pulll (pulll π₁∘⟨⟩) ∙ pullr π₂∘⟨⟩)
+      (pulll (pulll π₁∘⟨⟩) ∙ pullr π₁∘⟨⟩)
+      (pulll (pulll π₂∘⟨⟩) ∙ pullr π₁∘⟨⟩)
+    ∙ pushl (sym π₁∘⟨⟩))
+    (pulll π₂∘⟨⟩ ∙ pullr (pulll π₂∘⟨⟩) ∙ pulll (pulll π₂∘⟨⟩) ∙ pullr π₂∘⟨⟩)
+    refl
+    (pulll π₂∘⟨⟩ ∙ pullr π₂∘⟨⟩)
 
   by-π₁ : ∀ {f f' : Hom a b} {g g' : Hom a c} → ⟨ f , g ⟩ ≡ ⟨ f' , g' ⟩ → f ≡ f'
   by-π₁ p = sym π₁∘⟨⟩ ∙ ap (π₁ ∘_) p ∙ π₁∘⟨⟩
@@ -321,33 +351,10 @@ We also define a handful of common morphisms.
     → g ∘ is-invertible.inv ⟨⟩-inv ≡ π₂
   π₂-inv {f = f} {g = g} ⟨⟩-inv =
     pushl (sym π₂∘⟨⟩) ∙ elimr (is-invertible.invl ⟨⟩-inv)
-
-  swap-natural
-    : ∀ {A B C D} ((f , g) : Hom A C × Hom B D)
-    → (g ⊗₁ f) ∘ swap ≡ swap ∘ (f ⊗₁ g)
-  swap-natural (f , g) =
-    (g ⊗₁ f) ∘ swap                       ≡⟨ ⟨⟩∘ _ ⟩
-    ⟨ (g ∘ π₁) ∘ swap , (f ∘ π₂) ∘ swap ⟩ ≡⟨ ap₂ ⟨_,_⟩ (pullr π₁∘⟨⟩) (pullr π₂∘⟨⟩) ⟩
-    ⟨ g ∘ π₂ , f ∘ π₁ ⟩                   ≡˘⟨ ap₂ ⟨_,_⟩ π₂∘⟨⟩ π₁∘⟨⟩ ⟩
-    ⟨ π₂ ∘ (f ⊗₁ g) , π₁ ∘ (f ⊗₁ g) ⟩     ≡˘⟨ ⟨⟩∘ _ ⟩
-    swap ∘ (f ⊗₁ g)                       ∎
-
-  swap-δ : ∀ {A} → swap ∘ δ ≡ δ {A}
-  swap-δ = ⟨⟩-unique (pulll π₁∘⟨⟩ ∙ π₂∘⟨⟩) (pulll π₂∘⟨⟩ ∙ π₁∘⟨⟩)
-
-  assoc-δ : ∀ {a} → ×-assoc ∘ (id ⊗₁ δ {a}) ∘ δ {a} ≡ (δ ⊗₁ id) ∘ δ
-  assoc-δ = unique₂
-    (pulll π₁∘⟨⟩ ∙ unique₂
-      (pulll π₁∘⟨⟩ ∙ pulll π₁∘⟨⟩ ∙ pullr π₁∘⟨⟩)
-      (pulll π₂∘⟨⟩ ∙ pullr (pulll π₂∘⟨⟩) ∙ pulll (pulll π₁∘⟨⟩) ∙ pullr π₂∘⟨⟩)
-      (pulll (pulll π₁∘⟨⟩) ∙ pullr π₁∘⟨⟩)
-      (pulll (pulll π₂∘⟨⟩) ∙ pullr π₁∘⟨⟩)
-    ∙ pushl (sym π₁∘⟨⟩))
-    (pulll π₂∘⟨⟩ ∙ pullr (pulll π₂∘⟨⟩) ∙ pulll (pulll π₂∘⟨⟩) ∙ pullr π₂∘⟨⟩)
-    refl
-    (pulll π₂∘⟨⟩ ∙ pullr π₂∘⟨⟩)
 ```
 -->
+
+# Representability of products
 
 <!--
 ```agda
@@ -355,8 +362,6 @@ module _ {o ℓ} {C : Precategory o ℓ} where
   open Cat.Reasoning C
 ```
 -->
-
-## Representability of products
 
 The collection of maps into a product $a \times b$ is equivalent to
 the collection of pairs of maps into $a$ and $b$. The forward direction

--- a/src/Cat/Diagram/Product.lagda.md
+++ b/src/Cat/Diagram/Product.lagda.md
@@ -203,6 +203,26 @@ the projections.
     prod' .unique other p q = prod .unique other
       (sym (ap (_ ∘_) (sym p) ∙ pulll (cancell fi.invr)))
       (sym (ap (_ ∘_) (sym q) ∙ pulll (cancell gi.invr)))
+
+  is-product-iso-apex
+    : ∀ {A B P P'} {π₁ : Hom P A} {π₂ : Hom P B}
+        {π₁' : Hom P' A} {π₂' : Hom P' B}
+        {f : Hom P' P}
+    → is-invertible f
+    → π₁ ∘ f ≡ π₁'
+    → π₂ ∘ f ≡ π₂'
+    → is-product C π₁ π₂
+    → is-product C π₁' π₂'
+  is-product-iso-apex {f = f} f-iso f-π₁ f-π₂ prod = prod' where
+    module fi = is-invertible f-iso
+
+    open is-product
+    prod' : is-product _ _ _
+    prod' .⟨_,_⟩ qa qb = fi.inv ∘ prod .⟨_,_⟩ qa qb
+    prod' .π₁∘factor = pulll (rswizzle (sym f-π₁) fi.invl) ∙ prod .π₁∘factor
+    prod' .π₂∘factor = pulll (rswizzle (sym f-π₂) fi.invl) ∙ prod .π₂∘factor
+    prod' .unique other p q = sym $ lswizzle
+      (sym (prod .unique (f ∘ other) (pulll f-π₁ ∙ p) (pulll f-π₂ ∙ q))) fi.invr
 ```
 
 # Categories with all binary products
@@ -265,6 +285,9 @@ We also define a handful of common morphisms.
 
   swap : Hom (a ⊗₀ b) (b ⊗₀ a)
   swap = ⟨ π₂ , π₁ ⟩
+
+  ×-assoc : Hom (a ⊗₀ (b ⊗₀ c)) ((a ⊗₀ b) ⊗₀ c)
+  ×-assoc = ⟨ ⟨ π₁ , π₁ ∘ π₂ ⟩ , π₂ ∘ π₂ ⟩
 ```
 
 <!--
@@ -299,6 +322,31 @@ We also define a handful of common morphisms.
     → g ∘ is-invertible.inv ⟨⟩-inv ≡ π₂
   π₂-inv {f = f} {g = g} ⟨⟩-inv =
     pushl (sym π₂∘⟨⟩) ∙ elimr (is-invertible.invl ⟨⟩-inv)
+
+  swap-natural
+    : ∀ {A B C D} ((f , g) : Hom A C × Hom B D)
+    → (g ⊗₁ f) ∘ swap ≡ swap ∘ (f ⊗₁ g)
+  swap-natural (f , g) =
+    (g ⊗₁ f) ∘ swap                       ≡⟨ ⟨⟩∘ _ ⟩
+    ⟨ (g ∘ π₁) ∘ swap , (f ∘ π₂) ∘ swap ⟩ ≡⟨ ap₂ ⟨_,_⟩ (pullr π₁∘⟨⟩) (pullr π₂∘⟨⟩) ⟩
+    ⟨ g ∘ π₂ , f ∘ π₁ ⟩                   ≡˘⟨ ap₂ ⟨_,_⟩ π₂∘⟨⟩ π₁∘⟨⟩ ⟩
+    ⟨ π₂ ∘ (f ⊗₁ g) , π₁ ∘ (f ⊗₁ g) ⟩     ≡˘⟨ ⟨⟩∘ _ ⟩
+    swap ∘ (f ⊗₁ g)                       ∎
+
+  swap-δ : ∀ {A} → swap ∘ δ ≡ δ {A}
+  swap-δ = ⟨⟩-unique _ (pulll π₁∘⟨⟩ ∙ π₂∘⟨⟩) (pulll π₂∘⟨⟩ ∙ π₁∘⟨⟩)
+
+  assoc-δ : ∀ {a} → ×-assoc ∘ (id ⊗₁ δ {a}) ∘ δ {a} ≡ (δ ⊗₁ id) ∘ δ
+  assoc-δ = unique₂
+    (pulll π₁∘⟨⟩ ∙ unique₂
+      (pulll π₁∘⟨⟩ ∙ pulll π₁∘⟨⟩ ∙ pullr π₁∘⟨⟩)
+      (pulll π₂∘⟨⟩ ∙ pullr (pulll π₂∘⟨⟩) ∙ pulll (pulll π₁∘⟨⟩) ∙ pullr π₂∘⟨⟩)
+      (pulll (pulll π₁∘⟨⟩) ∙ pullr π₁∘⟨⟩)
+      (pulll (pulll π₂∘⟨⟩) ∙ pullr π₁∘⟨⟩)
+    ∙ pushl (sym π₁∘⟨⟩))
+    (pulll π₂∘⟨⟩ ∙ pullr (pulll π₂∘⟨⟩) ∙ pulll (pulll π₂∘⟨⟩) ∙ pullr π₂∘⟨⟩)
+    refl
+    (pulll π₂∘⟨⟩ ∙ pullr π₂∘⟨⟩)
 ```
 -->
 

--- a/src/Cat/Diagram/Product.lagda.md
+++ b/src/Cat/Diagram/Product.lagda.md
@@ -64,12 +64,12 @@ the pairing $\langle f, g \rangle$ is a global element of the product $A
 ```agda
   record is-product {A B P} (π₁ : Hom P A) (π₂ : Hom P B) : Type (o ⊔ ℓ) where
     field
-      ⟨_,_⟩     : ∀ {Q} (p1 : Hom Q A) (p2 : Hom Q B) → Hom Q P
-      π₁∘factor : ∀ {Q} {p1 : Hom Q _} {p2} → π₁ ∘ ⟨ p1 , p2 ⟩ ≡ p1
-      π₂∘factor : ∀ {Q} {p1 : Hom Q _} {p2} → π₂ ∘ ⟨ p1 , p2 ⟩ ≡ p2
+      ⟨_,_⟩ : ∀ {Q} (p1 : Hom Q A) (p2 : Hom Q B) → Hom Q P
+      π₁∘⟨⟩ : ∀ {Q} {p1 : Hom Q _} {p2} → π₁ ∘ ⟨ p1 , p2 ⟩ ≡ p1
+      π₂∘⟨⟩ : ∀ {Q} {p1 : Hom Q _} {p2} → π₂ ∘ ⟨ p1 , p2 ⟩ ≡ p2
 
       unique : ∀ {Q} {p1 : Hom Q A} {p2}
-             → (other : Hom Q P)
+             → {other : Hom Q P}
              → π₁ ∘ other ≡ p1
              → π₂ ∘ other ≡ p2
              → other ≡ ⟨ p1 , p2 ⟩
@@ -78,14 +78,14 @@ the pairing $\langle f, g \rangle$ is a global element of the product $A
             → ∀ {o1} (p1 : π₁ ∘ o1 ≡ pr1) (q1 : π₂ ∘ o1 ≡ pr2)
             → ∀ {o2} (p2 : π₁ ∘ o2 ≡ pr1) (q2 : π₂ ∘ o2 ≡ pr2)
             → o1 ≡ o2
-    unique₂ p1 q1 p2 q2 = unique _ p1 q1 ∙ sym (unique _ p2 q2)
+    unique₂ p1 q1 p2 q2 = unique p1 q1 ∙ sym (unique p2 q2)
 
     ⟨⟩∘ : ∀ {Q R} {p1 : Hom Q A} {p2 : Hom Q B} (f : Hom R Q)
         → ⟨ p1 , p2 ⟩ ∘ f ≡ ⟨ p1 ∘ f , p2 ∘ f ⟩
-    ⟨⟩∘ f = unique _ (pulll π₁∘factor) (pulll π₂∘factor)
+    ⟨⟩∘ f = unique (pulll π₁∘⟨⟩) (pulll π₂∘⟨⟩)
 
     ⟨⟩-η : ⟨ π₁ , π₂ ⟩ ≡ id
-    ⟨⟩-η = sym $ unique id (idr _) (idr _)
+    ⟨⟩-η = sym $ unique (idr _) (idr _)
 ```
 
 A product of $A$ and $B$ is an explicit choice of product diagram:
@@ -173,15 +173,15 @@ the projections.
       p1→p2→p1 : p1→p2 ∘ p2→p1 ≡ id
       p1→p2→p1 =
         p2.unique₂
-          (assoc _ _ _ ·· ap (_∘ _) p2.π₁∘factor ·· p1.π₁∘factor)
-          (assoc _ _ _ ·· ap (_∘ _) p2.π₂∘factor ·· p1.π₂∘factor)
+          (assoc _ _ _ ·· ap (_∘ _) p2.π₁∘⟨⟩ ·· p1.π₁∘⟨⟩)
+          (assoc _ _ _ ·· ap (_∘ _) p2.π₂∘⟨⟩ ·· p1.π₂∘⟨⟩)
           (idr _) (idr _)
 
       p2→p1→p2 : p2→p1 ∘ p1→p2 ≡ id
       p2→p1→p2 =
         p1.unique₂
-          (assoc _ _ _ ·· ap (_∘ _) p1.π₁∘factor ·· p2.π₁∘factor)
-          (assoc _ _ _ ·· ap (_∘ _) p1.π₂∘factor ·· p2.π₂∘factor)
+          (assoc _ _ _ ·· ap (_∘ _) p1.π₁∘⟨⟩ ·· p2.π₁∘⟨⟩)
+          (assoc _ _ _ ·· ap (_∘ _) p1.π₂∘⟨⟩ ·· p2.π₂∘⟨⟩)
           (idr _) (idr _)
 
   is-product-iso
@@ -198,9 +198,9 @@ the projections.
     open is-product
     prod' : is-product _ _ _
     prod' .⟨_,_⟩ qa qb = prod .⟨_,_⟩ (fi.inv ∘ qa) (gi.inv ∘ qb)
-    prod' .π₁∘factor = pullr (prod .π₁∘factor) ∙ cancell fi.invl
-    prod' .π₂∘factor = pullr (prod .π₂∘factor) ∙ cancell gi.invl
-    prod' .unique other p q = prod .unique other
+    prod' .π₁∘⟨⟩ = pullr (prod .π₁∘⟨⟩) ∙ cancell fi.invl
+    prod' .π₂∘⟨⟩ = pullr (prod .π₂∘⟨⟩) ∙ cancell gi.invl
+    prod' .unique p q = prod .unique
       (sym (ap (_ ∘_) (sym p) ∙ pulll (cancell fi.invr)))
       (sym (ap (_ ∘_) (sym q) ∙ pulll (cancell gi.invr)))
 
@@ -219,10 +219,10 @@ the projections.
     open is-product
     prod' : is-product _ _ _
     prod' .⟨_,_⟩ qa qb = fi.inv ∘ prod .⟨_,_⟩ qa qb
-    prod' .π₁∘factor = pulll (rswizzle (sym f-π₁) fi.invl) ∙ prod .π₁∘factor
-    prod' .π₂∘factor = pulll (rswizzle (sym f-π₂) fi.invl) ∙ prod .π₂∘factor
-    prod' .unique other p q = sym $ lswizzle
-      (sym (prod .unique (f ∘ other) (pulll f-π₁ ∙ p) (pulll f-π₂ ∙ q))) fi.invr
+    prod' .π₁∘⟨⟩ = pulll (rswizzle (sym f-π₁) fi.invl) ∙ prod .π₁∘⟨⟩
+    prod' .π₂∘⟨⟩ = pulll (rswizzle (sym f-π₂) fi.invl) ∙ prod .π₂∘⟨⟩
+    prod' .unique p q = sym $ lswizzle
+      (sym (prod .unique (pulll f-π₁ ∙ p) (pulll f-π₂ ∙ q))) fi.invr
 ```
 
 # Categories with all binary products
@@ -246,7 +246,7 @@ module Binary-products
   module product {a} {b} = Product (all-products a b)
 
   open product renaming
-    (unique to ⟨⟩-unique; π₁∘factor to π₁∘⟨⟩; π₂∘factor to π₂∘⟨⟩) public
+    (unique to ⟨⟩-unique) public
   open Functor
 
   infixr 7 _⊗₀_
@@ -266,13 +266,12 @@ This operation extends to a bifunctor $\cC \times \cC \to \cC$.
   _⊗₁_ : ∀ {a b x y} → Hom a x → Hom b y → Hom (a ⊗₀ b) (x ⊗₀ y)
   f ⊗₁ g = ⟨ f ∘ π₁ , g ∘ π₂ ⟩
 
-
   ×-functor : Functor (C ×ᶜ C) C
   ×-functor .F₀ (a , b) = a ⊗₀ b
   ×-functor .F₁ (f , g) = f ⊗₁ g
-  ×-functor .F-id = sym $ ⟨⟩-unique id id-comm id-comm
+  ×-functor .F-id = sym $ ⟨⟩-unique id-comm id-comm
   ×-functor .F-∘ (f , g) (h , i) =
-    sym $ ⟨⟩-unique (f ⊗₁ g ∘ h ⊗₁ i)
+    sym $ ⟨⟩-unique
       (pulll π₁∘⟨⟩ ∙ extendr π₁∘⟨⟩)
       (pulll π₂∘⟨⟩ ∙ extendr π₂∘⟨⟩)
 ```
@@ -334,7 +333,7 @@ We also define a handful of common morphisms.
     swap ∘ (f ⊗₁ g)                       ∎
 
   swap-δ : ∀ {A} → swap ∘ δ ≡ δ {A}
-  swap-δ = ⟨⟩-unique _ (pulll π₁∘⟨⟩ ∙ π₂∘⟨⟩) (pulll π₂∘⟨⟩ ∙ π₁∘⟨⟩)
+  swap-δ = ⟨⟩-unique (pulll π₁∘⟨⟩ ∙ π₂∘⟨⟩) (pulll π₂∘⟨⟩ ∙ π₁∘⟨⟩)
 
   assoc-δ : ∀ {a} → ×-assoc ∘ (id ⊗₁ δ {a}) ∘ δ {a} ≡ (δ ⊗₁ id) ∘ δ
   assoc-δ = unique₂
@@ -373,7 +372,7 @@ the reverse direction by the universal property of products.
   product-repr prod x = Iso→Equiv λ where
       .fst f → π₁ ∘ f , π₂ ∘ f
       .snd .is-iso.inv (f , g) → ⟨ f , g ⟩
-      .snd .is-iso.rinv (f , g) → π₁∘factor ,ₚ π₂∘factor
+      .snd .is-iso.rinv (f , g) → π₁∘⟨⟩ ,ₚ π₂∘⟨⟩
       .snd .is-iso.linv f → sym (⟨⟩∘ f) ∙ eliml ⟨⟩-η
     where open Product prod
 ```

--- a/src/Cat/Diagram/Product/Finite.lagda.md
+++ b/src/Cat/Diagram/Product/Finite.lagda.md
@@ -83,7 +83,7 @@ Cartesian→standard-finite-products F = prod where
   F-unique {n = zero} F f {h} p = sym $ !-unique terminal _
   F-unique {n = suc zero} F f {h} p = sym (idl h) ∙ p fzero
   F-unique {n = suc (suc n)} F f {h} p =
-    products _ _ .unique h (p fzero)
+    products _ _ .unique (p fzero)
       (F-unique (λ e → F (fsuc e)) (λ i → f (fsuc i))
         λ i → assoc _ _ _ ∙ p (fsuc i))
 

--- a/src/Cat/Diagram/Product/Solver.lagda.md
+++ b/src/Cat/Diagram/Product/Solver.lagda.md
@@ -188,7 +188,7 @@ lemmas. The first states that quoting a `vhom f` gives us back `f`.
   vhom-sound : ∀ X Y → (f : Hom ⟦ X ⟧ₒ ⟦ Y ⟧ₒ) → reflect X Y (vhom f) ≡ f
   vhom-sound X (Y ‶⊗‶ Z) f =
     ⟨ reflect X Y (vhom (π₁ ∘ f)) , reflect X Z (vhom (π₂ ∘ f)) ⟩ ≡⟨ ap₂ ⟨_,_⟩ (vhom-sound X Y (π₁ ∘ f)) (vhom-sound X Z (π₂ ∘ f)) ⟩
-    ⟨ π₁ ∘ f , π₂ ∘ f ⟩                                           ≡˘⟨ ⟨⟩-unique f refl refl ⟩
+    ⟨ π₁ ∘ f , π₂ ∘ f ⟩                                           ≡˘⟨ ⟨⟩-unique refl refl ⟩
     f                                                             ∎
   vhom-sound X ‶ x ‶ f = refl
 ```

--- a/src/Cat/Diagram/Pushout.lagda.md
+++ b/src/Cat/Diagram/Pushout.lagda.md
@@ -63,14 +63,14 @@ of identifications required to make the aforementioned square commute.
 ```agda
         universal : ∀ {Q} {i₁' : Hom Y Q} {i₂' : Hom Z Q}
                    → i₁' ∘ f ≡ i₂' ∘ g → Hom P Q
-        i₁∘universal : {p : i₁' ∘ f ≡ i₂' ∘ g} → universal p ∘ i₁ ≡ i₁'
-        i₂∘universal : {p : i₁' ∘ f ≡ i₂' ∘ g} → universal p ∘ i₂ ≡ i₂'
-  
+        universal∘i₁ : {p : i₁' ∘ f ≡ i₂' ∘ g} → universal p ∘ i₁ ≡ i₁'
+        universal∘i₂ : {p : i₁' ∘ f ≡ i₂' ∘ g} → universal p ∘ i₂ ≡ i₂'
+
         unique : {p : i₁' ∘ f ≡ i₂' ∘ g} {colim' : Hom P Q}
                → colim' ∘ i₁ ≡ i₁'
                → colim' ∘ i₂ ≡ i₂'
                → colim' ≡ universal p
-  
+
       unique₂
         : {p : i₁' ∘ f ≡ i₂' ∘ g} {colim' colim'' : Hom P Q}
         → colim' ∘ i₁ ≡ i₁' → colim' ∘ i₂ ≡ i₂'
@@ -89,6 +89,6 @@ maps:
       i₁       : Hom Y coapex
       i₂       : Hom Z coapex
       has-is-po  : is-pushout f i₁ g i₂
-  
+
     open is-pushout has-is-po public
 ```

--- a/src/Cat/Diagram/Pushout/Properties.lagda.md
+++ b/src/Cat/Diagram/Pushout/Properties.lagda.md
@@ -41,12 +41,12 @@ $f : A \to B$ is an epimorphism iff. the square below is a pushout
     is-epic→is-pushout : is-epic f → is-pushout C f id f id
     is-epic→is-pushout epi .square = refl
     is-epic→is-pushout epi .universal {i₁' = i₁'} p = i₁'
-    is-epic→is-pushout epi .i₁∘universal = idr _
-    is-epic→is-pushout epi .i₂∘universal {p = p} = idr _ ∙ epi _ _ p
+    is-epic→is-pushout epi .universal∘i₁ = idr _
+    is-epic→is-pushout epi .universal∘i₂ {p = p} = idr _ ∙ epi _ _ p
     is-epic→is-pushout epi .unique p q = intror refl ∙ p
   
     is-pushout→is-epic : is-pushout C f id f id → is-epic f
-    is-pushout→is-epic pb g h p = sym (pb .i₁∘universal {p = p}) ∙ pb .i₂∘universal
+    is-pushout→is-epic pb g h p = sym (pb .universal∘i₁ {p = p}) ∙ pb .universal∘i₂
 ```
 
 Pushout additionally preserve epimorphisms, as shown below:

--- a/src/Cat/Diagram/Zero.lagda.md
+++ b/src/Cat/Diagram/Zero.lagda.md
@@ -20,7 +20,7 @@ module _ {o h} (C : Precategory o h) where
 ```
 -->
 
-# Zero objects
+# Zero objects {defines="zero-object"}
 
 In some categories, `Initial`{.Agda} and `Terminal`{.Agda} objects
 coincide. When this occurs, we call the object a **zero object**.
@@ -30,42 +30,58 @@ coincide. When this occurs, we call the object a **zero object**.
     field
       has-is-initial  : is-initial C ob
       has-is-terminal : is-terminal C ob
-  
+
   record Zero : Type (o ⊔ h) where
     field
       ∅       : Ob
       has-is-zero : is-zero ∅
-  
+
     open is-zero has-is-zero public
-  
+
     terminal : Terminal C
     terminal = record { top = ∅ ; has⊤ = has-is-terminal }
-  
+
     initial : Initial C
     initial = record { bot = ∅ ; has⊥ = has-is-initial }
-  
+
     open Terminal terminal public hiding (top)
     open Initial initial public hiding (bot)
 ```
 
+::: {.definition #zero-morphism}
 A curious fact about zero objects is that their existence implies that
-every hom set is inhabited!
+every hom set is inhabited! Between any objects $x$ and $y$ the morphism
+$0 = ¡ \circ ! : x \to y$ is called the **zero morphism**.
+:::
 
 ```agda
     zero→ : ∀ {x y} → Hom x y
     zero→ = ¡ ∘ !
-  
+
     zero-∘l : ∀ {x y z} → (f : Hom y z) → f ∘ zero→ {x} {y} ≡ zero→
     zero-∘l f = pulll (sym (¡-unique (f ∘ ¡)))
-  
+
     zero-∘r : ∀ {x y z} → (f : Hom x y) → zero→ {y} {z} ∘ f ≡ zero→
     zero-∘r f = pullr (sym (!-unique (! ∘ f)))
-  
-    zero-comm : ∀ {x y z} → (f : Hom y z) → (g : Hom x y) → f ∘ zero→  ≡ zero→ ∘ g
+
+    zero-comm : ∀ {x y z} → (f : Hom y z) → (g : Hom x y) → f ∘ zero→ ≡ zero→ ∘ g
     zero-comm f g = zero-∘l f ∙ sym (zero-∘r g)
-  
-    zero-comm-sym : ∀ {x y z} → (f : Hom y z) → (g : Hom x y) → zero→ ∘ f  ≡ g ∘ zero→
+
+    zero-comm-sym : ∀ {x y z} → (f : Hom y z) → (g : Hom x y) → zero→ ∘ f ≡ g ∘ zero→
     zero-comm-sym f g = zero-∘r f ∙ sym (zero-∘l g)
+```
+
+In the presence of a zero object, zero morphisms are unique with the
+property of being *constant*, in the sense that $0 \circ f = 0 \circ g$
+for any parallel pair $f, g : x \to y$. (By duality, they are also
+unique with the property of being *coconstant*.)
+
+```agda
+    zero-unique
+      : ∀ {x y} {z : Hom x y}
+      → (∀ {w} (f g : Hom w x) → z ∘ f ≡ z ∘ g)
+      → z ≡ zero→
+    zero-unique const = sym (idr _) ∙ const _ zero→ ∙ zero-∘l _
 ```
 
 ## Intuition

--- a/src/Cat/Displayed/Doctrine/Frame.lagda.md
+++ b/src/Cat/Displayed/Doctrine/Frame.lagda.md
@@ -98,9 +98,9 @@ function which is constantly the top element.
 
 <!--
 ```agda
-  prod f g .has-is-product .π₁∘factor    = prop!
-  prod f g .has-is-product .π₂∘factor    = prop!
-  prod f g .has-is-product .unique _ _ _ = prop!
+  prod f g .has-is-product .π₁∘⟨⟩      = prop!
+  prod f g .has-is-product .π₂∘⟨⟩      = prop!
+  prod f g .has-is-product .unique _ _ = prop!
 ```
 -->
 

--- a/src/Cat/Displayed/Doctrine/Logic.lagda.md
+++ b/src/Cat/Displayed/Doctrine/Logic.lagda.md
@@ -382,8 +382,8 @@ $$
         ⟨⟩∘ _
       ·· ap₂ ⟨_,_⟩ (pullr π₁∘⟨⟩ ∙ p) π₂∘⟨⟩
       ·· sym (⟨⟩∘ _)
-      ∙ eliml (sym (⟨⟩-unique id (idr _) (idr _)))
-    rem₁ .unique q r = ⟨⟩-unique _ q (sym (ap (π₂ ∘_) (sym r) ∙ pulll π₂∘⟨⟩))
+      ∙ eliml (sym (⟨⟩-unique (idr _) (idr _)))
+    rem₁ .unique q r = ⟨⟩-unique q (sym (ap (π₂ ∘_) (sym r) ∙ pulll π₂∘⟨⟩))
 ```
 -->
 

--- a/src/Cat/Displayed/Instances/Simple.lagda.md
+++ b/src/Cat/Displayed/Instances/Simple.lagda.md
@@ -132,7 +132,7 @@ $\langle \pi_1 , f' \rangle$ is, in fact, an inverse.
 
 ```agda
   cart .commutes m h' =
-    f' ∘ ⟨ m ∘ π₁ , π₂ ∘ ⟨⟩-inv.inv ∘ ⟨ m ∘ π₁ , h' ⟩ ⟩ ≡˘⟨ ap₂ _∘_ refl (⟨⟩-unique _ (pulll (π₁-inv ⟨⟩-inv) ∙ π₁∘⟨⟩) refl) ⟩
+    f' ∘ ⟨ m ∘ π₁ , π₂ ∘ ⟨⟩-inv.inv ∘ ⟨ m ∘ π₁ , h' ⟩ ⟩ ≡˘⟨ ap₂ _∘_ refl (⟨⟩-unique (pulll (π₁-inv ⟨⟩-inv) ∙ π₁∘⟨⟩) refl) ⟩
     f' ∘ ⟨⟩-inv.inv ∘ ⟨ m ∘ π₁ , h' ⟩                   ≡⟨ pulll (π₂-inv ⟨⟩-inv) ⟩
     π₂ ∘ ⟨ m ∘ π₁ , h' ⟩                                ≡⟨ π₂∘⟨⟩ ⟩
     h'                                                  ∎

--- a/src/Cat/Displayed/Instances/Subobjects.lagda.md
+++ b/src/Cat/Displayed/Instances/Subobjects.lagda.md
@@ -358,9 +358,9 @@ Sub-products {y} pb a b = prod where
     it .Pullback.universal {p₁' = q≤a .map} {p₂' = q≤b .map} (sym (q≤a .sq) ∙ q≤b .sq)
   prod .Product.has-is-product .is-product.⟨_,_⟩ q≤a q≤b .sq =
     idl _ ∙ sym (pullr (it .p₁∘universal) ∙ sym (q≤a .sq) ∙ idl _)
-  prod .Product.has-is-product .is-product.π₁∘factor = prop!
-  prod .Product.has-is-product .is-product.π₂∘factor = prop!
-  prod .Product.has-is-product .is-product.unique _ _ _ = prop!
+  prod .Product.has-is-product .is-product.π₁∘⟨⟩ = prop!
+  prod .Product.has-is-product .is-product.π₂∘⟨⟩ = prop!
+  prod .Product.has-is-product .is-product.unique _ _ = prop!
 ```
 
 ## Univalence

--- a/src/Cat/Functor/Adjoint/Continuous.lagda.md
+++ b/src/Cat/Functor/Adjoint/Continuous.lagda.md
@@ -97,14 +97,14 @@ if we do it by hand.
     c-prod : is-product C (R.₁ p1) (R.₁ p2)
     c-prod .⟨_,_⟩ f g =
       L-adjunct L⊣R (d-prod .⟨_,_⟩ (R-adjunct L⊣R f) (R-adjunct L⊣R g))
-    c-prod .π₁∘factor =
-      R.pulll (d-prod .π₁∘factor) ∙ L-R-adjunct L⊣R _
-    c-prod .π₂∘factor =
-      R.pulll (d-prod .π₂∘factor) ∙ L-R-adjunct L⊣R _
-    c-prod .unique other p q =
+    c-prod .π₁∘⟨⟩ =
+      R.pulll (d-prod .π₁∘⟨⟩) ∙ L-R-adjunct L⊣R _
+    c-prod .π₂∘⟨⟩ =
+      R.pulll (d-prod .π₂∘⟨⟩) ∙ L-R-adjunct L⊣R _
+    c-prod .unique {other = other} p q =
       sym (L-R-adjunct L⊣R other)
       ∙ ap (L-adjunct L⊣R)
-           (d-prod .unique _ (R-adjunct-ap L⊣R p) (R-adjunct-ap L⊣R q))
+           (d-prod .unique (R-adjunct-ap L⊣R p) (R-adjunct-ap L⊣R q))
 
   right-adjoint→is-pullback
     : ∀ {p x y z}

--- a/src/Cat/Instances/OFE/Coproduct.lagda.md
+++ b/src/Cat/Instances/OFE/Coproduct.lagda.md
@@ -185,12 +185,12 @@ unique: but it suffices to reason at the level of sets.
 ```agda
   mk : Coproduct (OFEs _ _) A B
   mk .coapex = it
-  mk .in₀ = in0
-  mk .in₁ = in1
+  mk .ι₁ = in0
+  mk .ι₂ = in1
   mk .has-is-coproduct .is-coproduct.[_,_] {Q = Q} f g = disj f g
-  mk .has-is-coproduct .in₀∘factor = trivial!
-  mk .has-is-coproduct .in₁∘factor = trivial!
-  mk .has-is-coproduct .unique other p q = ext λ where
+  mk .has-is-coproduct .[]∘ι₁ = trivial!
+  mk .has-is-coproduct .[]∘ι₂ = trivial!
+  mk .has-is-coproduct .unique p q = ext λ where
     (inl x) → p #ₚ x
     (inr x) → q #ₚ x
 ```

--- a/src/Cat/Instances/OFE/Product.lagda.md
+++ b/src/Cat/Instances/OFE/Product.lagda.md
@@ -81,9 +81,9 @@ OFE-Product A B .has-is-product .⟨_,_⟩ f g .hom x = f # x , g # x
 OFE-Product A B .has-is-product .⟨_,_⟩ f g .preserves .pres-≈ p =
   f .preserves .pres-≈ p , g .preserves .pres-≈ p
 
-OFE-Product A B .has-is-product .π₁∘factor = trivial!
-OFE-Product A B .has-is-product .π₂∘factor = trivial!
-OFE-Product A B .has-is-product .unique o p q = ext λ x → p #ₚ x , q #ₚ x
+OFE-Product A B .has-is-product .π₁∘⟨⟩ = trivial!
+OFE-Product A B .has-is-product .π₂∘⟨⟩ = trivial!
+OFE-Product A B .has-is-product .unique p q = ext λ x → p #ₚ x , q #ₚ x
 ```
 
 <!--

--- a/src/Cat/Instances/Sets/Cocomplete.lagda.md
+++ b/src/Cat/Instances/Sets/Cocomplete.lagda.md
@@ -181,12 +181,12 @@ Coproducts are given by disjoint sums:
 ```agda
   Sets-coproducts : (A B : Set ℓ) → Coproduct (Sets ℓ) A B
   Sets-coproducts A B .coapex = el! (∣ A ∣ ⊎ ∣ B ∣)
-  Sets-coproducts A B .in₀ = inl
-  Sets-coproducts A B .in₁ = inr
+  Sets-coproducts A B .ι₁ = inl
+  Sets-coproducts A B .ι₂ = inr
   Sets-coproducts A B .has-is-coproduct .is-coproduct.[_,_] f g = Data.Sum.[ f , g ]
-  Sets-coproducts A B .has-is-coproduct .in₀∘factor = refl
-  Sets-coproducts A B .has-is-coproduct .in₁∘factor = refl
-  Sets-coproducts A B .has-is-coproduct .unique o p q = sym ([]-unique (sym p) (sym q))
+  Sets-coproducts A B .has-is-coproduct .[]∘ι₁ = refl
+  Sets-coproducts A B .has-is-coproduct .[]∘ι₂ = refl
+  Sets-coproducts A B .has-is-coproduct .unique p q = sym ([]-unique (sym p) (sym q))
 ```
 
 [[Set coequalisers]] are described in their own module.
@@ -214,8 +214,8 @@ Pushouts are similar to coequalisers, but gluing together points of $A + B$.
   Sets-pushouts f g .has-is-po .square = ext λ x → glue _
   Sets-pushouts f g .has-is-po .universal {i₁' = i₁'} {i₂'} p =
     Coeq-rec Data.Sum.[ i₁' , i₂' ] (unext p)
-  Sets-pushouts f g .has-is-po .i₁∘universal = refl
-  Sets-pushouts f g .has-is-po .i₂∘universal = refl
+  Sets-pushouts f g .has-is-po .universal∘i₁ = refl
+  Sets-pushouts f g .has-is-po .universal∘i₂ = refl
   Sets-pushouts f g .has-is-po .unique q r =
     ext (Equiv.from ⊎-universal (unext q , unext r))
 ```

--- a/src/Cat/Instances/Sets/Complete.lagda.md
+++ b/src/Cat/Instances/Sets/Complete.lagda.md
@@ -113,9 +113,9 @@ Products are given by product sets:
   Sets-products A B .π₁ = fst
   Sets-products A B .π₂ = snd
   Sets-products A B .has-is-product .⟨_,_⟩ f g x = f x , g x
-  Sets-products A B .has-is-product .π₁∘factor = refl
-  Sets-products A B .has-is-product .π₂∘factor = refl
-  Sets-products A B .has-is-product .unique o p q i x = p i x , q i x
+  Sets-products A B .has-is-product .π₁∘⟨⟩ = refl
+  Sets-products A B .has-is-product .π₂∘⟨⟩ = refl
+  Sets-products A B .has-is-product .unique p q i x = p i x , q i x
 ```
 
 Equalisers are given by carving out the subset of $A$ where $f$ and $g$ agree

--- a/src/Cat/Instances/Shape/Interval.lagda.md
+++ b/src/Cat/Instances/Shape/Interval.lagda.md
@@ -154,9 +154,9 @@ to establish commutativity and uniqueness.
 </details>
 
 ```agda
-0≤1-products A B .has-is-product .π₁∘factor = Poset.≤-thin Bool-poset _ _
-0≤1-products A B .has-is-product .π₂∘factor = Poset.≤-thin Bool-poset _ _
-0≤1-products A B .has-is-product .unique _ _ _ = Poset.≤-thin Bool-poset _ _
+0≤1-products A B .has-is-product .π₁∘⟨⟩ = Poset.≤-thin Bool-poset _ _
+0≤1-products A B .has-is-product .π₂∘⟨⟩ = Poset.≤-thin Bool-poset _ _
+0≤1-products A B .has-is-product .unique _ _ = Poset.≤-thin Bool-poset _ _
 ```
 
 # The space of arrows

--- a/src/Cat/Instances/Sheaves.lagda.md
+++ b/src/Cat/Instances/Sheaves.lagda.md
@@ -132,10 +132,10 @@ finite cases:
     prod .apex .fst = prod' .apex
     prod .π₁ = prod' .π₁
     prod .π₂ = prod' .π₂
-    prod .has-is-product .⟨_,_⟩     = prod' .⟨_,_⟩
-    prod .has-is-product .π₁∘factor = prod' .π₁∘factor
-    prod .has-is-product .π₂∘factor = prod' .π₂∘factor
-    prod .has-is-product .unique    = prod' .unique
+    prod .has-is-product .⟨_,_⟩  = prod' .⟨_,_⟩
+    prod .has-is-product .π₁∘⟨⟩  = prod' .π₁∘⟨⟩
+    prod .has-is-product .π₂∘⟨⟩  = prod' .π₂∘⟨⟩
+    prod .has-is-product .unique = prod' .unique
 
     prod .apex .snd = is-sheaf-limit
       {F = 2-object-diagram _ _} {ψ = 2-object-nat-trans _ _}

--- a/src/Cat/Instances/Slice.lagda.md
+++ b/src/Cat/Instances/Slice.lagda.md
@@ -394,9 +394,9 @@ product in $\cC/c.$
 
 <!--
 ```agda
-    is-pullback→is-fibre-product .π₁∘factor = ext pb.p₁∘universal
-    is-pullback→is-fibre-product .π₂∘factor = ext pb.p₂∘universal
-    is-pullback→is-fibre-product .unique other p q =
+    is-pullback→is-fibre-product .π₁∘⟨⟩ = ext pb.p₁∘universal
+    is-pullback→is-fibre-product .π₂∘⟨⟩ = ext pb.p₂∘universal
+    is-pullback→is-fibre-product .unique p q =
       ext (pb.unique (ap map p) (ap map q))
 
   Pullback→Fibre-product
@@ -692,9 +692,9 @@ module _ {o ℓ} {C : Precategory o ℓ} {B} (prod : has-products C) where
   constant-family .F₀ A = cut (π₂ {a = A})
   constant-family .F₁ f .map      = ⟨ f ∘ π₁ , π₂ ⟩
   constant-family .F₁ f .commutes = π₂∘⟨⟩
-  constant-family .F-id    = ext (sym (⟨⟩-unique _ id-comm (idr _)))
+  constant-family .F-id    = ext (sym (⟨⟩-unique id-comm (idr _)))
   constant-family .F-∘ f g = ext $ sym $
-      ⟨⟩-unique _ (pulll π₁∘⟨⟩ ∙ extendr π₁∘⟨⟩) (pulll π₂∘⟨⟩ ∙ π₂∘⟨⟩)
+      ⟨⟩-unique (pulll π₁∘⟨⟩ ∙ extendr π₁∘⟨⟩) (pulll π₂∘⟨⟩ ∙ π₂∘⟨⟩)
 ```
 
 We can observe that this really is a _constant families_ functor by
@@ -726,13 +726,13 @@ the fibre over $h$ would correspondingly be isomorphic to $A \times \top
     → pb (constant-family .F₀ A .map) h .Pullback.apex ≅ (A ⊗₀ Y)
   constant-family-fibre pb {A} h = make-iso
     ⟨ π₁ ∘ p₁ , p₂ ⟩ (universal {p₁' = ⟨ π₁ , h ∘ π₂ ⟩} {p₂' = π₂} π₂∘⟨⟩)
-    (⟨⟩∘ _ ∙ sym (Product.unique (prod _ _) _
+    (⟨⟩∘ _ ∙ sym (Product.unique (prod _ _)
       (idr _ ∙ sym (pullr p₁∘universal ∙ π₁∘⟨⟩))
       (idr _ ∙ sym p₂∘universal)))
     (Pullback.unique₂ (pb _ _) {p = π₂∘⟨⟩ ∙ square}
       (pulll p₁∘universal ∙ ⟨⟩∘ _ ∙ ap₂ ⟨_,_⟩ π₁∘⟨⟩ (pullr π₂∘⟨⟩ ∙ sym square))
       (pulll p₂∘universal ∙ π₂∘⟨⟩)
-      (idr _ ∙ Product.unique (prod _ _) _ refl refl)
+      (idr _ ∙ Product.unique (prod _ _) refl refl)
       (idr _))
     where open Pullback (pb (constant-family .F₀ A .map) h)
 ```

--- a/src/Cat/Instances/StrictCat.lagda.md
+++ b/src/Cat/Instances/StrictCat.lagda.md
@@ -84,8 +84,8 @@ Strict-cats-products {C = C} {D = D} cob dob = prod where
   prod .π₁ = Fst {C = C} {D = D}
   prod .π₂ = Snd {C = C} {D = D}
   prod .has-is-product .⟨_,_⟩ p q = Cat⟨ p , q ⟩
-  prod .has-is-product .π₁∘factor = Functor-path (λ _ → refl) λ _ → refl
-  prod .has-is-product .π₂∘factor = Functor-path (λ _ → refl) λ _ → refl
-  prod .has-is-product .unique other p q =
+  prod .has-is-product .π₁∘⟨⟩ = Functor-path (λ _ → refl) λ _ → refl
+  prod .has-is-product .π₂∘⟨⟩ = Functor-path (λ _ → refl) λ _ → refl
+  prod .has-is-product .unique p q =
     Functor-path (λ x i → F₀ (p i) x , F₀ (q i) x) λ f i → F₁ (p i) f , F₁ (q i) f
 ```

--- a/src/Cat/Internal/Instances/Congruence.lagda.md
+++ b/src/Cat/Internal/Instances/Congruence.lagda.md
@@ -93,14 +93,14 @@ around products and pullbacks.
     has-is-monic _ _ $
     inclusion ∘ has-trans ∘ R×R.universal _  ≡⟨ unpair-trans _ ⟩
     ⟨ rel₁ ∘ f .ihom , rel₂ ∘ has-refl ∘ y ⟩ ≡⟨ ap₂ ⟨_,_⟩ (f .has-src) (pulll refl-p₂ ∙ idl _) ⟩
-    ⟨ x , y ⟩                                ≡˘⟨ ⟨⟩-unique _ (assoc _ _ _ ∙ f .has-src) (assoc _ _ _ ∙ f .has-tgt) ⟩
+    ⟨ x , y ⟩                                ≡˘⟨ ⟨⟩-unique (assoc _ _ _ ∙ f .has-src) (assoc _ _ _ ∙ f .has-tgt) ⟩
     inclusion ∘ f .ihom                      ∎
   icat .has-internal-cat .idri {x = x} {y = y} f =
     Internal-hom-path $
     has-is-monic _ _ $
     inclusion ∘ has-trans ∘ R×R.universal _  ≡⟨ unpair-trans _ ⟩
     ⟨ rel₁ ∘ has-refl ∘ x , rel₂ ∘ f .ihom ⟩ ≡⟨ ap₂ ⟨_,_⟩ (pulll refl-p₁ ∙ idl _) (f .has-tgt) ⟩
-    ⟨ x , y ⟩                                ≡˘⟨ ⟨⟩-unique _ (assoc _ _ _ ∙ f .has-src) (assoc _ _ _ ∙ f .has-tgt) ⟩
+    ⟨ x , y ⟩                                ≡˘⟨ ⟨⟩-unique (assoc _ _ _ ∙ f .has-src) (assoc _ _ _ ∙ f .has-tgt) ⟩
     inclusion ∘ f .ihom ∎
   icat .has-internal-cat .associ {w = w} {x = x} {y = y} {z = z} f g h =
     Internal-hom-path $

--- a/src/Cat/Monoidal/Instances/Cartesian.lagda.md
+++ b/src/Cat/Monoidal/Instances/Cartesian.lagda.md
@@ -111,16 +111,6 @@ categories]].
 ```agda
   Cartesian-symmetric : Symmetric-monoidal Cartesian-monoidal
   Cartesian-symmetric = to-symmetric-monoidal mk where
-    swap-natural
-      : ∀ {A B C D} ((f , g) : Hom A C × Hom B D)
-      → (g ⊗₁ f) ∘ swap ≡ swap ∘ (f ⊗₁ g)
-    swap-natural (f , g) =
-      (g ⊗₁ f) ∘ swap                       ≡⟨ ⟨⟩∘ _ ⟩
-      ⟨ (g ∘ π₁) ∘ swap , (f ∘ π₂) ∘ swap ⟩ ≡⟨ ap₂ ⟨_,_⟩ (pullr π₁∘⟨⟩) (pullr π₂∘⟨⟩) ⟩
-      ⟨ g ∘ π₂ , f ∘ π₁ ⟩                   ≡˘⟨ ap₂ ⟨_,_⟩ π₂∘⟨⟩ π₁∘⟨⟩ ⟩
-      ⟨ π₂ ∘ (f ⊗₁ g) , π₁ ∘ (f ⊗₁ g) ⟩     ≡˘⟨ ⟨⟩∘ _ ⟩
-      swap ∘ (f ⊗₁ g)                       ∎
-
     open make-symmetric-monoidal
     mk : make-symmetric-monoidal Cartesian-monoidal
     mk .has-braiding = iso→isoⁿ

--- a/src/Cat/Monoidal/Instances/Cartesian.lagda.md
+++ b/src/Cat/Monoidal/Instances/Cartesian.lagda.md
@@ -96,7 +96,7 @@ formal proof requires a _lot_ of calculation, however:
     ni .natural x y f =
       ⟨ f .fst ∘ π₁ , ⟨ f .snd .fst ∘ π₁ , f .snd .snd ∘ π₂ ⟩ ∘ π₂ ⟩ ∘ ⟨ π₁ ∘ π₁ , ⟨ π₂ ∘ π₁ , π₂ ⟩ ⟩     ≡⟨ products! C prods ⟩
       ⟨ π₁ ∘ π₁ , ⟨ π₂ ∘ π₁ , π₂ ⟩ ⟩ ∘ ⟨ (⟨ f .fst ∘ π₁ , f .snd .fst ∘ π₂ ⟩ ∘ π₁) , (f .snd .snd ∘ π₂) ⟩ ∎
-  Cartesian-monoidal .triangle = Product.unique (prods _ _) _
+  Cartesian-monoidal .triangle = Product.unique (prods _ _)
     (pulll π₁∘⟨⟩ ·· pullr π₁∘⟨⟩ ·· π₁∘⟨⟩ ∙ introl refl)
     (pulll π₂∘⟨⟩ ·· pullr π₂∘⟨⟩ ·· idl _)
   Cartesian-monoidal .pentagon =

--- a/src/Cat/Monoidal/Instances/Cartesian.lagda.md
+++ b/src/Cat/Monoidal/Instances/Cartesian.lagda.md
@@ -124,7 +124,7 @@ We also have a system of [[diagonal morphisms|monoidal category with diagonals]]
 ```agda
   Cartesian-diagonal : Diagonals Cartesian-monoidal
   Cartesian-diagonal .diagonals ._=>_.η A = δ
-  Cartesian-diagonal .diagonals ._=>_.is-natural A B f = products! C prods
+  Cartesian-diagonal .diagonals ._=>_.is-natural = δ-natural
   Cartesian-diagonal .diagonal-λ→ = ap ⟨_, id ⟩ (sym (!-unique _))
 ```
 

--- a/src/Cat/Reasoning.lagda.md
+++ b/src/Cat/Reasoning.lagda.md
@@ -28,7 +28,7 @@ Most of these helpers were taken from `agda-categories`.
 ```agda
 private variable
   u v w x y z : Ob
-  a a' a'' b b' b'' c c' c'' d d' d'' : Hom x y
+  a a' a'' b b' b'' c c' c'' d d' d'' e : Hom x y
   f g g' h h' i : Hom x y
 ```
 -->
@@ -109,6 +109,15 @@ module _ (abc≡d : a ∘ b ∘ c ≡ d) where abstract
     f ∘ a ∘ b ∘ c     ≡⟨ ap (f ∘_) abc≡d ⟩
     f ∘ d ∎
 
+module _ (abcd≡e : a ∘ b ∘ c ∘ d ≡ e) where abstract
+  pulll4 : a ∘ (b ∘ (c ∘ (d ∘ f))) ≡ e ∘ f
+  pulll4 {f = f} =
+    a ∘ b ∘ c ∘ d ∘ f ≡⟨ ap (λ x → a ∘ b ∘ x) (assoc _ _ _) ⟩
+    a ∘ b ∘ (c ∘ d) ∘ f ≡⟨ ap (a ∘_) (assoc _ _ _) ⟩
+    a ∘ (b ∘ c ∘ d) ∘ f ≡⟨ assoc _ _ _ ⟩
+    (a ∘ b ∘ c ∘ d) ∘ f ≡⟨ ap (_∘ f) abcd≡e ⟩
+    e ∘ f ∎
+
 module _ (c≡ab : c ≡ a ∘ b) where abstract
   pushl : c ∘ f ≡ a ∘ (b ∘ f)
   pushl = sym (pulll (sym c≡ab))
@@ -125,6 +134,10 @@ module _ (d≡abc : d ≡ a ∘ b ∘ c) where abstract
 
   pushr3 : f ∘ d ≡ ((f ∘ a) ∘ b) ∘ c
   pushr3 = sym (pullr3 (sym d≡abc))
+
+module _ (e≡abcd : e ≡ a ∘ b ∘ c ∘ d) where abstract
+  pushl4 : e ∘ f ≡ a ∘ (b ∘ (c ∘ (d ∘ f)))
+  pushl4 = sym (pulll4 (sym e≡abcd))
 
 module _ (p : f ∘ h ≡ g ∘ i) where abstract
   extendl : f ∘ (h ∘ b) ≡ g ∘ (i ∘ b)
@@ -150,6 +163,10 @@ module _ (p : a ∘ b ∘ c ≡ d ∘ f ∘ g) where abstract
 
   extendr3 : ((h ∘ a) ∘ b) ∘ c ≡ ((h ∘ d) ∘ f) ∘ g
   extendr3 = pullr3 p ∙ sym (pullr3 refl)
+
+module _ (p : a ∘ b ∘ c ∘ d ≡ e ∘ f ∘ g ∘ h) where abstract
+  extendl4 : a ∘ b ∘ c ∘ d ∘ i ≡ e ∘ f ∘ g ∘ h ∘ i
+  extendl4 = pulll4 p ∙ sym (pulll4 refl)
 ```
 
 We also define some useful combinators for performing repeated pulls/pushes.

--- a/src/Cat/Regular.lagda.md
+++ b/src/Cat/Regular.lagda.md
@@ -271,8 +271,8 @@ obtaining
         m = π₁ C.∘ mn
         n = π₂ C.∘ mn
         sq' : ⟨ k C.∘ p , l C.∘ p ⟩ ≡ ⟨ d C.∘ m , d C.∘ n ⟩
-        sq' = sym (⟨⟩∘ _) ∙ sq'- ∙ ⟨⟩-unique _ (C.pulll π₁∘⟨⟩ ∙ C.pullr refl)
-                                               (C.pulll π₂∘⟨⟩ ∙ C.pullr refl)
+        sq' = sym (⟨⟩∘ _) ∙ sq'- ∙ ⟨⟩-unique (C.pulll π₁∘⟨⟩ ∙ C.pullr refl)
+                                             (C.pulll π₂∘⟨⟩ ∙ C.pullr refl)
 ```
 
 We define a map $q : P \to R$ into the kernel pair of $a$, factoring
@@ -322,9 +322,9 @@ skip it.
           .universal {p₁' = p₁'} {p₂'} p → ⟨ p₂' , π₂ ∘ p₁' ⟩
           .p₁∘universal {p₁' = p₁'} {p₂'} {p = p} → ⟨⟩∘ _
             ·· ap₂ ⟨_,_⟩ (pullr π₁∘⟨⟩ ∙ sym p) (pullr π₂∘⟨⟩ ∙ idl _)
-            ·· sym (⟨⟩-unique _ refl refl)
+            ·· sym (⟨⟩-unique refl refl)
           .p₂∘universal → π₁∘⟨⟩
-          .unique {p = p} {lim'} q r → ⟨⟩-unique _ r $ sym $
+          .unique {p = p} {lim'} q r → ⟨⟩-unique r $ sym $
             ap (π₂ ∘_) (sym q) ∙ pulll π₂∘⟨⟩ ∙ ap (_∘ lim') (idl _)
 
         rem₃ : is-strong-epi 𝒞 (×-functor .F₁ (id , d))
@@ -333,9 +333,9 @@ skip it.
           .universal {p₁' = p₁'} {p₂'} p → ⟨ π₁ ∘ p₁' , p₂' ⟩
           .p₁∘universal {p = p} → ⟨⟩∘ _
             ·· ap₂ ⟨_,_⟩ (pullr π₁∘⟨⟩ ∙ idl _) (pullr π₂∘⟨⟩)
-            ·· sym (⟨⟩-unique _ refl p)
+            ·· sym (⟨⟩-unique refl p)
           .p₂∘universal → π₂∘⟨⟩
-          .unique {p = p} {lim'} q r → ⟨⟩-unique _
+          .unique {p = p} {lim'} q r → ⟨⟩-unique
             (sym (ap (π₁ ∘_) (sym q) ∙ pulll π₁∘⟨⟩ ∙ ap (_∘ lim') (idl _)))
             r
 
@@ -365,11 +365,11 @@ construction, so $k = l$ --- so $g$ is _also_ monic.
 
         rem₈ : gh C.∘ k ≡ gh C.∘ l
         rem₈ =
-          gh ∘ k              ≡⟨ ⟨⟩-unique _ refl refl ⟩∘⟨refl ⟩
+          gh ∘ k              ≡⟨ ⟨⟩-unique refl refl ⟩∘⟨refl ⟩
           ⟨ g , h ⟩ ∘ k       ≡⟨ ⟨⟩∘ _ ⟩
           ⟨ g ∘ k , h ∘ k ⟩   ≡⟨ ap₂ ⟨_,_⟩ w' rem₇ ⟩
           ⟨ g ∘ l , h ∘ l ⟩   ≡˘⟨ ⟨⟩∘ _ ⟩
-          ⟨ g , h ⟩ ∘ l       ≡˘⟨ ⟨⟩-unique _ refl refl ⟩∘⟨refl ⟩
+          ⟨ g , h ⟩ ∘ l       ≡˘⟨ ⟨⟩-unique refl refl ⟩∘⟨refl ⟩
           gh ∘ l              ∎
 ```
 
@@ -395,7 +395,7 @@ we do below.
 ```agda
       compute =
         (h ∘ g.from) ∘ f                           ≡⟨ pullr refl ∙ pullr refl ⟩
-        π₂ ∘ dgh.gh ∘ g.from ∘ f                   ≡⟨ refl ⟩∘⟨ ⟨⟩-unique _ refl refl ⟩∘⟨ refl ⟩
+        π₂ ∘ dgh.gh ∘ g.from ∘ f                   ≡⟨ refl ⟩∘⟨ ⟨⟩-unique refl refl ⟩∘⟨ refl ⟩
         π₂ ∘ ⟨ g , h ⟩ ∘ g.from ∘ f                ≡⟨ refl⟩∘⟨ ⟨⟩∘ _ ⟩
         π₂ ∘ ⟨ g ∘ g.from ∘ f , h ∘ g.from ∘ f ⟩   ≡⟨ π₂∘⟨⟩ ⟩
         h ∘ g.from ∘ f                             ≡⟨ refl⟩∘⟨ g-ortho.p .centre .snd .fst ⟩

--- a/src/Order/Diagram/Join.lagda.md
+++ b/src/Order/Diagram/Join.lagda.md
@@ -142,11 +142,11 @@ relation, the concept of join needs to be refined to that of coproduct.
 
   is-join→coproduct : ∀ {a b lub : Ob} → is-join P a b lub → Coproduct (poset→category P) a b
   is-join→coproduct lub .coapex = _
-  is-join→coproduct lub .in₀ = lub .is-join.l≤join
-  is-join→coproduct lub .in₁ = lub .is-join.r≤join
+  is-join→coproduct lub .ι₁ = lub .is-join.l≤join
+  is-join→coproduct lub .ι₂ = lub .is-join.r≤join
   is-join→coproduct lub .has-is-coproduct .[_,_] a<q b<q =
     lub .is-join.least _ a<q b<q
-  is-join→coproduct lub .has-is-coproduct .in₀∘factor = prop!
-  is-join→coproduct lub .has-is-coproduct .in₁∘factor = prop!
-  is-join→coproduct lub .has-is-coproduct .unique _ _ _ = prop!
+  is-join→coproduct lub .has-is-coproduct .[]∘ι₁ = prop!
+  is-join→coproduct lub .has-is-coproduct .[]∘ι₂ = prop!
+  is-join→coproduct lub .has-is-coproduct .unique _ _ = prop!
 ```

--- a/src/Order/Diagram/Meet.lagda.md
+++ b/src/Order/Diagram/Meet.lagda.md
@@ -147,7 +147,7 @@ $\hom(x,y)$ a [[proposition]], then products in $\cC$ are simply meets.
   is-meet→product glb .π₂ = glb .is-meet.meet≤r
   is-meet→product glb .has-is-product .⟨_,_⟩ q<a q<b =
     glb .is-meet.greatest _ q<a q<b
-  is-meet→product glb .has-is-product .π₁∘factor = prop!
-  is-meet→product glb .has-is-product .π₂∘factor = prop!
-  is-meet→product glb .has-is-product .unique _ _ _ = prop!
+  is-meet→product glb .has-is-product .π₁∘⟨⟩ = prop!
+  is-meet→product glb .has-is-product .π₂∘⟨⟩ = prop!
+  is-meet→product glb .has-is-product .unique _ _ = prop!
 ```

--- a/src/Order/Instances/Coproduct.lagda.md
+++ b/src/Order/Instances/Coproduct.lagda.md
@@ -127,12 +127,12 @@ $\Pos$.
 ```agda
 Posets-has-coproducts : ∀ {o ℓ} → has-coproducts (Posets o ℓ)
 Posets-has-coproducts P Q .coapex = P ⊎ᵖ Q
-Posets-has-coproducts P Q .in₀ = inlᵖ
-Posets-has-coproducts P Q .in₁ = inrᵖ
+Posets-has-coproducts P Q .ι₁ = inlᵖ
+Posets-has-coproducts P Q .ι₂ = inrᵖ
 Posets-has-coproducts P Q .has-is-coproduct .is-coproduct.[_,_] = matchᵖ
-Posets-has-coproducts P Q .has-is-coproduct .in₀∘factor = trivial!
-Posets-has-coproducts P Q .has-is-coproduct .in₁∘factor = trivial!
-Posets-has-coproducts P Q .has-is-coproduct .unique other α β = ext λ where
+Posets-has-coproducts P Q .has-is-coproduct .[]∘ι₁ = trivial!
+Posets-has-coproducts P Q .has-is-coproduct .[]∘ι₂ = trivial!
+Posets-has-coproducts P Q .has-is-coproduct .unique α β = ext λ where
   (inl x) → α #ₚ x
   (inr x) → β #ₚ x
 ```

--- a/src/Order/Instances/Product.lagda.md
+++ b/src/Order/Instances/Product.lagda.md
@@ -88,9 +88,9 @@ Posets-has-products P Q .apex = P ×ᵖ Q
 Posets-has-products P Q .π₁ = fstᵖ
 Posets-has-products P Q .π₂ = sndᵖ
 Posets-has-products P Q .has-is-product .⟨_,_⟩     = pairᵖ
-Posets-has-products P Q .has-is-product .π₁∘factor = trivial!
-Posets-has-products P Q .has-is-product .π₂∘factor = trivial!
-Posets-has-products P Q .has-is-product .unique other α β =
+Posets-has-products P Q .has-is-product .π₁∘⟨⟩ = trivial!
+Posets-has-products P Q .has-is-product .π₂∘⟨⟩ = trivial!
+Posets-has-products P Q .has-is-product .unique α β =
   ext λ x → α #ₚ x , β #ₚ x
 ```
 

--- a/src/bibliography.bibtex
+++ b/src/bibliography.bibtex
@@ -255,3 +255,13 @@
       archivePrefix={arXiv},
       primaryClass={id='math.CT' full_name='Category Theory' is_active=True alt_name=None in_archive='math' is_general=False description='Enriched categories, topoi, abelian categories, monoidal categories, homological algebra'}
 }
+
+@misc{KarvonenBiproducts,
+      title={Biproducts without pointedness},
+      author={Martti Karvonen},
+      year={2020},
+      eprint={1801.06488},
+      archivePrefix={arXiv},
+      primaryClass={math.CT},
+      url={https://arxiv.org/abs/1801.06488},
+}


### PR DESCRIPTION
# Description

Define biproducts in a general category following [Karvonen 2020](https://arxiv.org/abs/1801.06488), prove that semiadditive categories are enriched in commutative monoids and other minor results relating semiadditive and additive categories.

## Checklist

Before submitting a merge request, please check the items below:

- [X] I've read [the contributing guidelines](https://github.com/plt-amy/1lab/blob/main/CONTRIBUTING.md).
- [X] The imports of new modules have been sorted with `support/sort-imports.hs` (or `nix run --experimental-features nix-command -f . sort-imports`).
- [X] All new code blocks have "agda" as their language.

If your change affects many files without adding substantial content, and
you don't want your name to appear on those pages (for example, treewide
refactorings or reformattings), start the commit message and PR title with `chore:`.
