### PR TITLE
parametrised re-exports for display forms

### DIFF
--- a/src/Cat/Abelian/Base.lagda.md
+++ b/src/Cat/Abelian/Base.lagda.md
@@ -60,11 +60,11 @@ record Ab-category {o ℓ} (C : Precategory o ℓ) : Type (o ⊔ lsuc ℓ) where
   field
     Abelian-group-on-hom : ∀ A B → Abelian-group-on (Hom A B)
 
-  _+_ : ∀ {A B} (f g : Hom A B) → Hom A B
-  f + g = Abelian-group-on-hom _ _ .Abelian-group-on._*_ f g
-
-  0m : ∀ {A B} → Hom A B
-  0m = Abelian-group-on-hom _ _ .Abelian-group-on.1g
+  module Hom {A B} = Abelian-group-on (Abelian-group-on-hom A B) renaming (_⁻¹ to inverse)
+  open Hom
+    using (zero-diff)
+    renaming (_—_ to _-_ ; _*_ to _+_ ; 1g to 0m)
+    public
 
   Hom-grp : ∀ A B → Abelian-group ℓ
   Hom-grp A B = (el (Hom A B) (Hom-set A B)) , Abelian-group-on-hom A B
@@ -85,12 +85,6 @@ record Ab-category {o ℓ} (C : Precategory o ℓ) : Type (o ⊔ lsuc ℓ) where
               ; pres-*l = λ x y z → sym (∘-linear-l x y z)
               ; pres-*r = λ x y z → sym (∘-linear-r x y z)
               })
-
-  module Hom {A B} = Abelian-group-on (Abelian-group-on-hom A B) renaming (_⁻¹ to inverse)
-  open Hom
-    using (zero-diff)
-    renaming (_—_ to _-_)
-    public
 ```
 
 <details>

--- a/src/Cat/Abelian/Base.lagda.md
+++ b/src/Cat/Abelian/Base.lagda.md
@@ -250,7 +250,7 @@ comultiplication.
     open Coproduct
     open is-coproduct
     coprod : Coproduct C A B
-    coprod .coapex = apex
+    coprod .coapex = A ⊗₀ B
     coprod .ι₁ = ⟨ id , 0m ⟩
     coprod .ι₂ = ⟨ 0m , id ⟩
     coprod .has-is-coproduct .[_,_] f g = f ∘ π₁ + g ∘ π₂

--- a/src/Cat/Diagram/Coproduct.lagda.md
+++ b/src/Cat/Diagram/Coproduct.lagda.md
@@ -127,17 +127,11 @@ has-coproducts = ∀ a b → Coproduct a b
 
 module Binary-coproducts (all-coproducts : has-coproducts) where
 
-  module coproduct {a} {b} = Coproduct (all-coproducts a b)
-
-  open coproduct renaming
-    (unique to []-unique) public
+  module _ {a b} where open Coproduct (all-coproducts a b) renaming (unique to []-unique) hiding (coapex) public
+  module _ a b where open Coproduct (all-coproducts a b) renaming (coapex to infixr 7 _⊕₀_) using () public
   open Functor
 
-  infixr 7 _⊕₀_
   infix 50 _⊕₁_
-
-  _⊕₀_ : Ob → Ob → Ob
-  a ⊕₀ b = coproduct.coapex {a} {b}
 
   _⊕₁_ : ∀ {a b x y} → Hom a x → Hom b y → Hom (a ⊕₀ b) (x ⊕₀ y)
   f ⊕₁ g = [ ι₁ ∘ f , ι₂ ∘ g ]

--- a/src/Cat/Diagram/Product.lagda.md
+++ b/src/Cat/Diagram/Product.lagda.md
@@ -235,29 +235,31 @@ has-products : ∀ {o ℓ} → Precategory o ℓ → Type _
 has-products C = ∀ a b → Product C a b
 
 module Binary-products
-  {o ℓ}
-  (C : Precategory o ℓ)
-  (all-products : has-products C)
-  where
+  {o ℓ} (C : Precategory o ℓ) (all-products : has-products C) where
+```
+
+<!--
+```agda
   open Cat.Reasoning C
   private variable
     A B a b c d : Ob
 
-  module product {a} {b} = Product (all-products a b)
-
-  open product renaming
-    (unique to ⟨⟩-unique) public
+  -- Note: here and below we have to open public the aliases in a module
+  -- with parameters so Agda picks up the display forms.
+  module _ {a b} where open Product (all-products a b) renaming (unique to ⟨⟩-unique) hiding (apex) public
   open Functor
 
-  infixr 7 _⊗₀_
   infix 50 _⊗₁_
 ```
+-->
 
 We start by defining a "global" product-assigning operation.
 
 ```agda
-  _⊗₀_ : Ob → Ob → Ob
-  a ⊗₀ b = product.apex {a} {b}
+  module _ a b where
+    open Product (all-products a b)
+      renaming (apex to infixr 7 _⊗₀_)
+      using () public
 ```
 
 This operation extends to a bifunctor $\cC \times \cC \to \cC$.

--- a/src/Order/DCPO.lagda.md
+++ b/src/Order/DCPO.lagda.md
@@ -237,7 +237,7 @@ module DCPOs {o ℓ : Level} = Cat.Reasoning (DCPOs o ℓ)
 DCPO : (o ℓ : Level) → Type _
 DCPO o ℓ = DCPOs.Ob {o} {ℓ}
 
-DCPOs↪Posets : ∀ {o ℓ} → Functor (DCPOs o ℓ) (Posets o ℓ) 
+DCPOs↪Posets : ∀ {o ℓ} → Functor (DCPOs o ℓ) (Posets o ℓ)
 DCPOs↪Posets = Forget-subcat
 
 DCPOs↪Sets : ∀ {o ℓ} → Functor (DCPOs o ℓ) (Sets o)
@@ -261,7 +261,7 @@ module DCPO {o ℓ} (D : DCPO o ℓ) where
   poset : Poset o ℓ
   poset = D .fst
 
-  open Order.Reasoning poset public
+  open Order.Reasoning (D .fst) public
 
   set : Set o
   set = el ⌞ D ⌟ Ob-is-set
@@ -269,7 +269,7 @@ module DCPO {o ℓ} (D : DCPO o ℓ) where
   has-dcpo : is-dcpo poset
   has-dcpo = D .snd
 
-  open is-dcpo has-dcpo public
+  open is-dcpo (D .snd) public
 
   ⋃-pointwise
     : ∀ {Ix} {s s' : Ix → Ob}


### PR DESCRIPTION
Supercedes #417. After the display form fix, as long as we re-export the renamings from a parametrised module, we can get the display forms to fire reliably. With this change, the type of Cartesian monoidal `pentagon` displays as

```
⟨ ⟨ ⟨ π₁ , π₁ ∘ π₂ ⟩ , π₂ ∘ π₂ ⟩ ∘ π₁ , id ∘ π₂ ⟩ ∘
      ⟨ ⟨ π₁ , π₁ ∘ π₂ ⟩ , π₂ ∘ π₂ ⟩ ∘
      ⟨ id ∘ π₁ , ⟨ ⟨ π₁ , π₁ ∘ π₂ ⟩ , π₂ ∘ π₂ ⟩ ∘ π₂ ⟩
      ≡ ⟨ ⟨ π₁ , π₁ ∘ π₂ ⟩ , π₂ ∘ π₂ ⟩ ∘ ⟨ ⟨ π₁ , π₁ ∘ π₂ ⟩ , π₂ ∘ π₂ ⟩
```

which is still a handful but is miles better what we had before. (actually, the display forms for `π₁` and `⟨_,_⟩` are already okay, but we need this change for `⊗₀`).