### PR TITLE
chore: make `Dec-→` incoherent

### DIFF
--- a/src/Data/Dec/Base.lagda.md
+++ b/src/Data/Dec/Base.lagda.md
@@ -153,6 +153,7 @@ instance
   Dec-→ {Q = _} ⦃ yes p ⦄ ⦃ yes q ⦄ = yes λ _ → q
   Dec-→ {Q = _} ⦃ yes p ⦄ ⦃ no ¬q ⦄ = no λ pq → ¬q (pq p)
   Dec-→ {Q = _} ⦃ no ¬p ⦄ ⦃ q ⦄ = yes λ p → absurd (¬p p)
+  {-# INCOHERENT Dec-→ #-}
 
   Dec-⊤ : Dec ⊤
   Dec-⊤ = yes tt


### PR DESCRIPTION
It overlaps with `Dec-Fin-∀`. Fixes:

```agda
open import 1Lab.Type
open import Data.Dec.Base
open import Data.Fin.Base
open import Data.Fin.Properties

wtf : Dec ((i : Fin 1) → ⊤)
wtf = auto
```