### PR TITLE
Two-sided fibrations

### DIFF
--- a/src/Cat/Displayed/Cartesian/Discrete.lagda.md
+++ b/src/Cat/Displayed/Cartesian/Discrete.lagda.md
@@ -29,7 +29,7 @@ open is-cartesian
 ```
 -->
 
-# Discrete fibrations
+# Discrete fibrations {defines="discrete-fibration"}
 
 A **discrete fibration** is a [[displayed category]] whose [[fibre
 categories]] are all _discrete categories_: thin, univalent groupoids.

--- a/src/Cat/Displayed/Cartesian/Discrete.lagda.md
+++ b/src/Cat/Displayed/Cartesian/Discrete.lagda.md
@@ -203,7 +203,7 @@ that every vertical morphism in a discrete fibration is invertible.
       x''≡x' = ap fst (discrete→vertical-id disc (x' , f'))
 ```
 
-## Discrete fibrations are presheaves
+## Discrete fibrations are presheaves {defines="discrete-fibrations-are-presheaves"}
 
 As noted earlier, a discrete fibration over $\cB$ encodes the same
 data as a presheaf on $\cB$. First, let us show that we can construct

--- a/src/Cat/Displayed/Cocartesian.lagda.md
+++ b/src/Cat/Displayed/Cocartesian.lagda.md
@@ -384,7 +384,7 @@ cocartesian→precompose-equiv cocart =
 ```
 
 
-## Cocartesian lifts
+## Cocartesian lifts {defines="cocartesian-lift"}
 
 We call an object $b'$ over $b$ together with a cartesian arrow
 $f' : a \to_{f} b'$ a **cocartesian lift** of $f$.

--- a/src/Cat/Displayed/Instances/Comma.lagda.md
+++ b/src/Cat/Displayed/Instances/Comma.lagda.md
@@ -1,0 +1,190 @@
+---
+description: |
+  Comma categories as two-sided displayed categories.
+---
+<!--
+```agda
+open import Cat.Displayed.TwoSided.Discrete
+open import Cat.Displayed.Cocartesian
+open import Cat.Displayed.Cartesian
+open import Cat.Instances.Product
+open import Cat.Displayed.Base
+open import Cat.Prelude
+
+import Cat.Functor.Reasoning
+import Cat.Reasoning
+```
+-->
+```agda
+module Cat.Displayed.Instances.Comma where
+```
+
+# Comma categories as displayed categories
+
+We can neatly present [[comma categories]] as categories displayed over
+product categories.
+
+<!--
+```agda
+module _
+  {oa ℓa ob ℓb oc ℓc}
+  {A : Precategory oa ℓa}
+  {B : Precategory ob ℓb}
+  {C : Precategory oc ℓc}
+  (F : Functor A C)
+  (G : Functor B C)
+  where
+  private
+    module A = Cat.Reasoning A
+    module B = Cat.Reasoning B
+    module C = Cat.Reasoning C
+    module F = Cat.Functor.Reasoning F
+    module G = Cat.Functor.Reasoning G
+
+  open Displayed
+```
+-->
+
+```agda
+  Comma : Displayed (A ×ᶜ B) ℓc ℓc
+  Comma .Ob[_] (a , b) = C.Hom (F.₀ a) (G.₀ b)
+  Comma .Hom[_] (u , v) f g = G.₁ v C.∘ f ≡ g C.∘ F.₁ u
+  Comma .Hom[_]-set _ _ _ = hlevel 2
+  Comma .id' = C.eliml G.F-id ∙ C.intror F.F-id
+  Comma ._∘'_ α β = G.popr β ∙ sym (F.shufflel (sym α))
+  Comma .idr' _ = prop!
+  Comma .idl' _ = prop!
+  Comma .assoc' _ _ _ = prop!
+```
+
+## Comma categories are discrete two-sided fibrations
+
+<!--
+```agda
+module _
+  {oa ℓa ob ℓb oc ℓc}
+  {A : Precategory oa ℓa}
+  {B : Precategory ob ℓb}
+  {C : Precategory oc ℓc}
+  {F : Functor A C}
+  {G : Functor B C}
+  where
+  private
+    module A = Cat.Reasoning A
+    module B = Cat.Reasoning B
+    module C = Cat.Reasoning C
+    module F = Cat.Functor.Reasoning F
+    module G = Cat.Functor.Reasoning G
+
+  open is-discrete-two-sided-fibration
+  open Displayed
+```
+-->
+
+Comma categories are [[discrete two-sided fibrations]].
+
+```agda
+  Comma-is-discrete-two-sided-fibration
+    : is-discrete-two-sided-fibration (Comma F G)
+  Comma-is-discrete-two-sided-fibration .fibre-set _ _ = hlevel 2
+  Comma-is-discrete-two-sided-fibration .cart-lift f g .centre =
+    g C.∘ F.₁ f , C.eliml G.F-id
+  Comma-is-discrete-two-sided-fibration .cart-lift f g .paths (h , p) =
+    Σ-prop-path! (sym p ∙ C.eliml G.F-id)
+  Comma-is-discrete-two-sided-fibration .cocart-lift f g .centre =
+    G.₁ f C.∘ g , C.intror F.F-id
+  Comma-is-discrete-two-sided-fibration .cocart-lift f g .paths (h , p) =
+    Σ-prop-path! (p ∙ C.elimr F.F-id)
+  Comma-is-discrete-two-sided-fibration .vert-lift {x = f} {y = g} {u = h} {v = k} p =
+    G.F₁ B.id C.∘ G.F₁ k C.∘ f   ≡⟨ C.eliml G.F-id ⟩
+    G.F₁ k C.∘ f                 ≡⟨ p ⟩
+    g C.∘ F.₁ h                  ≡⟨ C.intror F.F-id ⟩
+    (g C.∘ F.F₁ h) C.∘ F.F₁ A.id ∎
+  Comma-is-discrete-two-sided-fibration .factors _ = prop!
+```
+
+Every $B$-vertical morphism in a discrete two-sided fibration is [[cartesian|cartesian-morphism]],
+but this is not neccesarily true of *every* morphism. For instance, cartesian
+maps in comma categories are precisely squares that satisfy the following
+pasting property: for every (potentially non-commuting) square of the below
+form, if the outer square commutes, then the upper square commutes.
+
+~~~{.quiver}
+\begin{tikzcd}
+  F(A) && G(Y) \\
+  \\
+  F(W) && G(Y) \\
+  \\
+  F(X) && G(Z)
+  \arrow["h", from=1-1, to=1-3]
+  \arrow["F(j)"', from=1-1, to=3-1]
+  \arrow["G(k)", from=1-3, to=3-3]
+  \arrow["f", from=3-1, to=3-3]
+  \arrow["F(u)"', from=3-1, to=5-1]
+  \arrow["G(v)", from=3-3, to=5-3]
+  \arrow["g"', from=5-1, to=5-3]
+\end{tikzcd}
+~~~
+
+```agda
+  pasting→comma-cartesian
+    : ∀ {w x y z} {u : A.Hom w x} {v : B.Hom y z} {f : C.Hom (F.₀ w) (G.₀ y)} {g : C.Hom (F.₀ x) (G.₀ z)}
+    → (p : G.₁ v C.∘ f ≡ g C.∘ F.₁ u)
+    → (∀ {a b} {h : C.Hom (F.₀ a) (G.₀ b)} {j : A.Hom a w} {k : B.Hom b y}
+       → G.₁ v C.∘ G.₁ k C.∘ h ≡ g C.∘ F.₁ u C.∘ F.₁ j
+       → G.₁ k C.∘ h ≡ f C.∘ F.₁ j)
+    → is-cartesian (Comma F G) (u , v) p
+  pasting→comma-cartesian p paste .is-cartesian.universal _ outer =
+    paste (C.pulll (sym $ G.F-∘ _ _) ·· outer ·· ap₂ C._∘_ refl (F.F-∘ _ _))
+  pasting→comma-cartesian p paste .is-cartesian.commutes _ _ = prop!
+  pasting→comma-cartesian p paste .is-cartesian.unique _ _ = prop!
+
+  comma-cartesian→pasting
+    : ∀ {w x y z} {u : A.Hom w x} {v : B.Hom y z} {f : C.Hom (F.₀ w) (G.₀ y)} {g : C.Hom (F.₀ x) (G.₀ z)}
+    → (p : G.₁ v C.∘ f ≡ g C.∘ F.₁ u)
+    → is-cartesian (Comma F G) (u , v) p
+    → ∀ {a b} {h : C.Hom (F.₀ a) (G.₀ b)} {j : A.Hom a w} {k : B.Hom b y}
+       → G.₁ v C.∘ G.₁ k C.∘ h ≡ g C.∘ F.₁ u C.∘ F.₁ j
+       → G.₁ k C.∘ h ≡ f C.∘ F.₁ j
+  comma-cartesian→pasting p p-cart outer =
+    is-cartesian.universal p-cart _ $
+      C.pushl (G.F-∘ _ _) ·· outer ·· ap₂ C._∘_ refl (sym $ F.F-∘ _ _)
+```
+
+Moreover, a square is [[cocartesian|cocartesian-morphism]] when it satisfies
+the dual pasting lemma.
+
+```agda
+  pasting→comma-cocartesian
+    : ∀ {w x y z} {u : A.Hom w x} {v : B.Hom y z} {f : C.Hom (F.₀ w) (G.₀ y)} {g : C.Hom (F.₀ x) (G.₀ z)}
+    → (p : G.₁ v C.∘ f ≡ g C.∘ F.₁ u)
+    → (∀ {a b} {h : C.Hom (F.₀ a) (G.₀ b)} {j : A.Hom x a} {k : B.Hom z b}
+        → G.₁ k C.∘ G.₁ v C.∘ f ≡ h C.∘ F.₁ j C.∘ F.₁ u
+        → G.₁ k C.∘ g ≡ h C.∘ F.₁ j)
+    → is-cocartesian (Comma F G) (u , v) p
+
+  comma-cocartesian→pasting
+    : ∀ {w x y z} {u : A.Hom w x} {v : B.Hom y z} {f : C.Hom (F.₀ w) (G.₀ y)} {g : C.Hom (F.₀ x) (G.₀ z)}
+    → (p : G.₁ v C.∘ f ≡ g C.∘ F.₁ u)
+    → is-cocartesian (Comma F G) (u , v) p
+    → ∀ {a b} {h : C.Hom (F.₀ a) (G.₀ b)} {j : A.Hom x a} {k : B.Hom z b}
+        → G.₁ k C.∘ G.₁ v C.∘ f ≡ h C.∘ F.₁ j C.∘ F.₁ u
+        → G.₁ k C.∘ g ≡ h C.∘ F.₁ j
+
+```
+
+<details>
+<summary>The proofs are formally dual, so we omit them.
+</summary>
+
+```agda
+  pasting→comma-cocartesian p paste .is-cocartesian.universal _ outer =
+    paste (C.pulll (sym $ G.F-∘ _ _) ·· outer ·· ap₂ C._∘_ refl (F.F-∘ _ _))
+  pasting→comma-cocartesian p paste .is-cocartesian.commutes _ _ = prop!
+  pasting→comma-cocartesian p paste .is-cocartesian.unique _ _ = prop!
+
+  comma-cocartesian→pasting p p-cocart outer =
+    is-cocartesian.universal p-cocart _ $
+      C.pushl (G.F-∘ _ _) ·· outer ·· ap₂ C._∘_ refl (sym $ F.F-∘ _ _)
+```
+</details>

--- a/src/Cat/Displayed/Instances/Comma.lagda.md
+++ b/src/Cat/Displayed/Instances/Comma.lagda.md
@@ -103,11 +103,11 @@ Comma categories are [[discrete two-sided fibrations]].
   Comma-is-discrete-two-sided-fibration .factors _ = prop!
 ```
 
-Every $B$-vertical morphism in a discrete two-sided fibration is [[cartesian|cartesian-morphism]],
-but this is not neccesarily true of *every* morphism. For instance, cartesian
-maps in comma categories are precisely squares that satisfy the following
-pasting property: for every (potentially non-commuting) square of the below
-form, if the outer square commutes, then the upper square commutes.
+Every *$B$-vertical* morphism in a discrete two-sided fibration is [[cartesian|cartesian morphism]],
+but this is not neccesarily true of *every* morphism. In our setting,
+the cartesian maps are given by squares that satisfy the following
+pasting property: for every (potentially non-commutative) square of the below
+form, if the overall rectangle commutes, then the upper square commutes.
 
 ~~~{.quiver}
 \begin{tikzcd}

--- a/src/Cat/Displayed/TwoSided.lagda.md
+++ b/src/Cat/Displayed/TwoSided.lagda.md
@@ -93,7 +93,7 @@ $h$ is cartesian if and only if $k$ is cocartesian.
         → Cocartesian-lift E (A.id , v) x'
       cocartesian-stable
         : ∀ {a₁ a₂ : A.Ob} {b₁ b₂ : B.Ob}
-        → (u : A.Hom a₁ a₂) (v : B.Hom b₁ b₂)
+        → {u : A.Hom a₁ a₂} {v : B.Hom b₁ b₂}
         → {w' : Ob[ a₁ , b₁ ]} {x' : Ob[ a₂ , b₁ ]} {y' : Ob[ a₁ , b₂ ]} {z' : Ob[ a₂ , b₂ ]}
         → {f : Hom[ A.id , v ] x' z'} {g : Hom[ u , B.id ] w' x'}
         → {h : Hom[ u , B.id ] y' z'} {k : Hom[ A.id , v ] w' y'}
@@ -104,7 +104,7 @@ $h$ is cartesian if and only if $k$ is cocartesian.
         → is-cocartesian E (A.id , v) k
       cartesian-stable
         : ∀ {a₁ a₂ : A.Ob} {b₁ b₂ : B.Ob}
-        → (u : A.Hom a₁ a₂) (v : B.Hom b₁ b₂)
+        → {u : A.Hom a₁ a₂} {v : B.Hom b₁ b₂}
         → {w' : Ob[ a₁ , b₁ ]} {x' : Ob[ a₂ , b₁ ]} {y' : Ob[ a₁ , b₂ ]} {z' : Ob[ a₂ , b₂ ]}
         → {f : Hom[ A.id , v ] x' z'} {g : Hom[ u , B.id ] w' x'}
         → {h : Hom[ u , B.id ] y' z'} {k : Hom[ A.id , v ] w' y'}

--- a/src/Cat/Displayed/TwoSided.lagda.md
+++ b/src/Cat/Displayed/TwoSided.lagda.md
@@ -46,12 +46,12 @@ A displayed category $\cE \liesover \cA \times \cB$ is a **two-sided fibration**
 when it satisfies the following 3 conditions:
 
 1. For every $u : \cA(A_1, A_2)$, $B : \cB$ and $Y : \cE_{A_2, B}$, there
-exists a [[cartesian lift]] $u^{*} : \cE_{u, \id}(u^{*}(Y), Y)$.
+exists a [[cartesian lift]] $\pi_{u, Y} : \cE_{u, \id}(u^{*}(Y), Y)$.
 
 2. For every $A : \cA, v : \cB(B_1, B_2)$ and $X : \cE_{A, B_1}$, there
-exists a [[cocartesian lift]] $v_{!} : \cE_{\id, v}(X, v_{!}(X))$.
+exists a [[cocartesian lift]] $\iota_{v, X} : \cE_{\id, v}(X, v_{!}(X))$.
 
-3. For every a diagram of the form below with $f$ cocartesian and $g$ cartesian,
+3. For every diagram of the form below with $f$ cocartesian and $g$ cartesian,
 $h$ is cartesian if and only if $k$ is cocartesian.
 
 ~~~{.quiver}
@@ -119,7 +119,7 @@ This definition is rather opaque, so let's break it down. The first two
 conditions ensure that we have 2 functorial actions on each of the [[fibre categories]]
 $E_{a, b}$: the first acts contravariantly in $\cA$, the second covariantly
 in $\cB$. This is analogous to the actions $P(-, \id)$ and $P(\id, -)$ for
-a profunctor $P : \cA \times \cB \to \Sets$. The final condition servers to
+a profunctor $P : \cA \times \cB \to \Sets$. The final condition serves to
 ensure that the [[base change]] and [[cobase change]] functors
-$u^{*} : \cE_{A_2, B} \to \cE_{A_1, B}$ and $v_{!} : \cE_{A, B_1} \to \cE{A, B_2}$
+$u^{*} : \cE_{A_2, B} \to \cE_{A_1, B}$ and $v_{!} : \cE_{A, B_1} \to \cE_{A, B_2}$
 preserve cocartesian and cartesian morphisms, resp.

--- a/src/Cat/Displayed/TwoSided.lagda.md
+++ b/src/Cat/Displayed/TwoSided.lagda.md
@@ -91,28 +91,15 @@ $h$ is cartesian if and only if $k$ is cocartesian.
         → (v : B.Hom b₁ b₂)
         → (x' : Ob[ a , b₁ ])
         → Cocartesian-lift E (A.id , v) x'
-      cocartesian-stable
+      cart-cocart-commute
         : ∀ {a₁ a₂ : A.Ob} {b₁ b₂ : B.Ob}
         → {u : A.Hom a₁ a₂} {v : B.Hom b₁ b₂}
         → {w' : Ob[ a₁ , b₁ ]} {x' : Ob[ a₂ , b₁ ]} {y' : Ob[ a₁ , b₂ ]} {z' : Ob[ a₂ , b₂ ]}
         → {f : Hom[ A.id , v ] x' z'} {g : Hom[ u , B.id ] w' x'}
         → {h : Hom[ u , B.id ] y' z'} {k : Hom[ A.id , v ] w' y'}
         → f ∘' g ≡[ sym A.id-comm ,ₚ B.id-comm ] h ∘' k
-        → is-cocartesian E (A.id , v) f
-        → is-cartesian E (u , B.id) g
-        → is-cartesian E (u , B.id) h
-        → is-cocartesian E (A.id , v) k
-      cartesian-stable
-        : ∀ {a₁ a₂ : A.Ob} {b₁ b₂ : B.Ob}
-        → {u : A.Hom a₁ a₂} {v : B.Hom b₁ b₂}
-        → {w' : Ob[ a₁ , b₁ ]} {x' : Ob[ a₂ , b₁ ]} {y' : Ob[ a₁ , b₂ ]} {z' : Ob[ a₂ , b₂ ]}
-        → {f : Hom[ A.id , v ] x' z'} {g : Hom[ u , B.id ] w' x'}
-        → {h : Hom[ u , B.id ] y' z'} {k : Hom[ A.id , v ] w' y'}
-        → f ∘' g ≡[ sym A.id-comm ,ₚ B.id-comm ] h ∘' k
-        → is-cocartesian E (A.id , v) f
-        → is-cartesian E (u , B.id) g
-        → is-cocartesian E (A.id , v) k
-        → is-cartesian E (u , B.id) h
+        → is-cocartesian E (A.id , v) f → is-cartesian E (u , B.id) g
+        → is-cartesian E (u , B.id) h ↔ is-cocartesian E (A.id , v) k
 ```
 
 This definition is rather opaque, so let's break it down. The first two

--- a/src/Cat/Displayed/TwoSided.lagda.md
+++ b/src/Cat/Displayed/TwoSided.lagda.md
@@ -1,0 +1,125 @@
+---
+description: |
+  Two-sided fibrations.
+---
+<!--
+```agda
+open import Cat.Displayed.Cocartesian
+open import Cat.Displayed.Cartesian
+open import Cat.Instances.Product
+open import Cat.Displayed.Base
+open import Cat.Prelude
+
+import Cat.Displayed.Reasoning
+import Cat.Displayed.Morphism
+import Cat.Reasoning
+```
+-->
+```agda
+module Cat.Displayed.TwoSided where
+```
+
+# Two-sided fibrations
+
+One useful perspective on [[cartesian fibrations]] and [[cocartesian fibrations]]
+is that they are (co)presheaves of categories. This raises a natural question: what
+is the appropriate generalization of profunctors?
+
+<!--
+```agda
+module _
+  {oa ℓa ob ℓb oe ℓe}
+  {A : Precategory oa ℓa} {B : Precategory ob ℓb}
+  (E : Displayed (A ×ᶜ B) oe ℓe)
+  where
+  private
+    module A = Cat.Reasoning A
+    module B = Cat.Reasoning B
+    open Cat.Displayed.Reasoning E
+    open Cat.Displayed.Morphism E
+    open Displayed E
+```
+-->
+
+:::{.definition #two-sided-fibration}
+A displayed category $\cE \liesover \cA \times \cB$ is a **two-sided fibration**
+when it satisfies the following 3 conditions:
+
+1. For every $u : \cA(A_1, A_2)$, $B : \cB$ and $Y : \cE_{A_2, B}$, there
+exists a [[cartesian lift]] $u^{*} : \cE_{u, \id}(u^{*}(Y), Y)$.
+
+2. For every $A : \cA, v : \cB(B_1, B_2)$ and $X : \cE_{A, B_1}$, there
+exists a [[cocartesian lift]] $v_{!} : \cE_{\id, v}(X, v_{!}(X))$.
+
+3. For every a diagram of the form below with $f$ cocartesian and $g$ cartesian,
+$h$ is cartesian if and only if $k$ is cocartesian.
+
+~~~{.quiver}
+\begin{tikzcd}
+  W && X \\
+  & Y && Z \\
+  {(A_1, B_1)} && {(A_2, B_1)} \\
+  & {(A_1, B_2)} && {(A_2, B_2)}
+  \arrow["g", from=1-1, to=1-3]
+  \arrow["k", from=1-1, to=2-2]
+  \arrow[from=1-1, to=3-1]
+  \arrow["f", from=1-3, to=2-4]
+  \arrow[from=1-3, to=3-3]
+  \arrow["h"{pos=0.3}, from=2-2, to=2-4]
+  \arrow[from=2-2, to=4-2]
+  \arrow[from=2-4, to=4-4]
+  \arrow["{(u,\id)}"{pos=0.7}, from=3-1, to=3-3]
+  \arrow["{(\id, v)}"', from=3-1, to=4-2]
+  \arrow["{(\id, v)}", from=3-3, to=4-4]
+  \arrow["{(u,\id)}"', from=4-2, to=4-4]
+\end{tikzcd}
+~~~
+:::
+
+
+```agda
+  record Two-sided-fibration : Type (oa ⊔ ℓa ⊔ ob ⊔ ℓb ⊔ oe ⊔ ℓe) where
+    no-eta-equality
+    field
+      cart-lift
+        : ∀ {a₁ a₂ : A.Ob} {b : B.Ob}
+        → (u : A.Hom a₁ a₂)
+        → (y' : Ob[ a₂ , b ])
+        → Cartesian-lift E (u , B.id) y'
+      cocart-lift
+        : ∀ {a : A.Ob} {b₁ b₂ : B.Ob}
+        → (v : B.Hom b₁ b₂)
+        → (x' : Ob[ a , b₁ ])
+        → Cocartesian-lift E (A.id , v) x'
+      cocartesian-stable
+        : ∀ {a₁ a₂ : A.Ob} {b₁ b₂ : B.Ob}
+        → (u : A.Hom a₁ a₂) (v : B.Hom b₁ b₂)
+        → {w' : Ob[ a₁ , b₁ ]} {x' : Ob[ a₂ , b₁ ]} {y' : Ob[ a₁ , b₂ ]} {z' : Ob[ a₂ , b₂ ]}
+        → {f : Hom[ A.id , v ] x' z'} {g : Hom[ u , B.id ] w' x'}
+        → {h : Hom[ u , B.id ] y' z'} {k : Hom[ A.id , v ] w' y'}
+        → f ∘' g ≡[ sym A.id-comm ,ₚ B.id-comm ] h ∘' k
+        → is-cocartesian E (A.id , v) f
+        → is-cartesian E (u , B.id) g
+        → is-cartesian E (u , B.id) h
+        → is-cocartesian E (A.id , v) k
+      cartesian-stable
+        : ∀ {a₁ a₂ : A.Ob} {b₁ b₂ : B.Ob}
+        → (u : A.Hom a₁ a₂) (v : B.Hom b₁ b₂)
+        → {w' : Ob[ a₁ , b₁ ]} {x' : Ob[ a₂ , b₁ ]} {y' : Ob[ a₁ , b₂ ]} {z' : Ob[ a₂ , b₂ ]}
+        → {f : Hom[ A.id , v ] x' z'} {g : Hom[ u , B.id ] w' x'}
+        → {h : Hom[ u , B.id ] y' z'} {k : Hom[ A.id , v ] w' y'}
+        → f ∘' g ≡[ sym A.id-comm ,ₚ B.id-comm ] h ∘' k
+        → is-cocartesian E (A.id , v) f
+        → is-cartesian E (u , B.id) g
+        → is-cocartesian E (A.id , v) k
+        → is-cartesian E (u , B.id) h
+```
+
+This definition is rather opaque, so let's break it down. The first two
+conditions ensure that we have 2 functorial actions on each of the [[fibre categories]]
+$E_{a, b}$: the first acts contravariantly in $\cA$, the second covariantly
+in $\cB$. This is analogous to the actions $P(-, \id)$ and $P(\id, -)$ for
+a profunctor $P : \cA \times \cB \to \Sets$. The final condition servers to
+ensure that the [[base change]] and [[cobase change]] functors
+$u^{*} : \cE_{A_2, B} \to \cE_{A_1, B}$ and $v_{!} : \cE_{A, B_1} \to \cE{A, B_2}$
+preserve cocartesian and cartesian morphisms, resp.

--- a/src/Cat/Displayed/TwoSided.lagda.md
+++ b/src/Cat/Displayed/TwoSided.lagda.md
@@ -4,6 +4,7 @@ description: |
 ---
 <!--
 ```agda
+open import Cat.Displayed.BeckChevalley
 open import Cat.Displayed.Cocartesian
 open import Cat.Displayed.Cartesian
 open import Cat.Instances.Product
@@ -91,15 +92,18 @@ $h$ is cartesian if and only if $k$ is cocartesian.
         → (v : B.Hom b₁ b₂)
         → (x' : Ob[ a , b₁ ])
         → Cocartesian-lift E (A.id , v) x'
-      cart-cocart-commute
+      cart-beck-chevalley
         : ∀ {a₁ a₂ : A.Ob} {b₁ b₂ : B.Ob}
         → {u : A.Hom a₁ a₂} {v : B.Hom b₁ b₂}
-        → {w' : Ob[ a₁ , b₁ ]} {x' : Ob[ a₂ , b₁ ]} {y' : Ob[ a₁ , b₂ ]} {z' : Ob[ a₂ , b₂ ]}
-        → {f : Hom[ A.id , v ] x' z'} {g : Hom[ u , B.id ] w' x'}
-        → {h : Hom[ u , B.id ] y' z'} {k : Hom[ A.id , v ] w' y'}
-        → f ∘' g ≡[ sym A.id-comm ,ₚ B.id-comm ] h ∘' k
-        → is-cocartesian E (A.id , v) f → is-cartesian E (u , B.id) g
-        → is-cartesian E (u , B.id) h ↔ is-cocartesian E (A.id , v) k
+        → right-beck-chevalley E
+            (A.id , v) (u , B.id) (u , B.id) (A.id , v)
+            (sym A.id-comm ,ₚ B.id-comm)
+      cocart-beck-chevalley
+        : ∀ {a₁ a₂ : A.Ob} {b₁ b₂ : B.Ob}
+        → {u : A.Hom a₁ a₂} {v : B.Hom b₁ b₂}
+        → left-beck-chevalley E
+            (A.id , v) (u , B.id) (u , B.id) (A.id , v)
+            (sym A.id-comm ,ₚ B.id-comm)
 ```
 
 This definition is rather opaque, so let's break it down. The first two

--- a/src/Cat/Displayed/TwoSided.lagda.md
+++ b/src/Cat/Displayed/TwoSided.lagda.md
@@ -45,11 +45,11 @@ module _
 A displayed category $\cE \liesover \cA \times \cB$ is a **two-sided fibration**
 when it satisfies the following 3 conditions:
 
-1. For every $u : \cA(A_1, A_2)$, $B : \cB$ and $Y : \cE_{A_2, B}$, there
-exists a [[cartesian lift]] $\pi_{u, Y} : \cE_{u, \id}(u^{*}(Y), Y)$.
+1. We are given an operation assigning [[cartesian lifts]]
+$\pi_{u, Y} : \cE_{u, \id}(u^{*}(Y), Y)$ to each $u : \cA(A_1, A_2)$, $B : \cB$, and $Y : \cE_{A_2, B}$.
 
-2. For every $A : \cA, v : \cB(B_1, B_2)$ and $X : \cE_{A, B_1}$, there
-exists a [[cocartesian lift]] $\iota_{v, X} : \cE_{\id, v}(X, v_{!}(X))$.
+2. Similarly, to each $A : \cA, v : \cB(B_1, B_2)$ and $X : \cE_{A, B_1}$,
+we are equipped with a [[cocartesian lift]] $\iota_{v, X} : \cE_{\id, v}(X, v_{!}(X))$.
 
 3. For every diagram of the form below with $f$ cocartesian and $g$ cartesian,
 $h$ is cartesian if and only if $k$ is cocartesian.
@@ -105,7 +105,7 @@ $h$ is cartesian if and only if $k$ is cocartesian.
 This definition is rather opaque, so let's break it down. The first two
 conditions ensure that we have 2 functorial actions on each of the [[fibre categories]]
 $E_{a, b}$: the first acts contravariantly in $\cA$, the second covariantly
-in $\cB$. This is analogous to the actions $P(-, \id)$ and $P(\id, -)$ for
+in $\cB$. These are analogs to the actions $P(-, \id)$ and $P(\id, -)$ of
 a profunctor $P : \cA \times \cB \to \Sets$. The final condition serves to
 ensure that the [[base change]] and [[cobase change]] functors
 $u^{*} : \cE_{A_2, B} \to \cE_{A_1, B}$ and $v_{!} : \cE_{A, B_1} \to \cE_{A, B_2}$

--- a/src/Cat/Displayed/TwoSided/Discrete.lagda.md
+++ b/src/Cat/Displayed/TwoSided/Discrete.lagda.md
@@ -409,8 +409,6 @@ lifts exit.
     E-fib .Two-sided-fibration.cocart-lift v x' .y' = v ^! x'
     E-fib .Two-sided-fibration.cocart-lift v x' .lifting = ι! v x'
     E-fib .Two-sided-fibration.cocart-lift v x' .cocartesian = vertical-cocartesian (ι! v x')
-    E-fib .Two-sided-fibration.cocartesian-stable p f-cocart g-cart h-cart =
-      vertical-cocartesian _
-    E-fib .Two-sided-fibration.cartesian-stable p f-cocart g-cart k-cocart =
-      vertical-cartesian _
+    E-fib .Two-sided-fibration.cart-cocart-commute p f-cocart g-cart =
+      biimp (λ _ → vertical-cocartesian _) (λ _ → vertical-cartesian _)
 ```

--- a/src/Cat/Displayed/TwoSided/Discrete.lagda.md
+++ b/src/Cat/Displayed/TwoSided/Discrete.lagda.md
@@ -11,7 +11,6 @@ open import Cat.Instances.Product
 open import Cat.Displayed.Base
 open import Cat.Prelude
 
-
 import Cat.Displayed.Reasoning
 import Cat.Displayed.Morphism
 import Cat.Reasoning

--- a/src/Cat/Displayed/TwoSided/Discrete.lagda.md
+++ b/src/Cat/Displayed/TwoSided/Discrete.lagda.md
@@ -1,0 +1,321 @@
+---
+description: |
+  Discrete two-sided fibrations.
+---
+<!--
+```agda
+open import Cat.Displayed.Cocartesian
+open import Cat.Displayed.Cartesian
+open import Cat.Displayed.TwoSided
+open import Cat.Instances.Product
+open import Cat.Displayed.Base
+open import Cat.Prelude
+
+
+import Cat.Displayed.Reasoning
+import Cat.Displayed.Morphism
+import Cat.Reasoning
+```
+-->
+
+```agda
+module Cat.Displayed.TwoSided.Discrete where
+```
+
+# Discrete two-sided fibrations
+
+Much like how [[discrete fibrations are presheaves]], a **discrete two-sided
+fibration** is a displayed presentation of a profunctor.
+
+:::{.definition #discrete-two-sided-fibration}
+A [[displayed category]] $\cE \liesover \cA \times \cB$ is a **discrete two-sided
+fibration** if:
+
+<!--
+```agda
+module _
+  {oa ℓa ob ℓb oe ℓe}
+  {A : Precategory oa ℓa} {B : Precategory ob ℓb}
+  (E : Displayed (A ×ᶜ B) oe ℓe)
+  where
+  private
+    module A = Cat.Reasoning A
+    module B = Cat.Reasoning B
+    module A×B = Cat.Reasoning (A ×ᶜ B)
+    open Cat.Displayed.Reasoning E
+    open Cat.Displayed.Morphism E
+    open Displayed E
+```
+-->
+
+```agda
+  record is-discrete-two-sided-fibration : Type (oa ⊔ ℓa ⊔ ob ⊔ ℓb ⊔ oe ⊔ ℓe) where
+```
+
+1. For every $A : \cA$, $B : \cB$, $\cE_{A, B}$ is a [[set]].
+
+```agda
+    field
+      fibre-set : ∀ a b → is-set (Ob[ a , b ])
+```
+
+2. For every $u : \cA(A_1, A_2)$ and $Y : \cE_{A_2, B}$, there exists a
+unique pair $u^{*}(Y) : \cE_{A_1, B}, \pi_{u,Y} : \cE_{u, \id}(u^{*}(Y), Y)$.
+
+```agda
+    field
+      cart-lift
+        : ∀ {a₁ a₂ : A.Ob} {b : B.Ob}
+        → (f : A.Hom a₁ a₂)
+        → (y' : Ob[ a₂ , b ])
+        → is-contr (Σ[ x' ∈ Ob[ a₁ , b ] ] Hom[ f , B.id ] x' y')
+
+    _^*_ : ∀ {a₁ a₂ : A.Ob} {b : B.Ob} → A.Hom a₁ a₂ → Ob[ a₂ , b ] → Ob[ a₁ , b ]
+    u ^* y' = cart-lift u y' .centre .fst
+
+    π*
+      : ∀ {a₁ a₂ : A.Ob} {b : B.Ob}
+      → (u : A.Hom a₁ a₂)
+      → (y' : Ob[ a₂ , b ])
+      → Hom[ u , B.id ] (u ^* y') y'
+    π* u y' = cart-lift u y' .centre .snd
+```
+
+3. For every $v : \cB(B_1, B_2)$ and $X : \cE_{A, B_1}$, there exists a
+unique pair $v_{!}(X) : \cE_{B, B_2}, \iota_{v,X} : \cE_{\id, v}(X, v_{!}(X))$.
+
+```agda
+    field
+      cocart-lift
+        : ∀ {a : A.Ob} {b₁ b₂ : B.Ob}
+        → (f : B.Hom b₁ b₂)
+        → (x' : Ob[ a , b₁ ])
+        → is-contr (Σ[ y' ∈ Ob[ a , b₂ ] ] Hom[ A.id , f ] x' y')
+    _^!_ : ∀ {a : A.Ob} {b₁ b₂ : B.Ob} → B.Hom b₁ b₂ → Ob[ a , b₁ ] → Ob[ a , b₂ ]
+    v ^! x' = cocart-lift v x' .centre .fst
+
+    ι!
+      : ∀ {a : A.Ob} {b₁ b₂ : B.Ob}
+      → (v : B.Hom b₁ b₂)
+      → (x' : Ob[ a , b₁ ])
+      → Hom[ A.id , v ] x' (v ^! x')
+    ι! v x' = cocart-lift v x' .centre .snd
+
+```
+
+
+4. For every $f : \cE_{u, v}(X,Y)$, there exists a vertical map
+  $\alpha_{f} : \cE_{\id, \id}(v_{!}(X), u^{*}(Y))$ such that
+  $\pi_{u,Y} \circ \alpha_{f} \circ \iota_{v,X} = f$.
+
+```agda
+    field
+      vert-lift
+        : ∀ {a₁ a₂ b₁ b₂ x y}
+        → {u : A.Hom a₁ a₂} {v : B.Hom b₁ b₂}
+        → (f : Hom[ u , v ] x y)
+        → Hom[ A.id , B.id ] (v ^! x) (u ^* y)
+      factors
+        : ∀ {a₁ a₂ b₁ b₂ x y}
+        → {u : A.Hom a₁ a₂} {v : B.Hom b₁ b₂}
+        → (f : Hom[ u , v ] x y)
+        → f ≡[ A.intror (A.idl _) ,ₚ B.insertl (B.idl _) ] (π* u y ∘' vert-lift f ∘' ι! v x)
+```
+:::
+
+This final condition implies that for every $f : \cE_{u,v}(X,Y)$, the
+lifts $u^{*}(Y)$ and $v_{!}(X)$ coincide.
+
+```agda
+    same-lift
+      : ∀ {a₁ a₂ b₁ b₂ x' y'} {u : A.Hom a₁ a₂} {v : B.Hom b₁ b₂}
+      → (f : Hom[ u , v ] x' y')
+      → u ^* y' ≡ v ^! x'
+```
+
+First, note that it suffices to construct a map $\cE_{\id,\id}(v_{!}(X), u^{*}(Y))$,
+as the space of lifts of $u^{*}(Y)$ along $\id$ is contractible. The above
+axiom ensures that this map exists!
+
+```agda
+    same-lift {x' = x'} {y' = y'} {u = u} {v = v} f =
+       ap fst $ is-contr→is-prop (cart-lift A.id (u ^* y'))
+         (u ^* y' , id')
+         (v ^! x' , vert-lift f)
+```
+
+Moreover, the factorisation condition ensures that every hom set forms
+a [[proposition]].
+
+```agda
+    Hom[]-is-prop
+      : ∀ {a₁ a₂ b₁ b₂ x' y'} {u : A.Hom a₁ a₂} {v : B.Hom b₁ b₂}
+      → is-prop (Hom[ u , v ] x' y')
+```
+
+Let $f, g : \cE_{u,v}(X,Y)$ be a pair of morphisms. Both maps factor
+as $\pi_{u,Y} \circ \alpha_{f} \circ \iota_{v,X}$ and
+$\pi_{u,Y} \circ \alpha_{g} \circ \iota_{v,X}$, so it suffices to
+show that $\alpha_{f} = \alpha_{g}$.
+
+```agda
+    Hom[]-is-prop {x' = x'} {y' = y'} {u = u} {v = v} f' g' =
+      cast[] $
+        f'                                     ≡[]⟨ factors f' ⟩
+        π* u y' ∘' ⌜ vert-lift f' ⌝ ∘' ι! v x' ≡[]⟨ ap! vert-lift-eq ⟩
+        π* u y' ∘' vert-lift g' ∘' ι! v x'     ≡[]˘⟨ factors g' ⟩
+        g'                                     ∎
+```
+
+The type of objects is a set, so it further suffices to prove that
+$(v_{!}(X), \alpha_{f}) = (v_{!}(X), \alpha_{g})$, which follows immediately
+from uniqueness of lifts.
+
+```agda
+      where
+        vert-lift-eq : vert-lift f' ≡ vert-lift g'
+        vert-lift-eq =
+          Σ-inj-set (fibre-set _ _) $
+          is-contr→is-prop (cart-lift A.id (u ^* y'))
+            (v ^! x' , vert-lift f')
+            (v ^! x' , vert-lift g')
+```
+
+## Functoriality
+
+Note that the action $(-)^*$ is functorial on the fibres of $E$ that
+are vertical over $B$, as lifts are unique.
+
+```agda
+    ^*-∘
+      : ∀ {a₁ a₂ a₃ : A.Ob} {b : B.Ob}
+      → (u : A.Hom a₂ a₃) (v : A.Hom a₁ a₂)
+      → (y' : Ob[ a₃ , b ])
+      → (u A.∘ v) ^* y' ≡ (v ^* (u ^* y'))
+    ^*-∘ u v y' =
+      ap fst $ cart-lift (u A.∘ v) y' .paths $
+        v ^* (u ^* y') ,
+        hom[ refl ,ₚ B.idl _ ] (π* u y' ∘' π* v (u ^* y'))
+
+    ^*-id
+      : ∀ {a b} {x' : Ob[ a , b ]}
+      → A.id ^* x' ≡ x'
+    ^*-id {x' = x'} =
+      ap fst $ cart-lift A.id x' .paths (x' , id')
+```
+
+Dually, the action $(-)_{!}$ is functorial on the fibres of $E$ that
+are vertical over $B$.
+
+```agda
+    ^!-∘
+      : ∀ {a : A.Ob} {b₁ b₂ b₃ : B.Ob}
+      → (u : B.Hom b₂ b₃) (v : B.Hom b₁ b₂)
+      → (x' : Ob[ a , b₁ ])
+      → (u B.∘ v) ^! x' ≡ (u ^! (v ^! x'))
+    ^!-∘ u v x' =
+      ap fst $ cocart-lift (u B.∘ v) x' .paths $
+        u ^! (v ^! x') , hom[ A.idr _ ,ₚ refl ] (ι! u (v ^! x') ∘' ι! v x')
+
+    ^!-id
+      : ∀ {a b} {x' : Ob[ a , b ]}
+      → B.id ^! x' ≡ x'
+    ^!-id {x' = x'} =
+      ap fst $ cocart-lift B.id x' .paths (x' , id')
+```
+
+Moreover, we also have an interchange law that lets us relate
+the contravariant and covariant actions on fibres.
+
+```agda
+    ^*-^!-comm
+      : ∀ {a₁ a₂ : A.Ob} {b₁ b₂ : B.Ob}
+      → (u : A.Hom a₁ a₂) (v : B.Hom b₁ b₂)
+      → (x' : Ob[ a₂ , b₁ ])
+      → (u ^* (v ^! x')) ≡ (v ^! (u ^* x'))
+    ^*-^!-comm u v x' =
+      same-lift (hom[ A.idl u ,ₚ B.idr v ] (ι! v x' ∘' π* u x'))
+```
+
+## Invertible maps
+
+Every morphism in a discrete two-sided fibration living over an
+invertible pair of morphisms is itself invertible.
+
+```agda
+    all-invertible[]
+      : ∀ {a₁ a₂ b₁ b₂ x' y'} {u : A.Hom a₁ a₂} {v : B.Hom b₁ b₂}
+      → (f : Hom[ u , v ] x' y')
+      → (uv⁻¹ : A×B.is-invertible (u , v))
+      → is-invertible[ uv⁻¹ ] f
+```
+
+Let $f : \cE_{u,v}(X,Y)$ be a map displayed over a pair of invertible maps
+$u : \cA(A_1, A_2), v : \cB(B_1, B_2)$.
+
+```agda
+    all-invertible[] {a₁} {a₂} {b₁} {b₂} {x'} {y'} {u} {v} f uv⁻¹ = f⁻¹ where
+      module uv⁻¹ = A×B.is-invertible uv⁻¹
+      open is-invertible[_]
+
+      u⁻¹ : A.Hom _ _
+      u⁻¹ = uv⁻¹.inv .fst
+
+      v⁻¹ : B.Hom _ _
+      v⁻¹ = uv⁻¹.inv .snd
+```
+
+A bit of tedious algebra lets us deduce that $(u^{-1})^{*}(X) = v^{-1}_{!}(Y)$.
+
+```agda
+      same-lift⁻¹ : u⁻¹ ^* x' ≡ v⁻¹ ^! y'
+      same-lift⁻¹ =
+        u⁻¹ ^* x'                    ≡˘⟨ ap (u⁻¹ ^*_) ^!-id ⟩
+        u⁻¹ ^* (⌜ B.id ⌝ ^! x')      ≡⟨ ap! (sym (ap snd $ uv⁻¹.invr)) ⟩
+        u⁻¹ ^* ((v⁻¹ B.∘ v) ^! x')   ≡⟨ ap (u⁻¹ ^*_) (^!-∘ v⁻¹ v x') ⟩
+        u⁻¹ ^* (v⁻¹ ^! ⌜ v ^! x' ⌝)  ≡⟨ ap! (sym (same-lift f)) ⟩
+        u⁻¹ ^* (v⁻¹ ^! (u ^* y'))    ≡˘⟨ ap (u⁻¹ ^*_) (^*-^!-comm u v⁻¹ y') ⟩
+        u⁻¹ ^* (u ^* (v⁻¹ ^! y'))    ≡˘⟨ ^*-∘ u u⁻¹ (v⁻¹ ^! y') ⟩
+        ⌜ u A.∘ u⁻¹ ⌝ ^* (v⁻¹ ^! y') ≡⟨ ap! (ap fst $ uv⁻¹.invl) ⟩
+        A.id ^* (v⁻¹ ^! y')          ≡⟨ ^*-id ⟩
+        v⁻¹ ^! y' ∎
+```
+
+This means that the identity map can be considered as a map 
+$\cE_{\id, \id}(v^{-1}_{!}(Y), (u^{-1})^{*}(X))$.
+
+```agda
+      vert-lift⁻¹ : Hom[ A.id , B.id ] (v⁻¹ ^! y') (u⁻¹ ^* x')
+      vert-lift⁻¹ =
+        subst (λ v⁻¹^!y' → Hom[ A.id , B.id ] v⁻¹^!y' (u⁻¹ ^* x'))
+          same-lift⁻¹
+          id'
+```
+
+Finally, hom sets are propositional, so constructing an inverse only
+requires us to build a map $\cE_{u^{-1}, v^{-1}}(Y, X)$, and the following
+composite fits the bill!
+
+~~~{.quiver}
+\begin{tikzcd}
+  Y & {v^{-1}_!(Y)} & {(u^{-1})^{*}(X)} & X
+  \arrow["\pi", from=1-1, to=1-2]
+  \arrow[shift right, no head, from=1-2, to=1-3]
+  \arrow[shift left, no head, from=1-2, to=1-3]
+  \arrow["\iota", from=1-3, to=1-4]
+\end{tikzcd}
+~~~
+
+```agda
+      f⁻¹ : is-invertible[ uv⁻¹ ] f
+      f⁻¹ .inv' =
+        hom[ A.elimr (A.idr _) ,ₚ B.cancell (B.idl _) ] $
+          π* (uv⁻¹.inv .fst) _ ∘' vert-lift⁻¹ ∘' ι! (uv⁻¹.inv .snd) _
+      f⁻¹ .inverses' .Inverses[_].invl' =
+        is-prop→pathp (λ _ → Hom[]-is-prop) _ _
+      f⁻¹ .inverses' .Inverses[_].invr' =
+        is-prop→pathp (λ _ → Hom[]-is-prop) _ _
+```
+
+
+

--- a/src/Cat/Displayed/TwoSided/Discrete.lagda.md
+++ b/src/Cat/Displayed/TwoSided/Discrete.lagda.md
@@ -399,16 +399,19 @@ lifts exit.
 ```agda
   discrete-two-sided-fibration→two-sided-fibration E-dfib = E-fib where
     open is-discrete-two-sided-fibration E-dfib
-    open Cartesian-lift
+    open Two-sided-fibration
     open Cocartesian-lift
+    open Cartesian-lift
 
     E-fib : Two-sided-fibration E
-    E-fib .Two-sided-fibration.cart-lift u y' .x' = u ^* y'
-    E-fib .Two-sided-fibration.cart-lift u y' .lifting = π* u y'
-    E-fib .Two-sided-fibration.cart-lift u y' .cartesian = vertical-cartesian (π* u y')
-    E-fib .Two-sided-fibration.cocart-lift v x' .y' = v ^! x'
-    E-fib .Two-sided-fibration.cocart-lift v x' .lifting = ι! v x'
-    E-fib .Two-sided-fibration.cocart-lift v x' .cocartesian = vertical-cocartesian (ι! v x')
-    E-fib .Two-sided-fibration.cart-cocart-commute p f-cocart g-cart =
-      biimp (λ _ → vertical-cocartesian _) (λ _ → vertical-cartesian _)
+    E-fib .cart-lift u y' .x' = u ^* y'
+    E-fib .cart-lift u y' .lifting = π* u y'
+    E-fib .cart-lift u y' .cartesian = vertical-cartesian (π* u y')
+    E-fib .cocart-lift v x' .y' = v ^! x'
+    E-fib .cocart-lift v x' .lifting = ι! v x'
+    E-fib .cocart-lift v x' .cocartesian = vertical-cocartesian (ι! v x')
+    E-fib .cart-cocart-commute p f-cocart g-cart ._↔_.to _ =
+      vertical-cocartesian _
+    E-fib .cart-cocart-commute p f-cocart g-cart ._↔_.from _ =
+      vertical-cartesian _
 ```

--- a/src/Cat/Displayed/TwoSided/Discrete.lagda.md
+++ b/src/Cat/Displayed/TwoSided/Discrete.lagda.md
@@ -291,7 +291,7 @@ $u : \cA(A_1, A_2), v : \cB(B_1, B_2)$.
 
 All of our Hom sets are propositional, so constructing an inverse only
 requires us to build a map $\cE_{u^{-1}, v^{-1}}(Y, X)$. Moreover, it
-suffices to prove that $(u^{-1})^{*}(X) = v^{-1}_{!}(X)$, which follows
+suffices to prove that $(u^{-1})^{*}(X) = (v^{-1})_{!}(X)$, which follows
 from some tedious functoriality algebra.
 
 ```agda

--- a/src/Cat/Displayed/TwoSided/Discrete.lagda.md
+++ b/src/Cat/Displayed/TwoSided/Discrete.lagda.md
@@ -51,7 +51,7 @@ module _
   record is-discrete-two-sided-fibration : Type (oa ⊔ ℓa ⊔ ob ⊔ ℓb ⊔ oe ⊔ ℓe) where
 ```
 
-1. For every $A : \cA$, $B : \cB$, $\cE_{A, B}$ is a [[set]].
+1. For every $A : \cA$, $B : \cB$, the type $\cE_{A, B}$ is a [[set]].
 
 ```agda
     field
@@ -59,7 +59,26 @@ module _
 ```
 
 2. For every $u : \cA(A_1, A_2)$ and $Y : \cE_{A_2, B}$, there exists a
-unique pair $u^{*}(Y) : \cE_{A_1, B}, \pi_{u,Y} : \cE_{u, \id}(u^{*}(Y), Y)$.
+unique pair $u^{*}, \pi_{u,Y}$ that fit into the diagram below.
+
+~~~{.quiver}
+\begin{tikzcd}
+  {u^*(Y)} && Y \\
+  \\
+  {(A_1,B)} && {(A_2,B)}
+  \arrow["{\pi_{u,Y}}", dashed, lies over, from=1-1, to=1-3]
+  \arrow[dashed, from=1-1, to=3-1]
+  \arrow[from=1-3, lies over, to=3-3]
+  \arrow["{(u,\id)}"', from=3-1, to=3-3]
+\end{tikzcd}
+~~~
+
+This condition provides us with a source of [[cartesian lifts]], and
+ensures that the [[pullback|pullback-fibration]] of $\cE$ along the functor
+$(-,B) : \cA \to \cA \times \cB$ is a [[discrete fibration]]
+for every $B : \cB$. In more intuitive terms, this means that $\cE$ is
+a sort of "presheaf in $\cA$", as we can contravariantly reindex along
+morphisms in $\cA$!
 
 ```agda
     field
@@ -68,7 +87,10 @@ unique pair $u^{*}(Y) : \cE_{A_1, B}, \pi_{u,Y} : \cE_{u, \id}(u^{*}(Y), Y)$.
         → (f : A.Hom a₁ a₂)
         → (y' : Ob[ a₂ , b ])
         → is-contr (Σ[ x' ∈ Ob[ a₁ , b ] ] Hom[ f , B.id ] x' y')
+```
 
+<!--
+```agda
     _^*_ : ∀ {a₁ a₂ : A.Ob} {b : B.Ob} → A.Hom a₁ a₂ → Ob[ a₂ , b ] → Ob[ a₁ , b ]
     u ^* y' = cart-lift u y' .centre .fst
 
@@ -79,9 +101,26 @@ unique pair $u^{*}(Y) : \cE_{A_1, B}, \pi_{u,Y} : \cE_{u, \id}(u^{*}(Y), Y)$.
       → Hom[ u , B.id ] (u ^* y') y'
     π* u y' = cart-lift u y' .centre .snd
 ```
+-->
 
 3. For every $v : \cB(B_1, B_2)$ and $X : \cE_{A, B_1}$, there exists a
-unique pair $v_{!}(X) : \cE_{B, B_2}, \iota_{v,X} : \cE_{\id, v}(X, v_{!}(X))$.
+unique pair $v_{!}(X), \iota_{v,X}$ that fit into the following diagram.
+
+~~~{.quiver}
+\begin{tikzcd}
+  X && {v_{!}(X)} \\
+  \\
+  {(A,B_1)} && {(A,B_2)}
+  \arrow["{\iota_{v,X}}", dashed, from=1-1, to=1-3]
+  \arrow[from=1-1, to=3-1]
+  \arrow[dashed, from=1-3, to=3-3]
+  \arrow["{(\id,v)}"', from=3-1, to=3-3]
+\end{tikzcd}
+~~~
+
+This gives us a source of [[cocartesian lifts]], and ensures that
+the [[pullback|pullback-fibration]] of $\cE$ along the functor
+$(A,-) : \cB \to \cA \times \cB$ is a discrete opfibration.
 
 ```agda
     field
@@ -90,6 +129,10 @@ unique pair $v_{!}(X) : \cE_{B, B_2}, \iota_{v,X} : \cE_{\id, v}(X, v_{!}(X))$.
         → (f : B.Hom b₁ b₂)
         → (x' : Ob[ a , b₁ ])
         → is-contr (Σ[ y' ∈ Ob[ a , b₂ ] ] Hom[ A.id , f ] x' y')
+```
+
+<!--
+```agda
     _^!_ : ∀ {a : A.Ob} {b₁ b₂ : B.Ob} → B.Hom b₁ b₂ → Ob[ a , b₁ ] → Ob[ a , b₂ ]
     v ^! x' = cocart-lift v x' .centre .fst
 
@@ -99,13 +142,41 @@ unique pair $v_{!}(X) : \cE_{B, B_2}, \iota_{v,X} : \cE_{\id, v}(X, v_{!}(X))$.
       → (x' : Ob[ a , b₁ ])
       → Hom[ A.id , v ] x' (v ^! x')
     ι! v x' = cocart-lift v x' .centre .snd
-
 ```
+-->
 
 
 4. For every $f : \cE_{u, v}(X,Y)$, there exists a vertical map
-  $\alpha_{f} : \cE_{\id, \id}(v_{!}(X), u^{*}(Y))$ such that
-  $\pi_{u,Y} \circ \alpha_{f} \circ \iota_{v,X} = f$.
+  $\alpha_{f} : \cE_{\id, \id}(v_{!}(X), u^{*}(Y))$ that causes
+  the following diagram to commute.
+
+~~~{.quiver}
+\begin{tikzcd}
+	& {v_{!}(X)} &&& {u^{*}(Y)} \\
+	X &&& Y \\
+	& {(A_1,B_2)} &&& {(A_1,B_2)} \\
+	{(A_1,B_1)} &&& {(A_2,B_2)}
+	\arrow["{\alpha_f}", dashed, from=1-2, to=1-5]
+	\arrow[from=1-2, lies over, to=3-2]
+	\arrow["{\pi_{u,Y}}"'{pos=0.7}, from=1-5, to=2-4]
+	\arrow[from=1-5, lies over, to=3-5]
+	\arrow["{\iota_{v,X}}"{pos=0.3}, from=2-1, to=1-2]
+	\arrow["f", from=2-1, to=2-4]
+	\arrow[from=2-1, lies over, to=4-1]
+	\arrow[from=2-4, lies over, to=4-4]
+	\arrow["{(\id,\id)}", from=3-2, to=3-5]
+	\arrow["{(u,\id)}", from=3-5, to=4-4]
+	\arrow["{(\id,v)}", from=4-1, to=3-2]
+	\arrow["{(u,v)}"', from=4-1, to=4-4]
+\end{tikzcd}
+~~~
+
+This condition is a bit opaque, and is best understood from the indexed
+point of view. From this perspective, our previous 2 conditions ensure
+that $\cE$ is *separately* functorial in $\cA\op$ and $\cB$; there is
+no way to commute the two reindexing functors! To get something that is
+*jointly* functorial, we need to assert the existence of some extra lifts
+that allow us more room to manuever.
 
 ```agda
     field
@@ -114,6 +185,7 @@ unique pair $v_{!}(X) : \cE_{B, B_2}, \iota_{v,X} : \cE_{\id, v}(X, v_{!}(X))$.
         → {u : A.Hom a₁ a₂} {v : B.Hom b₁ b₂}
         → (f : Hom[ u , v ] x y)
         → Hom[ A.id , B.id ] (v ^! x) (u ^* y)
+
       factors
         : ∀ {a₁ a₂ b₁ b₂ x y}
         → {u : A.Hom a₁ a₂} {v : B.Hom b₁ b₂}
@@ -122,8 +194,8 @@ unique pair $v_{!}(X) : \cE_{B, B_2}, \iota_{v,X} : \cE_{\id, v}(X, v_{!}(X))$.
 ```
 :::
 
-This final condition implies that for every $f : \cE_{u,v}(X,Y)$, the
-lifts $u^{*}(Y)$ and $v_{!}(X)$ coincide.
+In particular, the existence of such vertical lifts ensure that the for
+every $f : \cE_{u,v}(X,Y)$, the lifts $u^{*}(Y)$ and $v_{!}(X)$ coincide.
 
 ```agda
     same-lift
@@ -229,7 +301,7 @@ are vertical over $B$, as lifts are unique.
 ```
 
 Dually, the action $(-)_{!}$ is functorial on the fibres of $E$ that
-are vertical over $B$.
+are vertical over $A$.
 
 ```agda
     ^!-∘
@@ -289,9 +361,9 @@ $u : \cA(A_1, A_2), v : \cB(B_1, B_2)$.
       v⁻¹ = uv⁻¹.inv .snd
 ```
 
-All of our Hom sets are propositional, so constructing an inverse only
-requires us to build a map $\cE_{u^{-1}, v^{-1}}(Y, X)$. Moreover, it
-suffices to prove that $(u^{-1})^{*}(X) = (v^{-1})_{!}(X)$, which follows
+Since each of our $\Hom$-sets is a proposition, to construct an inverse
+it suffices to build a map $\cE_{u^{-1}, v^{-1}}(Y, X)$. This, in turn,
+reduces to showing $(u^{-1})^{*}(X) = (v^{-1})_{!}(X)$, which follows
 from some tedious functoriality algebra.
 
 ```agda
@@ -315,8 +387,8 @@ from some tedious functoriality algebra.
 
 ## Cartesian and cocartesian maps
 
-Every map that is $\cB$-vertical is [[cartesian|cartesian-morphism]] and
-every map that is $\cA$-vertical is [[cocartesian|cocartesian-morphism]].
+Every map that is $\cB$-vertical is [[cartesian|cartesian morphism]]; and, dually,
+every map that is $\cA$-vertical is [[cocartesian|cocartesian morphism]].
 
 ```agda
     vertical-cartesian

--- a/src/Cat/Displayed/TwoSided/Discrete.lagda.md
+++ b/src/Cat/Displayed/TwoSided/Discrete.lagda.md
@@ -482,8 +482,6 @@ lifts exit.
     E-fib .cocart-lift v x' .y' = v ^! x'
     E-fib .cocart-lift v x' .lifting = ι! v x'
     E-fib .cocart-lift v x' .cocartesian = vertical-cocartesian (ι! v x')
-    E-fib .cart-cocart-commute p f-cocart g-cart ._↔_.to _ =
-      vertical-cocartesian _
-    E-fib .cart-cocart-commute p f-cocart g-cart ._↔_.from _ =
-      vertical-cartesian _
+    E-fib .cart-beck-chevalley _ _ _ _ = vertical-cartesian _
+    E-fib .cocart-beck-chevalley _ _ _ _ = vertical-cocartesian _
 ```

--- a/src/Cat/Displayed/TwoSided/Discrete.lagda.md
+++ b/src/Cat/Displayed/TwoSided/Discrete.lagda.md
@@ -361,7 +361,7 @@ $u : \cA(A_1, A_2), v : \cB(B_1, B_2)$.
       v⁻¹ = uv⁻¹.inv .snd
 ```
 
-Since each of our $\Hom$-sets is a proposition, to construct an inverse
+Since each of our $\rm{Hom}$-sets is a proposition, to construct an inverse
 it suffices to build a map $\cE_{u^{-1}, v^{-1}}(Y, X)$. This, in turn,
 reduces to showing $(u^{-1})^{*}(X) = (v^{-1})_{!}(X)$, which follows
 from some tedious functoriality algebra.

--- a/src/Cat/Displayed/TwoSided/Discrete.lagda.md
+++ b/src/Cat/Displayed/TwoSided/Discrete.lagda.md
@@ -59,7 +59,7 @@ module _
 ```
 
 2. For every $u : \cA(A_1, A_2)$ and $Y : \cE_{A_2, B}$, there exists a
-unique pair $u^{*}, \pi_{u,Y}$ that fit into the diagram below.
+unique pair $u^{*}, \pi_{u,Y}$ that fits into the diagram below.
 
 ~~~{.quiver}
 \begin{tikzcd}


### PR DESCRIPTION
# Description

This PR defines two-sided fibrations and two-sided discrete fibrations, and proves that the comma category is a two-sided discrete fibration when regarded as a displayed category.

## Checklist

Before submitting a merge request, please check the items below:

- [x] I've read [the contributing guidelines](https://github.com/plt-amy/1lab/blob/main/CONTRIBUTING.md).
- [x] The imports of new modules have been sorted with `support/sort-imports.hs` (or `nix run --experimental-features nix-command -f . sort-imports`).
- [x] All new code blocks have "agda" as their language.

If your change affects many files without adding substantial content, and
you don't want your name to appear on those pages (for example, treewide
refactorings or reformattings), start the commit message and PR title with `chore:`.
