### PR TITLE
Set-projective types and projective objects

### DIFF
--- a/src/1Lab/HIT/Truncation.lagda.md
+++ b/src/1Lab/HIT/Truncation.lagda.md
@@ -6,6 +6,7 @@ definition: |
 <!--
 ```agda
 open import 1Lab.Reflection.Induction
+open import 1Lab.Function.Embedding
 open import 1Lab.Reflection.HLevel
 open import 1Lab.HLevel.Closure
 open import 1Lab.Path.Reasoning
@@ -239,16 +240,16 @@ image {A = A} {B = B} f = Σ[ b ∈ B ] ∃[ a ∈ A ] (f a ≡ b)
 
 To see that the `image`{.Agda} indeed implements the concept of image,
 we define a way to factor any map through its image. By the definition
-of image, we have that the map `f-image`{.Agda} is always surjective,
+of image, we have that the map `image-inc`{.Agda} is always surjective,
 and since `∃` is a family of props, the first projection out of
 `image`{.Agda} is an embedding. Thus we factor a map $f$ as $A \epi \im
 f \mono B$.
 
 ```agda
-f-image
+image-inc
   : ∀ {ℓ ℓ'} {A : Type ℓ} {B : Type ℓ'}
   → (f : A → B) → A → image f
-f-image f x = f x , inc (x , refl)
+image-inc f x = f x , inc (x , refl)
 ```
 
 We now prove the theorem that will let us map out of a propositional
@@ -295,7 +296,7 @@ truncation onto a set using a constant map.
             → ∥ A ∥ → B
 ∥-∥-rec-set {A = A} {B} bset f fconst x =
   ∥-∥-elim {P = λ _ → image f}
-    (λ _ → is-constant→image-is-prop bset f fconst) (f-image f) x .fst
+    (λ _ → is-constant→image-is-prop bset f fconst) (image-inc f) x .fst
 ```
 
 <!--
@@ -489,5 +490,26 @@ instance
     go : ∥ A ∥ → (A → ∥ B ∥) → ∥ B ∥
     go (inc x) f = f x
     go (squash x y i) f = squash (go x f) (go y f) i
+```
+-->
+
+<!--
+```agda
+is-embedding→image-inc-is-equiv
+  : ∀ {ℓ ℓ'} {A : Type ℓ} {B : Type ℓ'} {f : A → B}
+  → is-embedding f
+  → is-equiv (image-inc f)
+is-embedding→image-inc-is-equiv {f = f} f-emb =
+  is-iso→is-equiv $
+  iso (λ im → fst $ ∥-∥-out (f-emb _) (im .snd))
+    (λ im → Σ-prop-path! (snd $ ∥-∥-out (f-emb _) (im .snd)))
+    (λ _ → refl)
+
+is-embedding→image-equiv
+  : ∀ {ℓ ℓ'} {A : Type ℓ} {B : Type ℓ'} {f : A → B}
+  → is-embedding f
+  → A ≃ image f
+is-embedding→image-equiv {f = f} f-emb =
+  image-inc f , is-embedding→image-inc-is-equiv f-emb
 ```
 -->

--- a/src/Borceux.lagda.md
+++ b/src/Borceux.lagda.md
@@ -858,6 +858,7 @@ _ = indexed-coproduct-strong-projective
 _ = retract→strong-projective
 _ = Strong-projectives
 _ = strong-projective-separating-faily→strong-projectives
+_ = zero+indexed-coproduct-strong-projective→strong-projective
 ```
 -->
 
@@ -871,6 +872,9 @@ _ = strong-projective-separating-faily→strong-projectives
 * Proposition 4.6.4: `retract→strong-projective`{.Agda}
 * Definition 4.6.5: `Strong-projectives`{.Agda}
 * Proposition 4.6.6: `strong-projective-separating-faily→strong-projectives`{.Agda}
+* Proposition 4.6.7:
+  * (⇒) `zero+indexed-coproduct-strong-projective→strong-projective`{.Agda}
+  * (⇐) `indexed-coproduct-strong-projective`{.Agda}
 
 ### 4.7 Injective cogenerators
 

--- a/src/Borceux.lagda.md
+++ b/src/Borceux.lagda.md
@@ -854,6 +854,10 @@ Borceux uses the term "projective" to refer to [[strong projectives]].
 _ = is-strong-projective
 _ = preserves-strong-epis→strong-projective
 _ = strong-projective→preserves-strong-epis
+_ = indexed-coproduct-strong-projective
+_ = retract→strong-projective
+_ = Strong-projectives
+_ = strong-projective-separating-faily→strong-projectives
 ```
 -->
 
@@ -863,6 +867,10 @@ _ = strong-projective→preserves-strong-epis
   must preserve [[strong epimorphisms]].
   (⇒) `preserves-strong-epis→strong-projective`{.Agda}
   (⇐) `strong-projective→preserves-strong-epis`{.Agda}
+* Proposition 4.6.3: `indexed-coproduct-strong-projective`{.Agda}
+* Proposition 4.6.4: `retract→strong-projective`{.Agda}
+* Definition 4.6.5: `Strong-projectives`{.Agda}
+* Proposition 4.6.6: `strong-projective-separating-faily→strong-projectives`{.Agda}
 
 ### 4.7 Injective cogenerators
 

--- a/src/Borceux.lagda.md
+++ b/src/Borceux.lagda.md
@@ -59,6 +59,7 @@ open import Cat.Bi.Instances.Spans
 open import Cat.Diagram.Idempotent
 open import Cat.Diagram.Limit.Base
 open import Cat.Diagram.Limit.Cone
+open import Cat.Diagram.Projective
 open import Cat.Functor.Hom.Yoneda
 open import Cat.Functor.Properties
 open import Cat.Instances.Discrete
@@ -843,6 +844,10 @@ _ = zero+separating-family→separator
 * Proposition 4.5.16: `zero+separating-family→separator`{.Agda}
 
 ### 4.6 Projectives
+
+::: warning
+Borceux uses the term "projective" to refer to [[strong projectives]].
+:::
 
 ### 4.7 Injective cogenerators
 

--- a/src/Borceux.lagda.md
+++ b/src/Borceux.lagda.md
@@ -21,6 +21,7 @@ open import Cat.Functor.Adjoint.Continuous
 open import Cat.Functor.Adjoint.Reflective
 open import Cat.Diagram.Colimit.Universal
 open import Cat.Diagram.Coproduct.Indexed
+open import Cat.Diagram.Projective.Strong
 open import Cat.Diagram.Separator.Regular
 open import Cat.Functor.Hom.Representable
 open import Cat.Instances.Sets.Cocomplete
@@ -59,7 +60,6 @@ open import Cat.Bi.Instances.Spans
 open import Cat.Diagram.Idempotent
 open import Cat.Diagram.Limit.Base
 open import Cat.Diagram.Limit.Cone
-open import Cat.Diagram.Projective
 open import Cat.Functor.Hom.Yoneda
 open import Cat.Functor.Properties
 open import Cat.Instances.Discrete
@@ -848,6 +848,21 @@ _ = zero+separating-family→separator
 ::: warning
 Borceux uses the term "projective" to refer to [[strong projectives]].
 :::
+
+<!--
+```agda
+_ = is-strong-projective
+_ = preserves-strong-epis→strong-projective
+_ = strong-projective→preserves-strong-epis
+```
+-->
+
+* Definition 4.6.1: `is-strong-projective`{.Agda}
+* Proposition 4.6.2:
+  Note that there is a slight typo in Borceux here: $\cC(P,-)$
+  must preserve [[strong epimorphisms]].
+  (⇒) `preserves-strong-epis→strong-projective`{.Agda}
+  (⇐) `strong-projective→preserves-strong-epis`{.Agda}
 
 ### 4.7 Injective cogenerators
 

--- a/src/Cat/Diagram/Coproduct/Indexed.lagda.md
+++ b/src/Cat/Diagram/Coproduct/Indexed.lagda.md
@@ -2,8 +2,8 @@
 ```agda
 open import Cat.Instances.Shape.Terminal
 open import Cat.Diagram.Pullback
-open import Cat.Diagram.Zero
 open import Cat.Diagram.Initial
+open import Cat.Diagram.Zero
 open import Cat.Univalent
 open import Cat.Prelude
 

--- a/src/Cat/Diagram/Coproduct/Indexed.lagda.md
+++ b/src/Cat/Diagram/Coproduct/Indexed.lagda.md
@@ -2,9 +2,12 @@
 ```agda
 open import Cat.Instances.Shape.Terminal
 open import Cat.Diagram.Pullback
+open import Cat.Diagram.Zero
 open import Cat.Diagram.Initial
 open import Cat.Univalent
 open import Cat.Prelude
+
+open import Data.Dec
 ```
 -->
 
@@ -303,4 +306,96 @@ is-initial→is-disjoint-coproduct {F = F} {i = i} init = is-disjoint where
   is-disjoint .injections-are-monic i = absurd i
   is-disjoint .summands-intersect i j = absurd i
   is-disjoint .different-images-are-disjoint i j p = absurd i
+```
+
+## Coproducts and zero objects
+
+Let $\cC$ be a category with a [[zero object]], and let $\coprod_{i : I} P_i$
+be a coproduct. If $I$ is a [[discrete]] type, then every coproduct
+inclusion $\iota_{i} : \cC(P_i, \coprod_{i : I} P_i)$ has a [[retract]].
+
+<!--
+```agda
+module _
+  {κ} {Idx : Type κ}
+  {P : Idx → C.Ob} {∐P : C.Ob} {ι : ∀ i → C.Hom (P i) ∐P}
+  (coprod : is-indexed-coproduct P ι)
+  where
+  open is-indexed-coproduct coprod
+```
+-->
+
+First, a useful lemma. Suppose that we have a coproduct $\coprod_{i : I} P_i$
+indexed by a discrete type, and a map $t_i : \cC(P_i, X)$ for some $i : I$.
+If there exists maps $f_j : \cC(P_j, X)$ for every $j \neq i$, then we can
+obtain a map $\cC(\coprod_{i : I} P_i, X)$.
+
+
+```agda
+  detect
+    : ∀ {X} ⦃ Idx-Discrete : Discrete Idx ⦄
+    → (i : Idx) → C.Hom (P i) X
+    → (∀ (j : Idx) → ¬ i ≡ j → C.Hom (P j) X)
+    → C.Hom ∐P X
+```
+
+The key idea here is to check if $i = j$ when invoking the universal
+property of $\coprod_{i : I} P_i$; if $i = j$ we use $t_i$,
+otherwise we use $f_j$.
+
+```agda
+  detect {X = X} ⦃ Idx-Discrete ⦄ i tᵢ fⱼ = match probe
+    module detect where
+      probe : ∀ (j : Idx) → C.Hom (P j) X
+      probe j with i ≡? j
+      ... | yes i=j = subst _ i=j tᵢ
+      ... | no ¬i=j = fⱼ j ¬i=j
+
+      probe-yes : probe i ≡ tᵢ
+      probe-yes with i ≡? i
+      ... | yes i=i =
+        is-set→subst-refl
+          (λ j → C.Hom (P j) X)
+          (Discrete→is-set Idx-Discrete)
+          i=i tᵢ
+      ... | no ¬i=i = absurd (¬i=i refl)
+
+      probe-no : ∀ j → (¬i=j : ¬ (i ≡ j)) → probe j ≡ fⱼ j ¬i=j
+      probe-no j ¬i=j with i ≡? j
+      ... | yes i=j = absurd (¬i=j i=j)
+      ... | no _ = ap (fⱼ j) prop!
+```
+
+Moreover, we observe that our newly created map interacts nicely
+with the inclusions into the coproduct.
+
+```agda
+  detect-yes
+    : ∀ {X} ⦃ Idx-Discrete : Discrete Idx ⦄
+    → {i : Idx} → {tᵢ : C.Hom (P i) X}
+    → {fⱼ : ∀ (j : Idx) → ¬ i ≡ j → C.Hom (P j) X}
+    → detect i tᵢ fⱼ C.∘ ι i ≡ tᵢ
+  detect-yes = commute ∙ detect.probe-yes _ _ _
+
+  detect-no
+    : ∀ {X} ⦃ Idx-Discrete : Discrete Idx ⦄
+    → {i : Idx} → {tᵢ : C.Hom (P i) X}
+    → {fⱼ : ∀ (j : Idx) → ¬ i ≡ j → C.Hom (P j) X}
+    → ∀ j → (¬i=j : ¬ i ≡ j) → detect i tᵢ fⱼ C.∘ ι j ≡ fⱼ j ¬i=j
+  detect-no j ¬i=j = commute ∙ detect.probe-no _ _ _ j ¬i=j
+```
+
+Refocusing our attention back to our original claim, suppose that
+$\cC$ has a zero object. This means that there is a canonical choice
+of morphism between any two objects, so we can apply our previous
+lemma to obtain a retract $\cC(\coprod_{I} P_i, P_i)$.
+
+```agda
+  zero→ι-has-retract
+    : ∀ ⦃ Idx-Discrete : Discrete Idx ⦄
+    → Zero C
+    → ∀ i → C.has-retract (ι i)
+  zero→ι-has-retract z i =
+    C.make-retract (detect i C.id (λ _ _ → zero→)) detect-yes
+    where open Zero z
 ```

--- a/src/Cat/Diagram/Projective.lagda.md
+++ b/src/Cat/Diagram/Projective.lagda.md
@@ -8,12 +8,14 @@ open import Cat.Diagram.Coproduct.Indexed
 open import Cat.Diagram.Coproduct
 open import Cat.Functor.Morphism
 open import Cat.Diagram.Initial
+open import Cat.Diagram.Zero
 open import Cat.Functor.Hom
 open import Cat.Groupoid
 open import Cat.Prelude
 
 open import Data.Set.Projective
 open import Data.Set.Surjection
+open import Data.Dec
 
 import Cat.Reasoning
 ```
@@ -221,6 +223,8 @@ indexed-coproduct-projective {P = P} {ι = ι} Idx-pro P-pro coprod {X = X} {Y =
   where open is-indexed-coproduct coprod
 ```
 
+
+
 Note that this projectivity requirement is required: if projective objects
 were closed under arbitrary coproducts, then we would immediately be able
 to prove the [[axiom of choice]]: the singleton set is both a projective
@@ -229,16 +233,42 @@ coproducts would mean that every set is projective, which is precisely
 the axiom of choice.
 
 Putting coproducts aside, note that projectives are closed under retracts.
+This follows by a straightforward bit of algebra.
 
 ```agda
 retract→projective
-  : ∀ {R P} {r : Hom P R} {s : Hom R P}
+  : ∀ {R P}
   → is-projective P
-  → r retract-of s
+  → (s : Hom R P)
+  → has-retract s
   → is-projective R
-retract→projective {r = r} {s = s} P-pro retract p e = do
-  (t , t-factor) ← P-pro (p ∘ r) e
-  pure (t ∘ s , pulll t-factor ∙ cancelr retract)
+retract→projective P-pro s r p e = do
+  (t , t-factor) ← P-pro (p ∘ r .retract) e
+  pure (t ∘ s , pulll t-factor ∙ cancelr (r .is-retract))
+```
+
+A nice consequence of this is that if $\cC$ has a [[zero object]] and
+a projective coproduct $\coprod_{I} P_i$ indexed by a [[discrete]] type,
+then each component of the coproduct is also projective.
+
+```agda
+zero+indexed-coproduct-projective→projective
+  : ∀ {κ} {Idx : Type κ} ⦃ Idx-Discrete : Discrete Idx ⦄
+  → {P : Idx → Ob} {∐P : Ob} {ι : ∀ i → Hom (P i) ∐P}
+  → Zero C
+  → is-indexed-coproduct C P ι
+  → is-projective ∐P
+  → ∀ i → is-projective (P i)
+```
+
+This follows immediately from the fact that if $\cC$ has a zero object
+and $\coprod_{I} P_i$ is indexed by a discrete type, then each coproduct
+inclusion has a retract.
+
+```agda
+zero+indexed-coproduct-projective→projective {ι = ι} z coprod ∐P-pro i =
+  retract→projective ∐P-pro (ι i) $
+  zero→ι-has-retract C coprod z i
 ```
 
 ## Enough projectives

--- a/src/Cat/Diagram/Projective.lagda.md
+++ b/src/Cat/Diagram/Projective.lagda.md
@@ -1,0 +1,258 @@
+---
+description: |
+  Projective objects.
+---
+<!--
+```agda
+open import Cat.Diagram.Coproduct.Indexed
+open import Cat.Diagram.Coproduct
+open import Cat.Functor.Morphism
+open import Cat.Diagram.Initial
+open import Cat.Functor.Hom
+open import Cat.Groupoid
+open import Cat.Prelude
+
+open import Data.Set.Surjection
+
+import Cat.Reasoning
+```
+-->
+```agda
+module Cat.Diagram.Projective
+  {o ℓ}
+  (C : Precategory o ℓ)
+  where
+```
+
+<!--
+```agda
+open Cat.Reasoning C
+```
+-->
+
+# Projective objects
+
+:::{.definition #projective-object alias="projective"}
+Let $\cC$ be a precategory. An object $P : \cC$ is **projective**
+if for every $p : P \to Y$ and $e : X \epi Y$, there merely exists
+a $s : P \to X$ such that $e \circ s = p$, as in the following diagram:
+
+~~~{.quiver}
+\begin{tikzcd}
+  && X \\
+  \\
+  P && Y
+  \arrow["e", two heads, from=1-3, to=3-3]
+  \arrow["\exists", dashed, from=3-1, to=1-3]
+  \arrow["p"', from=3-1, to=3-3]
+\end{tikzcd}
+~~~
+
+More concisely, $P$ is projective if it has the left-lifting property
+relative to epimorphisms in $\cC$.
+:::
+
+```agda
+is-projective : (P : Ob) → Type _
+is-projective P =
+  ∀ {X Y} (p : Hom P Y) (e : X ↠ Y)
+  → ∃[ s ∈ Hom P X ] (e .mor ∘ s ≡ p)
+```
+
+If we take the perspective of generalized elements, then a projective
+object $P$ lets us pick a $P$-element of $X$ from the preimage $e^{-1}(y)$
+of a $P$-element $y : Y$ along every $e : X \epi Y$. This endows $\cC$ with
+a $P$-relative version of the [[axiom of choice]].
+
+This intuition can be made more precise by noticing that every
+object of $\cC$ is projective if and only if every epimorphism (merely)
+splits.
+
+For the forward direction, let $e : X \epi Y$ have a section $s : Y \to X$,
+and note that $s \circ p$ factorizes $p$ through $e$.
+
+```agda
+epis-split→all-projective
+  : (∀ {X Y} → (e : X ↠ Y) → ∥ has-section (e .mor) ∥)
+  → ∀ {P} → is-projective P
+epis-split→all-projective epi-split p e = do
+  s ← epi-split e
+  pure (s .section ∘ p , cancell (s .is-section))
+  where open has-section
+```
+
+Conversely, given an epi $X \epi Y$, we can factorize $\id : Y \to Y$
+to get our desired section $s : Y \to X$.
+
+```agda
+all-projective→epis-split
+  : (∀ {P} → is-projective P)
+  → ∀ {X Y} → (e : X ↠ Y) → ∥ has-section (e .mor) ∥
+all-projective→epis-split pro e = do
+  (s , p) ← pro id e
+  pure (make-section s p)
+```
+
+This suggests that projective objects are quite hard to come by
+in constructive foundations! For the most part, this is true:
+constructively, the category of sets has very few projectives, and
+many categories inherit their epimorphisms from $\Sets$. However,
+it is still possible to have projectives if epis in $\cC$ are extremely
+structured, or there are very few maps out of some $P$.
+
+<!-- [TODO: Reed M, 26/07/2024]
+  Link to stuff about projective modules when that gets written.
+-->
+
+For instance, observe that every epi splits in a [[pregroupoid]],
+so every every object in a pregroupoid must be projective.
+
+```agda
+pregroupoid→all-projective
+  : is-pregroupoid C
+  → ∀ {P} → is-projective P
+pregroupoid→all-projective pregroupoid =
+  epis-split→all-projective λ e →
+    pure (invertible→to-has-section (pregroupoid (e .mor)))
+```
+
+Likewise, if $\cC$ has an [[initial object]] $\bot : \cC$, then
+$\bot$ is projective, as there is a unique map out of $\bot$.
+
+```agda
+module _ (initial : Initial C) where
+  open Initial initial
+
+  initial-projective : is-projective bot
+  initial-projective p e = pure (¡ , ¡-unique₂ (e .mor ∘ ¡) p)
+```
+
+## A functorial definition
+
+Some authors prefer to define projective objects via a functorial
+approach. In particular, an object $P : \cC$ is projective if and only
+if the $\hom$-functor $\cC(P,-)$ preserves epimorphisms.
+
+For the forward direction, recall that in $\Sets$, [[epis are surjective]].
+This means that if $e : X \epi Y$ is an epi in $\cC$, then
+$e \circ - : \cC(P,X) \to \cC(P,Y)$ is surjective, as $\cC(P,-)$ preserves
+epis. This directly gives us the factorization we need!
+
+```agda
+preserves-epis→projective
+  : ∀ {P}
+  → preserves-epis (Hom-from C P)
+  → is-projective P
+preserves-epis→projective {P = P} hom-epi {X = X} {Y = Y} p e =
+  epi→surjective (el! (Hom P X)) (el! (Hom P Y))
+    (e .mor ∘_)
+    (λ {c} → hom-epi (e .epic) {c = c})
+    p
+```
+
+For the reverse direciton, let $P$ be projective, $f : X \epi Y$ be an epi,
+and $g, h : \cC(P, X) \to A$ be a pair of functions into an arbitrary
+set $A$ such that $g(f \circ s) = h(f \circ s)$ for any $s : \cC(P, X)$.
+To show that $\cC(P,-)$ preserves epis, we must show that $g = h$.
+This follows directly from the existence of a lift for every $\cC(P,X)$.
+
+```agda
+projective→preserves-epis
+  : ∀ {P}
+  → is-projective P
+  → preserves-epis (Hom-from C P)
+projective→preserves-epis pro {f = f} f-epi g h p =
+  ext λ k →
+    rec!
+      (λ s s-section →
+        g k       ≡˘⟨ ap g s-section ⟩
+        g (f ∘ s) ≡⟨ p $ₚ s ⟩
+        h (f ∘ s) ≡⟨ ap h s-section ⟩
+        h k       ∎)
+      (pro k (record { epic = f-epi }))
+```
+
+## Closure of projectives
+
+Projective objects are equipped with a mapping-out property, so they
+tend to interact nicely with other constructions that also have a
+mapping-out property. For instance, f $P$ and $Q$ are both projective,
+then their [[coproduct]] $P + Q$ is projective (if it exists).
+
+```agda
+coproduct-projective
+  : ∀ {P Q P+Q} {ι₁ : Hom P P+Q} {ι₂ : Hom Q P+Q}
+  → is-projective P
+  → is-projective Q
+  → is-coproduct C ι₁ ι₂
+  → is-projective P+Q
+coproduct-projective {ι₁ = ι₁} {ι₂ = ι₂} P-pro Q-pro coprod p e = do
+  (s₁ , s₁-factor) ← P-pro (p ∘ ι₁) e
+  (s₂ , s₂-factor) ← Q-pro (p ∘ ι₂) e
+  pure $
+    [ s₁ , s₂ ] ,
+    unique₂
+      (pullr []∘ι₁ ∙ s₁-factor) (pullr []∘ι₂ ∙ s₂-factor)
+      refl refl
+  where open is-coproduct coprod
+```
+
+Additionally, projectives are closed under retracts.
+
+```agda
+retract-projective
+  : ∀ {R P} {r : Hom P R} {s : Hom R P}
+  → is-projective P
+  → r retract-of s
+  → is-projective R
+retract-projective {r = r} {s = s} P-pro retract p e = do
+  (t , t-factor) ← P-pro (p ∘ r) e
+  pure (t ∘ s , pulll t-factor ∙ cancelr retract)
+```
+
+
+
+## Enough projectives
+
+A category $\cC$ is said to have **enough projectives** if for
+object $X : \cC$ there is some $P \epi X$ with $P$ projective.
+We will refer to these projectives as **projective presentations**
+of $X$.
+
+Note that there are two variations on this condition: one where
+there *merely* exists a projective presentation for every $X$, and
+another where those presentations are provided as structure. We prefer
+to work with the latter, as it tends to be less painful to work with.
+
+```agda
+record Projectives : Type (o ⊔ ℓ) where
+  field
+    Pro : Ob → Ob
+    present : ∀ {X} → Pro X ↠ X
+    projective : ∀ {X} → is-projective (Pro X)
+```
+
+# Algebraically projective objects
+
+```agda
+Algebraically-projective : (P : Ob) → Type _
+Algebraically-projective P =
+  ∀ {X Y} (p : Hom P Y) (e : X ↠ Y)
+  → Σ[ s ∈ Hom P X ] (e .mor ∘ s ≡ p)
+```
+
+```agda
+indexed-coproduct-algebraically-projective
+  : ∀ {κ} {Idx : Type κ}
+  → {Pᵢ : Idx → Ob} {∐P : Ob} {ι : (i : Idx) → Hom (Pᵢ i) ∐P}
+  → (∀ i → Algebraically-projective (Pᵢ i))
+  → is-indexed-coproduct C Pᵢ ι
+  → Algebraically-projective ∐P
+indexed-coproduct-algebraically-projective {ι = ι} Pᵢ-pro coprod p e =
+  match (λ i → Pᵢ-pro i (p ∘ ι i) e .fst) ,
+  unique₂ λ i →
+    (e .mor ∘ match λ i → Pᵢ-pro i (p ∘ ι i) e .fst) ∘ ι i ≡⟨ pullr commute ⟩
+    e .mor ∘ Pᵢ-pro i (p ∘ ι i) e .fst                     ≡⟨ Pᵢ-pro i (p ∘ ι i) e .snd ⟩
+    p ∘ ι i                                                ∎
+  where open is-indexed-coproduct coprod
+```

--- a/src/Cat/Diagram/Projective.lagda.md
+++ b/src/Cat/Diagram/Projective.lagda.md
@@ -206,14 +206,14 @@ We can extend this result to [[indexed coproducts]], provided that
 the indexing type is [[set projective]].
 
 ```agda
-indexed-coproduct→projective
+indexed-coproduct-projective
   : ∀ {κ} {Idx : Type κ}
   → {P : Idx → Ob} {∐P : Ob} {ι : ∀ i → Hom (P i) ∐P}
   → is-set-projective Idx ℓ
   → (∀ i → is-projective (P i))
   → is-indexed-coproduct C P ι
   → is-projective ∐P
-indexed-coproduct→projective {P = P} {ι = ι} Idx-pro P-pro coprod {X = X} {Y = Y} p e = do
+indexed-coproduct-projective {P = P} {ι = ι} Idx-pro P-pro coprod {X = X} {Y = Y} p e = do
   s ← Idx-pro
         (λ i → Σ[ sᵢ ∈ Hom (P i) X ] (e .mor ∘ sᵢ ≡ p ∘ ι i)) (λ i → hlevel 2)
         (λ i → P-pro i (p ∘ ι i) e)
@@ -231,12 +231,12 @@ the axiom of choice.
 Putting coproducts aside, note that projectives are closed under retracts.
 
 ```agda
-retract-projective
+retract→projective
   : ∀ {R P} {r : Hom P R} {s : Hom R P}
   → is-projective P
   → r retract-of s
   → is-projective R
-retract-projective {r = r} {s = s} P-pro retract p e = do
+retract→projective {r = r} {s = s} P-pro retract p e = do
   (t , t-factor) ← P-pro (p ∘ r) e
   pure (t ∘ s , pulll t-factor ∙ cancelr retract)
 ```

--- a/src/Cat/Diagram/Projective.lagda.md
+++ b/src/Cat/Diagram/Projective.lagda.md
@@ -37,8 +37,9 @@ open Cat.Reasoning C
 
 :::{.definition #projective-object alias="projective"}
 Let $\cC$ be a precategory. An object $P : \cC$ is **projective**
-if for every $p : P \to Y$ and $e : X \epi Y$, there merely exists
-a $s : P \to X$ such that $e \circ s = p$, as in the following diagram:
+if for every morphism $p : P \to Y$ and [[epimorphism]] $e : X \epi Y$,
+there merely exists a $s : P \to X$ such that $e \circ s = p$, as in the
+following diagram:
 
 ~~~{.quiver}
 \begin{tikzcd}
@@ -46,7 +47,7 @@ a $s : P \to X$ such that $e \circ s = p$, as in the following diagram:
   \\
   P && Y
   \arrow["e", two heads, from=1-3, to=3-3]
-  \arrow["\exists", dashed, from=3-1, to=1-3]
+  \arrow["\exists s", dashed, from=3-1, to=1-3]
   \arrow["p"', from=3-1, to=3-3]
 \end{tikzcd}
 ~~~
@@ -65,14 +66,12 @@ is-projective P =
 If we take the perspective of generalized elements, then a projective
 object $P$ lets us pick a $P$-element of $X$ from the preimage $e^{-1}(y)$
 of a $P$-element $y : Y$ along every $e : X \epi Y$. This endows $\cC$ with
-a $P$-relative version of the [[axiom of choice]].
+an internal $P$-relative version of the [[axiom of choice]].
 
 This intuition can be made more precise by noticing that every
 object of $\cC$ is projective if and only if every epimorphism (merely)
-splits.
-
-For the forward direction, let $e : X \epi Y$ have a section $s : Y \to X$,
-and note that $s \circ p$ factorizes $p$ through $e$.
+splits. For the forward direction, let $e : X \epi Y$ have a section
+$s : Y \to X$, and note that $s \circ p$ factorizes $p$ through $e$.
 
 ```agda
 epis-split→all-projective
@@ -160,8 +159,8 @@ preserves-epis→projective {P = P} hom-epi {X = X} {Y = Y} p e =
 For the reverse direciton, let $P$ be projective, $f : X \epi Y$ be an epi,
 and $g, h : \cC(P, X) \to A$ be a pair of functions into an arbitrary
 set $A$ such that $g(f \circ s) = h(f \circ s)$ for any $s : \cC(P, X)$.
-To show that $\cC(P,-)$ preserves epis, we must show that $g = h$.
-This follows directly from the existence of a lift for every $\cC(P,X)$.
+To show that $\cC(P,-)$ preserves epis, we must show that $g = h$, which
+follows directly from the existence of a lift for every $\cC(P,X)$.
 
 ```agda
 projective→preserves-epis
@@ -223,8 +222,6 @@ indexed-coproduct-projective {P = P} {ι = ι} Idx-pro P-pro coprod {X = X} {Y =
   where open is-indexed-coproduct coprod
 ```
 
-
-
 Note that this projectivity requirement is required: if projective objects
 were closed under arbitrary coproducts, then we would immediately be able
 to prove the [[axiom of choice]]: the singleton set is both a projective
@@ -232,8 +229,8 @@ object and a [[dense separator]] in $\Sets$, so closure under arbitrary
 coproducts would mean that every set is projective, which is precisely
 the axiom of choice.
 
-Putting coproducts aside, note that projectives are closed under retracts.
-This follows by a straightforward bit of algebra.
+Putting coproducts aside for a moment, note that projectives are closed
+under retracts. This follows by a straightforward bit of algebra.
 
 ```agda
 retract→projective

--- a/src/Cat/Diagram/Projective/Strong.lagda.md
+++ b/src/Cat/Diagram/Projective/Strong.lagda.md
@@ -7,11 +7,14 @@ description: |
 open import Cat.Diagram.Coproduct.Copower
 open import Cat.Diagram.Coproduct.Indexed
 open import Cat.Functor.Morphism
+open import Cat.Diagram.Zero
 open import Cat.Functor.Hom
 open import Cat.Prelude
 
 open import Data.Set.Projective
 open import Data.Set.Surjection
+
+open import Data.Dec
 
 import Cat.Diagram.Separator.Strong
 import Cat.Diagram.Projective
@@ -130,9 +133,10 @@ indexed-coproduct-strong-projective
   → is-strong-projective ∐P
 
 retract→strong-projective
-  : ∀ {R P} {r : Hom P R} {s : Hom R P}
+  : ∀ {R P}
   → is-strong-projective P
-  → r retract-of s
+  → (s : Hom R P)
+  → has-retract s
   → is-strong-projective R
 ```
 
@@ -148,9 +152,34 @@ indexed-coproduct-strong-projective {P = P} {ι = ι} Idx-pro P-pro coprod {X = 
   pure (match (λ i → s i .fst) , unique₂ (λ i → pullr commute ∙ s i .snd))
   where open is-indexed-coproduct coprod
 
-retract→strong-projective {r = r} {s = s} P-pro retract p e e-strong = do
-  (t , t-factor) ← P-pro (p ∘ r) e e-strong
-  pure (t ∘ s , pulll t-factor ∙ cancelr retract)
+retract→strong-projective P-pro s r p e e-strong = do
+  (t , t-factor) ← P-pro (p ∘ r .retract) e e-strong
+  pure (t ∘ s , pulll t-factor ∙ cancelr (r .is-retract))
+```
+</details>
+
+Moreover, if $\cC$ has a [[zero object]] and a strong projective
+coproduct $\coprod_{I} P_i$ indexed by a [[discrete]] type, then
+each component of the coproduct is a strong projective.
+
+```agda
+zero+indexed-coproduct-strong-projective→strong-projective
+  : ∀ {κ} {Idx : Type κ} ⦃ Idx-Discrete : Discrete Idx ⦄
+  → {P : Idx → Ob} {∐P : Ob} {ι : ∀ i → Hom (P i) ∐P}
+  → Zero C
+  → is-indexed-coproduct C P ι
+  → is-strong-projective ∐P
+  → ∀ i → is-strong-projective (P i)
+```
+
+<details>
+<summary>Following the general theme, the proof is identical
+to the non-strong case.
+</summary>
+```agda
+zero+indexed-coproduct-strong-projective→strong-projective {ι = ι} z coprod ∐P-pro i =
+  retract→strong-projective ∐P-pro (ι i) $
+  zero→ι-has-retract C coprod z i
 ```
 </details>
 

--- a/src/Cat/Diagram/Projective/Strong.lagda.md
+++ b/src/Cat/Diagram/Projective/Strong.lagda.md
@@ -53,7 +53,7 @@ a $s : P \to X$ such that $e \circ s = p$, as in the following diagram:
   \\
   P && Y
   \arrow["e", two heads, from=1-3, to=3-3]
-  \arrow["\exists", dashed, from=3-1, to=1-3]
+  \arrow["\exists s", dashed, from=3-1, to=1-3]
   \arrow["p"', from=3-1, to=3-3]
 \end{tikzcd}
 ~~~
@@ -214,7 +214,7 @@ module _ (coprods : (Idx : Set ℓ) → has-coproducts-indexed-by C ∣ Idx ∣)
 
 If $\cC$ has set-indexed coproducts, and $P_i$ is a [[strong separating family]]
 with each $P_i$ a strong projective, then $\cC$ has enough strong projectives
-if $\Sigma(i : Idx), (\cC(P_i, X))$ is a set-projective type.
+if $\Sigma(i : Idx) (\cC(P_i, X))$ is a set-projective type.
 
 ```agda
   strong-projective-separating-faily→strong-projectives
@@ -225,9 +225,9 @@ if $\Sigma(i : Idx), (\cC(P_i, X))$ is a set-projective type.
     → Strong-projectives
 ```
 
-The hypotheses of this theorem hint basically give the game away: by definition,
-there is a strong epimorphism $\coprod_{\Sigma(i : I), \cC(P_i, X)} S_i \to X$
-for every $X$. Moreover, $\Sigma(i : I), \cC(P_i, X)$ is set-projective,
+The hypotheses of this theorem basically give the game away: by definition,
+there is a strong epimorphism $\coprod_{\Sigma(i : I) \cC(P_i, X)} S_i \to X$
+for every $X$. Moreover, $\Sigma(i : I) \cC(P_i, X)$ is set-projective,
 so the corresponding coproduct is a strong projective.
 
 ```agda

--- a/src/Cat/Diagram/Projective/Strong.lagda.md
+++ b/src/Cat/Diagram/Projective/Strong.lagda.md
@@ -13,7 +13,6 @@ open import Cat.Prelude
 
 open import Data.Set.Projective
 open import Data.Set.Surjection
-
 open import Data.Dec
 
 import Cat.Diagram.Separator.Strong

--- a/src/Cat/Diagram/Projective/Strong.lagda.md
+++ b/src/Cat/Diagram/Projective/Strong.lagda.md
@@ -1,0 +1,112 @@
+---
+description: |
+  Strong projective objects.
+---
+<!--
+```agda
+open import Cat.Functor.Morphism
+open import Cat.Functor.Hom
+open import Cat.Prelude
+
+open import Data.Set.Surjection
+
+import Cat.Diagram.Projective
+import Cat.Morphism.StrongEpi
+import Cat.Reasoning
+```
+-->
+```agda
+module Cat.Diagram.Projective.Strong
+  {o ℓ}
+  (C : Precategory o ℓ)
+  where
+```
+
+<!--
+```agda
+open Cat.Diagram.Projective C
+open Cat.Morphism.StrongEpi C
+open Cat.Reasoning C
+```
+-->
+
+# Strong projective objects
+
+:::{.definition #strong-projective-object alias="strong-projective"}
+Let $\cC$ be a precategory. An object $P : \cC$ is a
+**strong projective object** if it has the left-lifting property against
+[[strong epimorphisms]].
+
+More explicitly, $P$ is a strong projective object if for every
+morphism $p : P \to Y$ and strong epi $e : X \epi Y$, there merely exists
+a $s : P \to X$ such that $e \circ s = p$, as in the following diagram:
+
+~~~{.quiver}
+\begin{tikzcd}
+  && X \\
+  \\
+  P && Y
+  \arrow["e", two heads, from=1-3, to=3-3]
+  \arrow["\exists", dashed, from=3-1, to=1-3]
+  \arrow["p"', from=3-1, to=3-3]
+\end{tikzcd}
+~~~
+:::
+
+```agda
+is-strong-projective : (P : Ob) → Type _
+is-strong-projective P =
+  ∀ {X Y} (p : Hom P Y) (e : Hom X Y)
+  → is-strong-epi e
+  → ∃[ s ∈ Hom P X ] (e ∘ s ≡ p)
+```
+
+::: warning
+Being a strong projective object is actually a weaker condition than
+being a [[projective object]]: strong projectives only need to lift
+against strong epis, whereas projectives need to lift against *all* epis.
+:::
+
+```agda
+projective→strong-projective
+  : ∀ {P}
+  → is-projective P
+  → is-strong-projective P
+projective→strong-projective pro p e e-strong =
+  pro p (record { mor = e ; epic = e-strong .fst })
+```
+
+## A functorial definition
+
+Like their non-strong counterparts, we can give a functorial definition of
+strong projectives. In particular, an object $P : \cC$ is a strong projective
+if and only if the $\hom$-functor $\cC(P,-)$ preserves strong epimorphisms.
+
+```agda
+preserves-strong-epis→strong-projective
+  : ∀ {P}
+  → preserves-strong-epis (Hom-from C P)
+  → is-strong-projective P
+
+strong-projective→preserves-strong-epis
+  : ∀ {P}
+  → is-strong-projective P
+  → preserves-strong-epis (Hom-from C P)
+```
+
+<details>
+<summary>These proofs are essentially the same as the corresponding
+ones for projective objects, so we omit the details.
+</summary>
+```agda
+preserves-strong-epis→strong-projective {P = P} hom-epi {X = X} {Y = Y} p e e-strong =
+  epi→surjective (el! (Hom P X)) (el! (Hom P Y))
+    (e ∘_)
+    (λ {c} → hom-epi e-strong .fst {c = c})
+    p
+
+strong-projective→preserves-strong-epis {P = P} pro {X} {Y} {f = f} f-strong =
+    surjective→strong-epi (el! (Hom P X)) (el! (Hom P Y)) (f ∘_) $ λ p →
+    pro p f f-strong
+```
+</details>

--- a/src/Cat/Functor/Morphism.lagda.md
+++ b/src/Cat/Functor/Morphism.lagda.md
@@ -6,6 +6,7 @@ description: |
 <!--
 ```agda
 open import Cat.Functor.Properties
+open import Cat.Morphism.StrongEpi
 open import Cat.Morphism.Duality
 open import Cat.Functor.Adjoint
 open import Cat.Prelude
@@ -56,6 +57,14 @@ preserves-epis : Type _
 preserves-epis =
   ∀ {a b : 𝒞.Ob} {f : 𝒞.Hom a b} → 𝒞.is-epic f → 𝒟.is-epic (F₁ f)
 ```
+
+<!--
+```agda
+preserves-strong-epis : Type _
+preserves-strong-epis =
+  ∀ {a b : 𝒞.Ob} {f : 𝒞.Hom a b} → is-strong-epi 𝒞 f → is-strong-epi 𝒟 (F₁ f)
+```
+-->
 
 Likewise, a functor $F : \cC \to \cD$ **reflects** $H$-morphisms
 if $F(f) \in H$ implies that $f \in H$.

--- a/src/Cat/Functor/Morphism.lagda.md
+++ b/src/Cat/Functor/Morphism.lagda.md
@@ -28,7 +28,7 @@ module Cat.Functor.Morphism
 private
   module 𝒞 = Cat.Reasoning 𝒞
   module 𝒟 = Cat.Reasoning 𝒟
-open Cat.Functor.Reasoning F public
+open Cat.Functor.Reasoning F
 
 private variable
   A B C : 𝒞.Ob
@@ -42,6 +42,34 @@ private variable
 
 This module describes how various classes of functors act on designated
 collections of morphisms.
+
+First, some general definitions. Let $H$ be a collection of morphisms in $\cC$.
+A functor $F : \cC \to \cD$ **preserves** $H$-morphisms if $f \in H$ implies
+that $F(f) \in H$.
+
+```agda
+preserves-monos : Type _
+preserves-monos =
+  ∀ {a b : 𝒞.Ob} {f : 𝒞.Hom a b} → 𝒞.is-monic f → 𝒟.is-monic (F₁ f)
+
+preserves-epis : Type _
+preserves-epis =
+  ∀ {a b : 𝒞.Ob} {f : 𝒞.Hom a b} → 𝒞.is-epic f → 𝒟.is-epic (F₁ f)
+```
+
+Likewise, a functor $F : \cC \to \cD$ **reflects** $H$-morphisms
+if $F(f) \in H$ implies that $f \in H$.
+
+```agda
+reflects-monos : Type _
+reflects-monos =
+  ∀ {a b : 𝒞.Ob} {f : 𝒞.Hom a b} → 𝒟.is-monic (F₁ f) → 𝒞.is-monic f
+
+reflects-epis : Type _
+reflects-epis =
+  ∀ {a b : 𝒞.Ob} {f : 𝒞.Hom a b} → 𝒟.is-epic (F₁ f) → 𝒞.is-epic f
+```
+
 
 ## Faithful functors
 

--- a/src/Cat/Morphism.lagda.md
+++ b/src/Cat/Morphism.lagda.md
@@ -219,7 +219,7 @@ has-section→epic {f = f} f-sect g h p =
   h ∎
 ```
 
-## Retracts
+## Retracts {defines="retract"}
 
 A morphism $r : A \to B$ is a retract of another morphism $s : B \to A$
 when $r \cdot s = id$. Note that this is the same equation involved

--- a/src/Cat/Morphism.lagda.md
+++ b/src/Cat/Morphism.lagda.md
@@ -744,6 +744,13 @@ inverses→from-has-retract
   → Inverses f g → has-retract g
 inverses→from-has-retract {f = f} inv .retract = f
 inverses→from-has-retract inv .is-retract = Inverses.invl inv
+```
+
+<!--
+```agda
+invertible→to-has-section : is-invertible f → has-section f
+invertible→to-has-section f-inv .section = is-invertible.inv f-inv
+invertible→to-has-section f-inv .is-section = is-invertible.invl f-inv
 
 iso→to-has-section : (f : a ≅ b) → has-section (f .to)
 iso→to-has-section f .section = f .from
@@ -761,6 +768,7 @@ iso→from-has-retract : (f : a ≅ b) → has-retract (f .from)
 iso→from-has-retract f .retract = f .to
 iso→from-has-retract f .is-retract = f .invl
 ```
+-->
 
 Using our lemmas about section/retraction pairs from before, we
 can show that if $f$ is a monic retract, then $f$ is an

--- a/src/Data/Set/Projective.lagda.md
+++ b/src/Data/Set/Projective.lagda.md
@@ -1,6 +1,6 @@
 ---
 description: |
-  We define projective sets, and prove some taboos.
+  We define set-projective types, and prove some taboos.
 ---
 <!--
 ```agda
@@ -17,7 +17,7 @@ open import Meta.Invariant
 module Data.Set.Projective where
 ```
 
-# Projective sets
+# Set-projective types
 
 <!--
 ```agda
@@ -65,7 +65,7 @@ sets-projective→surjections-split
 ```
 
 <details>
-<summary>These proof of this is a specialization of the of the proof that
+<summary>This is essentially a specialization of the of the proof that
 the axiom of choice is equivalent to every surjection splitting, so we
 will not dwell on the details.
 </summary>
@@ -85,11 +85,12 @@ sets-projective→surjections-split A-set A-pro E-set f =
 
 Set-projective types are closed under Σ-types. Suppose that $A : \ty$ is a
 set-projective type, and that $B : A \to \ty$ is a family of set-projective
-types, and let $P : \Sigma A B \to \set$ be a family of sets such that $\| P(a,b) \|$
-for every $a, b$. Note that $\lambda a. (b : B(a)) \to P(a, b)$ is an $A$-indexed
-family of sets, so we can commute truncation past it via projectivity of $A$.
-Moreover, each $B(a)$ is also projective, so we can further commute truncations
-past the $B(a)$.
+types, and let $P : \Sigma\ A\ B \to \set$ be a family of merely inhabited sets.
+Note that $(b : B(a)) \to P(a, b)$ is a $B(a)$-indexed family of merely
+inhabited sets for every $a$, so its product must also be inhabited by projectivity
+of $B(a)$. Moreover, $A$ is also projective, so $(a : A) \to (b : B(a)) \to P(a, b)$
+is also merely inhabited, as $(b : B(a)) \to P(a, b)$ is an $A$-indexed family of
+merely inhabited sets. We can then uncurry this family to finish the proof.
 
 ```agda
 Σ-set-projective
@@ -104,7 +105,7 @@ past the $B(a)$.
 ```
 
 Moreover, set-projective types are stable under retracts. Suppose that
-we have $f : A \to B, g : B \to A$ with $f \circ g = id$ and $A$ set-projective,
+we have $f : A \to B, g : B \to A$ with $f \circ g = id$ with $A$ set-projective,
 and let $P : B \to \set$ be a family of merely inhabited sets. We can
 precompose $P$ with $f$ to obtain an $A$-indexed family of sets whose
 product $\Pi (a : A) \to P(f(a))$ must be inhabited via projectivity of $A$.
@@ -163,7 +164,7 @@ constructively! The general sketch of the taboo is that it is consistent that:
 
 The existence of such a model is out of scope for this page, so we will
 focus our attention on the internal portion of the argument. In particular,
-we will prove that under assumptions (1), the existence of an
+we will prove that if propositions are set-projective, then the existence of an
 Dedekind-infinite set-projective type implies countable choice.
 
 First, note that if propositions are set-projective, then the [[image]] of
@@ -213,7 +214,7 @@ obtain countable choice from the existence of a Dedekind-infinite type.
     props-projective+is-embedding→set-projective
 ```
 
-Note that the projectivity of propositions is itself a taboo: in particular,
+Note that the set-projectivity of propositions is itself a taboo: in particular,
 every proposition is set-projective if and only if every set has split support.
 The following proof is adapted from [@Kraus-Escardó-Coquand-Altenkirch:2016].
 

--- a/src/Data/Set/Projective.lagda.md
+++ b/src/Data/Set/Projective.lagda.md
@@ -1,0 +1,251 @@
+---
+description: |
+  We define projective sets, and prove some taboos.
+---
+<!--
+```agda
+open import 1Lab.Classical
+open import 1Lab.Prelude
+
+open import Data.Dec
+open import Data.Fin
+
+open import Meta.Invariant
+```
+-->
+```agda
+module Data.Set.Projective where
+```
+
+# Projective sets
+
+<!--
+```agda
+private variable
+  ℓ ℓ' ℓ'' : Level
+```
+-->
+
+:::{.definition #set-projective}
+A type $A$ is **set-projective** if we can commute [[propositional truncation]]
+past $A$-indexed families.
+:::
+
+```agda
+is-set-projective : ∀ {ℓ} (A : Type ℓ) → (κ : Level) → Type _
+is-set-projective A κ =
+  ∀ (P : A → Type κ)
+  → (∀ a → is-set (P a))
+  → (∀ a → ∥ P a ∥)
+  → ∥ (∀ a → P a) ∥
+```
+
+Intuitively, a type $A$ is set-projective if it validates a sort of
+$A$-indexed version of the [[axiom of choice]].
+
+If $A$ is a set, then $A$ is set-projective if and only if every
+surjection $E \to A$ from a set $E$ splits.
+
+```agda
+surjections-split→set-projective
+  : ∀ {ℓ ℓ'} {A : Type ℓ}
+  → is-set A
+  → (∀ (E : Type (ℓ ⊔ ℓ')) → is-set E
+     → (f : E → A) → is-surjective f
+     → ∥ (∀ a → fibre f a) ∥)
+  → is-set-projective A (ℓ ⊔ ℓ')
+
+sets-projective→surjections-split
+  : ∀ {ℓ ℓ'} {A : Type ℓ}
+  → is-set A
+  → is-set-projective A (ℓ ⊔ ℓ')
+  → ∀ {E : Type ℓ'} → is-set E
+  → (f : E → A) → is-surjective f
+  → ∥ (∀ a → fibre f a) ∥
+```
+
+<details>
+<summary>These proof of this is a specialization of the of the proof that
+the axiom of choice is equivalent to every surjection splitting, so we
+will not dwell on the details.
+</summary>
+```agda
+surjections-split→set-projective {A = A} A-set surj-split P P-set ∥P∥ =
+  ∥-∥-map
+    (Equiv.to (Π-cod≃ (Fibre-equiv P)))
+    (surj-split (Σ[ x ∈ A ] (P x)) (Σ-is-hlevel 2 A-set P-set) fst λ x →
+      ∥-∥-map (Equiv.from (Fibre-equiv P x)) (∥P∥ x))
+
+sets-projective→surjections-split A-set A-pro E-set f =
+  A-pro (fibre f) (λ x → fibre-is-hlevel 2 E-set A-set f x)
+```
+</details>
+
+## Closure of set-projectivity
+
+Set-projective types are closed under Σ-types. Suppose that $A : \ty$ is a
+set-projective type, and that $B : A \to \ty$ is a family of set-projective
+types, and let $P : \Sigma A B \to \set$ be a family of sets such that $\| P(a,b) \|$
+for every $a, b$. Note that $\lambda a. (b : B(a)) \to P(a, b)$ is an $A$-indexed
+family of sets, so we can commute truncation past it via projectivity of $A$.
+Moreover, each $B(a)$ is also projective, so we can further commute truncations
+past the $B(a)$.
+
+```agda
+Σ-set-projective
+  : ∀ {A : Type ℓ} {B : A → Type ℓ'}
+  → is-set-projective A (ℓ' ⊔ ℓ'')
+  → (∀ a → is-set-projective (B a) ℓ'')
+  → is-set-projective (Σ[ a ∈ A ] B a) ℓ''
+Σ-set-projective {A = A} {B = B} A-pro B-pro P P-set ∥P∥ = do
+  ∥-∥-map uncurry $
+    A-pro (λ a → ((b : B a) → P (a , b))) (λ a → Π-is-hlevel 2 λ b → P-set (a , b)) λ a →
+    B-pro a (λ b → P (a , b)) (λ b → P-set (a , b)) λ b → ∥P∥ (a , b)
+```
+
+Moreover, set-projective types are stable under retracts. Suppose that
+we have $f : A \to B, g : B \to A$ with $f \circ g = id$ and $A$ set-projective,
+and let $P : B \to \set$ be a family of merely inhabited sets. We can
+precompose $P$ with $f$ to obtain an $A$-indexed family of sets whose
+product $\Pi (a : A) \to P(f(a))$ must be inhabited via projectivity of $A$.
+Moreover, we can precompose again with $g$ to see that $\Pi (b : B) \to P(f(g(b)))$
+is merely inhabited. Finally, $f(g(b)) = b$, so $\Pi (b : B) \to P(b)$ is
+merely inhabited.
+
+```agda
+retract→set-projective
+  : ∀ {A : Type ℓ} {B : Type ℓ'}
+  → (f : A → B) (g : B → A)
+  → is-left-inverse f g
+  → is-set-projective A ℓ''
+  → is-set-projective B ℓ''
+retract→set-projective {A = A} {B = B} f g retract A-pro P P-set ∥P∥ =
+  ∥-∥-map (λ k b → subst P (retract b) (k (g b)))
+    (A-pro (P ∘ f) (P-set ∘ f) (∥P∥ ∘ f))
+```
+
+This gives us a nice proof that set-projectivity is stable under equivalence.
+
+```agda
+Equiv→set-projective
+  : ∀ {A : Type ℓ} {B : Type ℓ'}
+  → A ≃ B
+  → is-set-projective A ℓ''
+  → is-set-projective B ℓ''
+Equiv→set-projective f A-pro =
+  retract→set-projective (Equiv.to f) (Equiv.from f) (Equiv.ε f) A-pro
+```
+
+By the theorem of [[finite choice]], finite sets are projective.
+
+```agda
+Fin-set-projective : ∀ {n} → is-set-projective (Fin n) ℓ
+Fin-set-projective {n = n} P P-set ∥P∥ = finite-choice n ∥P∥
+
+finite→set-projective
+  : {A : Type ℓ}
+  → Finite A
+  → is-set-projective A ℓ'
+finite→set-projective finite =
+  rec! (λ enum → Equiv→set-projective (enum e⁻¹) Fin-set-projective)
+    (Finite.enumeration finite)
+```
+
+## Taboos
+
+As it turns out, the finite types are the *only* types that are projective
+constructively! The general sketch of the taboo is that it is consistent that:
+
+1. Propositions are projective.
+2. Every infinite set admits an injection from `Nat`{.Agda}. In other
+  words, every infinite set is Dedekind-infinite.
+3. Countable choice fails (IE: the natural numbers are not set-projective).
+
+The existence of such a model is out of scope for this page, so we will
+focus our attention on the internal portion of the argument. In particular,
+we will prove that under assumptions (1), the existence of an
+Dedekind-infinite set-projective type implies countable choice.
+
+First, note that if propositions are set-projective, then the [[image]] of
+every function into a set-projective type is itself set-projective. This
+follows directly from the definition of images, along with closure of
+projectives under `Σ`{.Agda}.
+
+```agda
+module _
+  (props-projective : ∀ {ℓ ℓ'} → (A : Type ℓ) → is-prop A → is-set-projective A ℓ')
+  where
+
+  props-projective→image-projective
+    : ∀ {A : Type ℓ} {B : Type ℓ'}
+    → (f : A → B)
+    → is-set-projective B (ℓ ⊔ ℓ' ⊔ ℓ'')
+    → is-set-projective (image f) ℓ''
+  props-projective→image-projective f B-pro =
+    Σ-set-projective B-pro λ b → props-projective _ (hlevel 1)
+```
+
+This in turn implies that set-projective types are stable under embeddings,
+as the image of an [[embedding]] $f : A \mono B$ is equivalent to $A$.
+
+```agda
+  props-projective+is-embedding→set-projective
+    : ∀ {A : Type ℓ} {B : Type ℓ'} {f : A → B}
+    → is-embedding f
+    → is-set-projective B (ℓ ⊔ ℓ' ⊔ ℓ'')
+    → is-set-projective A ℓ''
+  props-projective+is-embedding→set-projective {f = f} f-emb B-pro =
+    Equiv→set-projective
+      (is-embedding→image-equiv f-emb e⁻¹)
+      (props-projective→image-projective f B-pro)
+```
+
+If we specialise this result to embeddings $Nat \mono A$, then we
+obtain countable choice from the existence of a Dedekind-infinite type.
+
+```agda
+  props-projective+dedekind-infinite-projective→countable-choice
+    : ∀ {A : Type ℓ} {f : Nat → A}
+    → is-embedding f
+    → is-set-projective A (ℓ ⊔ ℓ')
+    → is-set-projective Nat ℓ'
+  props-projective+dedekind-infinite-projective→countable-choice =
+    props-projective+is-embedding→set-projective
+```
+
+Note that the projectivity of propositions is itself a taboo: in particular,
+every proposition is set-projective if and only if every set has split support.
+The following proof is adapted from [@Kraus-Escardó-Coquand-Altenkirch:2016].
+
+We will start with the reverse direction. Suppose that every proposition
+is set projective, and let $A$ be a set. The truncation of $A$ is a propositon,
+and the constant family $\| A \| \to A$ is a set-indexed family, so projectivity
+of $\| A \|$ directly gives us split support.
+
+```agda
+props-projective→split-support
+  : ∀ {ℓ}
+  → ((A : Type ℓ) → is-prop A → is-set-projective A ℓ)
+  → ∀ (A : Type ℓ) → is-set A → ∥ (∥ A ∥ → A) ∥
+props-projective→split-support props-projective A A-set =
+  props-projective ∥ A ∥ (hlevel 1) (λ _ → A) (λ _ → A-set) id
+```
+
+For the forward direction, suppose that every set has split support,
+let $A$ be a proposition, and $P : A \to \set$ a family of merely inhabited
+sets. Note that the type $\Sigma A P$ is a set, so it must have split
+support $s : \| \| \Sigma A P \| \to \Sigma A P \|$. Moreover, $P(a)$
+is always merely inhabited, so we can readily show that $\| A \to \Sigma A P\|$.
+Finally, $A$ is a proposition, so we can obtain a $P(a)$ from $\Sigma A P$
+for any $a : A$; if we combine this with our previous observation, we
+immediately get $\| (a : A) \to P(a) \|$.
+
+```agda
+split-support→props-projective
+  : ∀ {ℓ}
+  → (∀ (A : Type ℓ) → is-set A → ∥ (∥ A ∥ → A) ∥)
+  → (A : Type ℓ) → is-prop A → is-set-projective A ℓ
+split-support→props-projective split-support A A-prop P P-set ∥P∥ = do
+  s ← split-support (Σ[ a ∈ A ] P a) (Σ-is-hlevel 2 (is-prop→is-set A-prop) P-set)
+  pure λ a → subst P (A-prop _ _) (snd (s (∥-∥-map (λ p → (a , p)) (∥P∥ a))))
+```

--- a/src/Data/Set/Surjection.lagda.md
+++ b/src/Data/Set/Surjection.lagda.md
@@ -81,6 +81,17 @@ surjectivity out of the way, we get what we wanted.
       (surj a)
 ```
 
+<!--
+```agda
+surjective→epi
+  : ∀ {ℓ} (c d : n-Type ℓ 2) (f : ∣ c ∣ → ∣ d ∣)
+  → is-surjective f
+  → Cr.is-epic (Sets ℓ) {c} {d} f
+surjective→epi c d f surj {c = x} =
+  is-regular-epi→is-epic (surjective→regular-epi c d f surj) {c = x}
+```
+-->
+
 # Epis are surjective {defines="epis-are-surjective"}
 
 Now _this_ is the hard direction. Our proof follows [@Rijke:2015, §2.9],

--- a/src/Data/Set/Surjection.lagda.md
+++ b/src/Data/Set/Surjection.lagda.md
@@ -2,6 +2,7 @@
 ```agda
 open import Cat.Diagram.Coequaliser.RegularEpi
 open import Cat.Diagram.Coequaliser
+open import Cat.Morphism.StrongEpi
 open import Cat.Prelude
 
 open import Homotopy.Connectedness
@@ -83,6 +84,14 @@ surjectivity out of the way, we get what we wanted.
 
 <!--
 ```agda
+surjective→strong-epi
+  : ∀ {ℓ} (c d : n-Type ℓ 2) (f : ∣ c ∣ → ∣ d ∣)
+  → is-surjective f
+  → is-strong-epi (Sets ℓ) {c} {d} f
+surjective→strong-epi c d f f-surj =
+  is-regular-epi→is-strong-epi (Sets _) f $
+  surjective→regular-epi c d f f-surj
+
 surjective→epi
   : ∀ {ℓ} (c d : n-Type ℓ 2) (f : ∣ c ∣ → ∣ d ∣)
   → is-surjective f

--- a/src/Data/Set/Surjection.lagda.md
+++ b/src/Data/Set/Surjection.lagda.md
@@ -33,7 +33,7 @@ together, we get _every epimorphism is regular_ as a corollary.
 [regular epimorphisms]: Cat.Diagram.Coequaliser.RegularEpi.html#regular-epimorphisms
 [epimorphism]: Cat.Morphism.html#epis
 
-## Surjections are epic
+## Surjections are epic {defines="surjections-are-epic"}
 
 This is the straightforward direction: We know (since $\Sets$ has
 pullbacks) that if a morphism is going to be a regular epimorphism, then
@@ -81,7 +81,7 @@ surjectivity out of the way, we get what we wanted.
       (surj a)
 ```
 
-# Epis are surjective
+# Epis are surjective {defines="epis-are-surjective"}
 
 Now _this_ is the hard direction. Our proof follows [@Rijke:2015, §2.9],
 so if the exposition below doesn't make a lot of sense, be sure to check

--- a/src/bibliography.bibtex
+++ b/src/bibliography.bibtex
@@ -265,3 +265,10 @@
       primaryClass={math.CT},
       url={https://arxiv.org/abs/1801.06488},
 }
+
+@article{Kraus-Escardó-Coquand-Altenkirch:2016,
+  title={Notions of Anonymous Existence in Martin-Löf Type Theory},
+  journal={Log. Methods Comput. Sci.}, author={Kraus, Nicolai and Escardó, M. and Coquand, T. and Altenkirch, Thorsten},
+  year={2016},
+  language={en}
+}


### PR DESCRIPTION
# Description

This PR defines projective objects, and proves a bunch of properties about them. It also defines set-projective types, and shows that projectivity of propositions + a set-projective dedekind type implies countable choice. This closes #420.

## Checklist

Before submitting a merge request, please check the items below:

- [x] I've read [the contributing guidelines](https://github.com/plt-amy/1lab/blob/main/CONTRIBUTING.md).
- [x] The imports of new modules have been sorted with `support/sort-imports.hs` (or `nix run --experimental-features nix-command -f . sort-imports`).
- [x] All new code blocks have "agda" as their language.

If your change affects many files without adding substantial content, and
you don't want your name to appear on those pages (for example, treewide
refactorings or reformattings), start the commit message and PR title with `chore:`.
