### PR TITLE
Beck-Chevalley conditions

### DIFF
--- a/src/Cat/Diagram/Product/Finite.lagda.md
+++ b/src/Cat/Diagram/Product/Finite.lagda.md
@@ -32,7 +32,7 @@ open Cart using (_⊗₀_)
 ```
 -->
 
-# Computing finite products
+# Computing finite products {defines="finite-products"}
 
 Throughout the 1lab, we have referred to categories having a terminal
 object and binary products as _Cartesian categories_, _finite products

--- a/src/Cat/Displayed/BeckChevalley.lagda.md
+++ b/src/Cat/Displayed/BeckChevalley.lagda.md
@@ -4,23 +4,22 @@ description: |
 ---
 <!--
 ```agda
+open import Cat.Displayed.Cartesian.Indexing
 open import Cat.Displayed.Cocartesian.Weak
 open import Cat.Displayed.Cocartesian
-open import Cat.Displayed.Cartesian
-open import Cat.Displayed.Fibre
-open import Cat.Displayed.Base
 open import Cat.Functor.Adjoint.Mate
+open import Cat.Displayed.Cartesian
 open import Cat.Functor.Naturality
+open import Cat.Displayed.Fibre
 open import Cat.Functor.Adjoint
+open import Cat.Displayed.Base
 open import Cat.Prelude
-open import Cat.Displayed.Cartesian.Indexing
 
 import Cat.Displayed.Fibre.Reasoning
 import Cat.Displayed.Reasoning
 import Cat.Displayed.Morphism
 import Cat.Functor.Reasoning
 import Cat.Reasoning
-
 ```
 -->
 ```agda

--- a/src/Cat/Displayed/BeckChevalley.lagda.md
+++ b/src/Cat/Displayed/BeckChevalley.lagda.md
@@ -51,11 +51,11 @@ diagram:
 \begin{tikzcd}
   {\mathcal{E}_{\Gamma \times X}} && {\mathcal{E}_{\Gamma}} \\
   \\
-  {\mathcal{E}_{\Delta \times X} && {\mathcal{E}_{\Delta}}
+  {\mathcal{E}_{\Delta \times X}} && {\mathcal{E}_{\Delta}}
   \arrow["{\exists_{X}}", from=1-1, to=1-3]
-  \arrow["{(\sigma \times \id)^*}"', from=1-1, to=3-1]
+  \arrow["{(\sigma \times \id)^{*}}"', from=1-1, to=3-1]
   \arrow["{\sigma^{*}}", from=1-3, to=3-3]
-  \arrow["{\exist_{X}}"', from=3-1, to=3-3]
+  \arrow["{\exists_{X}}"', from=3-1, to=3-3]
 \end{tikzcd}
 ~~~
 
@@ -231,7 +231,6 @@ universal properties.
   && B
   \arrow["{((\iota \circ \pi)_{!})^*}"{description}, curve={height=12pt}, to=1-4, from=1-2]
   \arrow["{((\iota \circ \pi)^{*})_!}"{description}, curve={height=-12pt}, to=1-4, from=1-2]
-  \arrow[shorten <=3pt, shorten >=3pt, equals, from=1, to=0]
   \arrow[lies over, from=1-2, to=3-2]
   \arrow[lies over, from=1-4, to=3-4]
   \arrow["{(\iota \circ \pi)_{!}}"{description}, from=1-4, to=3-5]

--- a/src/Cat/Displayed/BeckChevalley.lagda.md
+++ b/src/Cat/Displayed/BeckChevalley.lagda.md
@@ -634,9 +634,29 @@ the comparison map derived from the aforementioned mate is invertible.
 
 Left Beck-Chevalley conditions require stability of cocartesian maps
 under cartesian maps. We can dualize this to obtain the **right Beck-Chevalley
-conditions**, which require that cartesian maps be stable under pushforward
-along cocartesian maps.
+conditions**, which ensures stability of cartesian maps under pushforward
+along cocartesian maps. As before, this is best understood diagrammatically:
 
+~~~{.quiver}
+\begin{tikzcd}
+	{A'} &&& {D'} \\
+	& {B'} &&& {C'} \\
+	A &&& B \\
+	& C &&& D
+	\arrow["{\mathrm{cart}}"{description}, color={rgb,255:red,214;green,92;blue,92}, from=1-1, to=1-4]
+	\arrow["{\mathrm{cocart}}"{description}, color={rgb,255:red,214;green,92;blue,92}, from=1-1, to=2-2]
+	\arrow[lies over, from=1-1, to=3-1]
+	\arrow["{\mathrm{cocart}}"{description}, color={rgb,255:red,214;green,92;blue,92}, from=1-4, to=2-5]
+	\arrow[lies over, from=1-4, to=3-4]
+	\arrow["{\mathrm{cart}}"{description}, color={rgb,255:red,92;green,92;blue,214}, from=2-2, to=2-5]
+	\arrow[lies over, from=2-2, to=4-2]
+	\arrow[lies over, from=2-5, to=4-5]
+	\arrow["g"{description}, from=3-1, to=3-4]
+	\arrow["k"{description}, from=3-1, to=4-2]
+	\arrow["f"{description}, from=3-4, to=4-5]
+	\arrow["h"{description}, from=4-2, to=4-5]
+\end{tikzcd}
+~~~
 
 <!--
 ```agda

--- a/src/Cat/Displayed/BeckChevalley.lagda.md
+++ b/src/Cat/Displayed/BeckChevalley.lagda.md
@@ -213,7 +213,7 @@ over $g, h$, as in the following diagram.
 -->
 
 Now, fix some $B' : \cE_{B}$. We can form the following immortal pentagonal
-diagram by repeatedly performing taking lifts of $B$ and applying various
+diagram by repeatedly performing taking lifts of $B'$ and applying various
 universal properties.
 
 ~~~{.quiver}
@@ -233,7 +233,7 @@ universal properties.
   \arrow["\pi"{description}, from=3-1, to=4-3]
   \arrow[lies over, from=3-1, to=5-1]
   \arrow["\id"{description}, from=3-2, to=3-4]
-  \arrow[lies over, from=3-4, to=5-5]
+  \arrow["h"{description}, from=3-4, to=5-5]
   \arrow[lies over, from=3-5, to=5-5]
   \arrow["\iota"{description}, from=4-3, to=3-5]
   \arrow[lies over, from=4-3, to=6-3]

--- a/src/Cat/Displayed/BeckChevalley.lagda.md
+++ b/src/Cat/Displayed/BeckChevalley.lagda.md
@@ -1,0 +1,64 @@
+---
+description: |
+  Beck-Chevalley conditions.
+---
+<!--
+```agda
+open import Cat.Displayed.Cocartesian
+open import Cat.Displayed.Cartesian
+open import Cat.Displayed.Base
+open import Cat.Prelude
+```
+-->
+```agda
+module Cat.Displayed.BeckChevalley where
+```
+
+# Beck-Chevalley conditions
+
+<!--
+```agda
+module _
+  {o ℓ o' ℓ'}
+  {B : Precategory o ℓ}
+  (E : Displayed B o' ℓ')
+  where
+  open Precategory B
+  open Displayed E
+```
+-->
+
+```agda
+  record cocartesian-beck-chevalley
+    {a b c d : Ob}
+    (f : Hom b d) (g : Hom a b) (h : Hom c d) (k : Hom a c)
+    (p : f ∘ g ≡ h ∘ k)
+    : Type (o ⊔ ℓ ⊔ o' ⊔ ℓ') where
+    no-eta-equality
+    field
+      cocart-stable
+        : {a' : Ob[ a ]} {b' : Ob[ b ]} {c' : Ob[ c ]} {d' : Ob[ d ]}
+        → {f' : Hom[ f ] b' d'} {g' : Hom[ g ] a' b'}
+        → {h' : Hom[ h ] c' d'} {k' : Hom[ k ] a' c'}
+        → f' ∘' g' ≡[ p ] h' ∘' k'
+        → is-cocartesian E f f' → is-cartesian E g g'
+        → is-cartesian E h h' → is-cocartesian E k k'
+
+```
+
+```agda
+  record cartesian-beck-chevalley
+    {a b c d : Ob}
+    (f : Hom b d) (g : Hom a b) (h : Hom c d) (k : Hom a c)
+    (p : f ∘ g ≡ h ∘ k)
+    : Type (o ⊔ ℓ ⊔ o' ⊔ ℓ') where
+    no-eta-equality
+    field
+      cart-stable
+        : {a' : Ob[ a ]} {b' : Ob[ b ]} {c' : Ob[ c ]} {d' : Ob[ d ]}
+        → {f' : Hom[ f ] b' d'} {g' : Hom[ g ] a' b'}
+        → {h' : Hom[ h ] c' d'} {k' : Hom[ k ] a' c'}
+        → f' ∘' g' ≡[ p ] h' ∘' k'
+        → is-cocartesian E f f' → is-cartesian E g g'
+        → is-cocartesian E k k' → is-cartesian E h h'
+```

--- a/src/Cat/Displayed/BeckChevalley.lagda.md
+++ b/src/Cat/Displayed/BeckChevalley.lagda.md
@@ -28,18 +28,16 @@ module Cat.Displayed.BeckChevalley where
 
 # Beck-Chevalley conditions
 
-Let $\cE \to \cB$ be a [[cartesian fibration]], which we shall view
+Let $\cE \liesover \cB$ be a [[cartesian fibration]], which we shall view
 as a setting for some sort of logic or type theory. In particular, we
 shall view the corresponding [[base change]] functors $f^{*} : \cE_{Y} \to \cE_{X}$
-as an operation of substitution on predicates/types. This leads to a particularly
-tidy definition of quantifiers as [[adjoints]] to base change.
-
-For instance, we can describe existential quantifiers as left adjoints
-$\exists_{Y} : \cE_{X \times Y} \to \cE{X}$ to base changes along projections
+as an operation of substitution on predicates/types, and assume that $\cB$ has
+[[finite products]]. This setup leads to a tidy definition of existential quantifiers 
+as left adjoints $\exists_{Y} : \cE_{X \times Y} \to \cE{X}$ to the base changes along projections
 $\pi : X \times Y \to X$:
 
-- The introduction rule is given by the unit $\eta : \cE_{X}(P, \exists_{Y} (\pi^{*} P))$
-- The elimination rule is given by the counit $\eps : \cE_{X \times Y}(\pi^{*}\exists_{Y} P, P)$
+- The introduction rule is given by the unit $\eta : \cE_{X}(P, \exists_{Y} (\pi^{*} P))$;
+- The elimination rule is given by the counit $\eps : \cE_{X \times Y}(\pi^{*}\exists_{Y} P, P)$; and
 - The $\beta$ and $\eta$ rules are given by the zig-zag equations.
 
 This story is quite elegant, but there is a missing piece: how do substitutions
@@ -59,15 +57,13 @@ diagram:
 \end{tikzcd}
 ~~~
 
-Ideally, we'd like $(\sigma)^*{\exists_{X} P} \iso \exists_{X}((\sigma \times \id)^{*} P)$;
-this corresponds to the usual substitution rule for quantifiers. Somewhat
+Ideally, we'd like $\sigma^*({\exists_{X} P}) \iso \exists_{X}((\sigma \times \id)^{*} P)$,
+corresponding to the usual substitution rule for quantifiers. Somewhat
 surprisingly, this does not always hold; we always have a map
-
 $$\exists_{X}((\sigma \times \id)^{*} P) \to (\sigma)^*{\exists_{X} P}$$
-
-that comes from some adjoint yoga, but this map is not necessarily invertible!
-This leads us to the main topic of this page: the **Beck-Chevalley**
-conditions are a set of properties that ensure that the aforementioned
+coming from adjoint yoga, but this map is not necessarily invertible!
+This leads us to the main topic of this page: the **Beck-Chevalley
+conditions** are a set of properties that ensure that the aforementioned
 map is invertible, which in turn ensures that our quantifiers are stable
 under substitution.
 
@@ -82,10 +78,9 @@ be missing some cartesian maps.
 
 :::{.definition #left-beck-chevalley-condition}
 Explicitly, a square $fg = hk$ in $\cB$ satisfies the left Beck-Chevalley
-condition if for every square $f'g' = h'interp$ over $fg = hk$, if $g'$ and
-$h'$ are cartesian and $f'$ is cocartesian, then $interp$ is cocartesian.
-This is best understood diagrammatically: suppose we are in a situation
-like the diagram below:
+condition if for every square $f'g' = h'k'$ over $fg = hk$, if $g'$ and
+$h'$ are cartesian and $f'$ is cocartesian, then $k'$ is cocartesian.
+This is best understood diagrammatically, so consider the diagram below:
 
 ~~~{.quiver}
 \begin{tikzcd}
@@ -284,7 +279,7 @@ ought to give us.
 
 First, observe that the map $(\iota \circ \pi)^{*}$ fits into a square
 with 2 cartesian sides and 1 cocartesian side; so can apply Beck-Chevalley
-to deduce that $(\iota \circ \pi)^{*}$ is cocartesian.
+to deduce that it is cocartesian.
 
 ~~~{.quiver}
 \begin{tikzcd}
@@ -324,7 +319,7 @@ to deduce that $(\iota \circ \pi)^{*}$ is cocartesian.
 ```
 
 Notably, this lets us factor the map $\iota : \cE_{k}(g^{*}(B'),k_{!}g^{*}(B'))$
-to get a vertical map $\cE()^{*}f_{!}(B'), k_{!}g^{*}(B'))$ that fits neatly
+to get a vertical map $\cE(h^{*}f_{!}(B'), k_{!}g^{*}(B'))$ that fits neatly
 into the gap in the pentagon.
 
 ```agda
@@ -334,7 +329,7 @@ into the gap in the pentagon.
 
 We can show that our putative inverse is a left inverse of the comparison
 map by appealing to uniqueness of both maps into and maps out of $h^*f_!(B')$,
-as $h^*f_!(B')$ is simultaneously a cartesian and a cocartesian lift. This
+as it is simultaneously a cartesian and a cocartesian lift. This
 yields the following hexagonal goal, which we can show commutes by a short
 diagram chase.
 
@@ -407,7 +402,7 @@ We shall now show the converse of our previous statement: if
 the comparison map from earlier is invertible, then the Beck-Chevalley
 property holds for our square. At a first glance, this seems a bit tricky:
 the Beck-Chevalley property talks about an arbitrary square of (co)cartesian
-morphisms, but the comparison map only references from a *particular* square.
+morphisms, but the comparison map only refers to a *particular* square.
 Luckily, we can reduce the Beck-Chevalley property to checking if the
 interpolation map $(\iota \circ \pi)^{*}$ is cocartesian.
 
@@ -475,7 +470,7 @@ property.
 </details>
 
 On to the converse! Suppose that the comparison map
-is invertible, and denote the inverse $\alpha$. By our previous lemma,$((\iota \circ\ pi)_{!})^{*}$
+is invertible, and denote the inverse $\alpha$. By our previous lemma,$((\iota \circ\ \pi)_{!})^{*}$
 it suffices to show that the interpolant $(\iota \circ \pi)^{*}$ is cocartesian.
 Moreover, cocartesian maps are stable under precomposition of isomorphisms,
 so it suffices to show that $\alpha \circ (\iota \circ \pi)^{*}$ is cocartesian.
@@ -483,14 +478,14 @@ A short calculation reveals that:
 
 $$
 \begin{align*}
-  ((\iota \circ\ pi)_{!})^{*} \circ \alpha \circ (\iota \circ \pi)^{*}
+  ((\iota \circ\ \pi)_{!})^{*} \circ \alpha \circ (\iota \circ \pi)^{*}
   &= (\iota \circ \pi)^{*} \\
   &= ((\iota \circ\ pi)^{*})_{!} \circ \iota \\
   &= ((\iota \circ\ pi)_{!})^{*} \circ \iota \\
 \end{align*}
 $$
 
-Finally, $((\iota \circ\ pi)_{!})^{*}$ is monic, so we have $\alpha \circ (\iota \circ \pi)^{*} = \iota$,
+Finally, since $((\iota \circ\ \pi)_{!})^{*}$ is monic, we have $\alpha \circ (\iota \circ \pi)^{*} = \iota$,
 which is cocartesian!
 
 ```agda
@@ -521,7 +516,7 @@ Now that we have our arsenal of lemmas, we shall tackle our original
 question: how are adjoints to base change related to our formulation
 of Beck-Chevalley? To start, suppose that we have a commutative square
 $fg = hk$, and left adjoints $f_{!}$ and $k_{!}$ to base change along $f$ and $k$,
-respectively. Moreover, recall that [cocartesian lifts are left adjoints to base change];
+respectively. Moreover, recall that [cocartesian lifts are left adjoints to base change],
 so we have cocartesian lifts along $f$ and $k$.
 
 [cocartesian lifts are left adjoints to base change]: Cat.Displayed.Cocartesian.Weak.html#weak-cocartesian-morphisms-as-left-adjoints-to-base-change

--- a/src/Cat/Displayed/BeckChevalley.lagda.md
+++ b/src/Cat/Displayed/BeckChevalley.lagda.md
@@ -37,7 +37,7 @@ as left adjoints $\exists_{Y} : \cE_{X \times Y} \to \cE{X}$ to the base changes
 $\pi : X \times Y \to X$:
 
 - The introduction rule is given by the unit $\eta : \cE_{X}(P, \exists_{Y} (\pi^{*} P))$;
-- The elimination rule is given by the counit $\eps : \cE_{X \times Y}(\pi^{*}\exists_{Y} P, P)$; and
+- The elimination rule is given by the counit $\eps : \cE_{X \times Y}(\pi^{*}(\exists_{Y} P), P)$; and
 - The $\beta$ and $\eta$ rules are given by the zig-zag equations.
 
 This story is quite elegant, but there is a missing piece: how do substitutions
@@ -60,7 +60,7 @@ diagram:
 Ideally, we'd like $\sigma^*({\exists_{X} P}) \iso \exists_{X}((\sigma \times \id)^{*} P)$,
 corresponding to the usual substitution rule for quantifiers. Somewhat
 surprisingly, this does not always hold; we always have a map
-$$\exists_{X}((\sigma \times \id)^{*} P) \to (\sigma)^*{\exists_{X} P}$$
+$$\exists_{X}((\sigma \times \id)^{*} P) \to \sigma^*({\exists_{X} P})$$
 coming from adjoint yoga, but this map is not necessarily invertible!
 This leads us to the main topic of this page: the **Beck-Chevalley
 conditions** are a set of properties that ensure that the aforementioned
@@ -470,7 +470,7 @@ property.
 </details>
 
 On to the converse! Suppose that the comparison map
-is invertible, and denote the inverse $\alpha$. By our previous lemma,$((\iota \circ\ \pi)_{!})^{*}$
+is invertible, and denote the inverse $\alpha$. By our previous lemma,
 it suffices to show that the interpolant $(\iota \circ \pi)^{*}$ is cocartesian.
 Moreover, cocartesian maps are stable under precomposition of isomorphisms,
 so it suffices to show that $\alpha \circ (\iota \circ \pi)^{*}$ is cocartesian.
@@ -480,8 +480,8 @@ $$
 \begin{align*}
   ((\iota \circ\ \pi)_{!})^{*} \circ \alpha \circ (\iota \circ \pi)^{*}
   &= (\iota \circ \pi)^{*} \\
-  &= ((\iota \circ\ pi)^{*})_{!} \circ \iota \\
-  &= ((\iota \circ\ pi)_{!})^{*} \circ \iota \\
+  &= ((\iota \circ\ \pi)^{*})_{!} \circ \iota \\
+  &= ((\iota \circ\ \pi)_{!})^{*} \circ \iota \\
 \end{align*}
 $$
 

--- a/src/Cat/Displayed/BeckChevalley.lagda.md
+++ b/src/Cat/Displayed/BeckChevalley.lagda.md
@@ -220,7 +220,7 @@ lifts over $g, h$, as in the following diagram.
 -->
 
 Now, fix some $B' : \cE_{B}$. We can form the following immortal
-pentagonal diagram by repeatedly performing taking lifts of $B'$ and
+pentagonal diagram by repeatedly taking lifts of $B'$ and
 applying various universal properties.
 
 ~~~{.quiver}
@@ -231,8 +231,8 @@ applying various universal properties.
   && {B'} \\
   A &&&& D \\
   && B
-  \arrow["{((\iota \circ \pi)_{!})^*}"{description}, curve={height=12pt}, to=1-4, from=1-2]
-  \arrow["{((\iota \circ \pi)^{*})_!}"{description}, curve={height=-12pt}, to=1-4, from=1-2]
+  \arrow["{((\iota \circ \pi)_{!})^*}"{description}, curve={height=12pt}, to=1-2, from=1-4]
+  \arrow["{((\iota \circ \pi)^{*})_!}"{description}, curve={height=-12pt}, to=1-2, from=1-4]
   \arrow[lies over, from=1-2, to=3-2]
   \arrow[lies over, from=1-4, to=3-4]
   \arrow["{(\iota \circ \pi)_{!}}"{description}, from=1-4, to=3-5]
@@ -285,7 +285,7 @@ that the Beck-Chevalley condition ought to give us.
 ```
 
 First, observe that the map $(\iota \circ \pi)^{*}$ fits into a square
-with 2 cartesian sides and 1 cocartesian side; so can apply
+with 2 cartesian sides and 1 cocartesian side; so we can apply
 Beck-Chevalley to deduce that it is cocartesian.
 
 ~~~{.quiver}

--- a/src/Cat/Displayed/BeckChevalley.lagda.md
+++ b/src/Cat/Displayed/BeckChevalley.lagda.md
@@ -634,3 +634,40 @@ the comparison map derived from the aforementioned mate is invertible.
           (left-adjoint→cocartesian-lift E E-fib Lᵏ⊣k^*)
           (λ b' → subst is-invertible↓ mate-comparison (mate-inv b'))
 ```
+
+## Right Beck-Chevalley conditions
+
+Left Beck-Chevalley conditions require stability of cocartesian maps
+under cartesian maps. We can dualize this to obtain the **right Beck-Chevalley
+conditions**, which require that cartesian maps be stable under pushforward
+along cocartesian maps.
+
+
+<!--
+```agda
+module _
+  {o ℓ o' ℓ'}
+  {B : Precategory o ℓ}
+  (E : Displayed B o' ℓ')
+  where
+  open Cat.Reasoning B
+  open Displayed E
+  open Cat.Displayed.Reasoning E
+```
+-->
+
+```agda
+  right-beck-chevalley
+    : {a b c d : Ob}
+    → (f : Hom b d) (g : Hom a b) (h : Hom c d) (k : Hom a c)
+    → (p : f ∘ g ≡ h ∘ k)
+    → Type _
+  right-beck-chevalley {a} {b} {c} {d} f g h k p =
+    ∀ {a' : Ob[ a ]} {b' : Ob[ b ]} {c' : Ob[ c ]} {d' : Ob[ d ]}
+    → {f' : Hom[ f ] b' d'} {g' : Hom[ g ] a' b'}
+    → {h' : Hom[ h ] c' d'} {k' : Hom[ k ] a' c'}
+    → f' ∘' g' ≡[ p ] h' ∘' k'
+    → is-cartesian E g g'
+    → is-cocartesian E f f' → is-cocartesian E k k'
+    → is-cartesian E h h'
+```

--- a/src/Cat/Displayed/BeckChevalley.lagda.md
+++ b/src/Cat/Displayed/BeckChevalley.lagda.md
@@ -28,22 +28,25 @@ module Cat.Displayed.BeckChevalley where
 
 # Beck-Chevalley conditions
 
-Let $\cE \liesover \cB$ be a [[cartesian fibration]], which we shall view
-as a setting for some sort of logic or type theory. In particular, we
-shall view the corresponding [[base change]] functors $f^{*} : \cE_{Y} \to \cE_{X}$
-as an operation of substitution on predicates/types, and assume that $\cB$ has
-[[finite products]]. This setup leads to a tidy definition of existential quantifiers 
-as left adjoints $\exists_{Y} : \cE_{X \times Y} \to \cE{X}$ to the base changes along projections
-$\pi : X \times Y \to X$:
+Let $\cE \liesover \cB$ be a [[cartesian fibration]], which we shall
+view as a setting for some sort of logic or type theory. In particular,
+we shall view the corresponding [[base change]] functors $f^{*} :
+\cE_{Y} \to \cE_{X}$ as an operation of substitution on
+predicates/types, and assume that $\cB$ has [[finite products]]. This
+setup leads to a tidy definition of existential quantifiers as left
+adjoints $\exists_{Y} : \cE_{X \times Y} \to \cE{X}$ to the base changes
+along projections $\pi : X \times Y \to X$:
 
-- The introduction rule is given by the unit $\eta : \cE_{X}(P, \exists_{Y} (\pi^{*} P))$;
-- The elimination rule is given by the counit $\eps : \cE_{X \times Y}(\pi^{*}(\exists_{Y} P), P)$; and
+- The introduction rule is given by the unit
+    $\eta : \cE_{X}(P, \exists_{Y} (\pi^{*} P))$;
+- The elimination rule is given by the counit
+    $\eps : \cE_{X \times Y}(\pi^{*}(\exists_{Y} P), P)$; and
 - The $\beta$ and $\eta$ rules are given by the zig-zag equations.
 
-This story is quite elegant, but there is a missing piece: how do substitutions
-interact with $\exists$, or, in categorical terms, how do base change functors
-commute with their left adjoints? In particular, consider the following
-diagram:
+This story is quite elegant, but there is a missing piece: how do
+substitutions interact with $\exists$, or, in categorical terms, how do
+base change functors commute with their left adjoints? In particular,
+consider the following diagram:
 
 ~~~{.quiver}
 \begin{tikzcd}
@@ -57,7 +60,8 @@ diagram:
 \end{tikzcd}
 ~~~
 
-Ideally, we'd like $\sigma^*({\exists_{X} P}) \iso \exists_{X}((\sigma \times \id)^{*} P)$,
+Ideally, we'd like
+$\sigma^*({\exists_{X} P}) \iso \exists_{X}((\sigma \times \id)^{*} P)$,
 corresponding to the usual substitution rule for quantifiers. Somewhat
 surprisingly, this does not always hold; we always have a map
 $$\exists_{X}((\sigma \times \id)^{*} P) \to \sigma^*({\exists_{X} P})$$
@@ -69,18 +73,19 @@ under substitution.
 
 ## Left Beck-Chevalley conditions
 
-A **left Beck-Chevalley condition** characterises well-behaved left adjoints
-to base change. Typically, this is done by appealing to properties of
-base change, but we opt to use a a more local definition in
-terms of [[cartesian|cartesian map]] and [[cocartesian|cocartesian map]]
-maps. This has the benefit of working in displayed categories that may
-be missing some cartesian maps.
+A **left Beck-Chevalley condition** characterises well-behaved left
+adjoints to base change. Typically, this is done by appealing to
+properties of base change, but we opt to use a a more local definition
+in terms of [[cartesian|cartesian map]] and [[cocartesian|cocartesian
+map]] maps. This has the benefit of working in displayed categories that
+may be missing some cartesian maps.
 
 :::{.definition #left-beck-chevalley-condition}
-Explicitly, a square $fg = hk$ in $\cB$ satisfies the left Beck-Chevalley
-condition if for every square $f'g' = h'k'$ over $fg = hk$, if $g'$ and
-$h'$ are cartesian and $f'$ is cocartesian, then $k'$ is cocartesian.
-This is best understood diagrammatically, so consider the diagram below:
+Explicitly, a square $fg = hk$ in $\cB$ satisfies the left
+Beck-Chevalley condition if for every square $f'g' = h'k'$ over $fg =
+hk$, if $g'$ and $h'$ are cartesian and $f'$ is cocartesian, then $k'$
+is cocartesian.  This is best understood diagrammatically, so consider
+the diagram below:
 
 ~~~{.quiver}
 \begin{tikzcd}
@@ -104,8 +109,9 @@ This is best understood diagrammatically, so consider the diagram below:
 ~~~
 
 If all the morphisms marked in red are (co)cartesian, then the morphism
-marked in blue must be cocartesian. To put things more succinctly, cocartesian
-morphisms can be pulled back along pairs of cartesian morphisms.
+marked in blue must be cocartesian. To put things more succinctly,
+cocartesian morphisms can be pulled back along pairs of cartesian
+morphisms.
 :::
 
 
@@ -139,9 +145,10 @@ module _
 
 ## Beck-Chevalley and left adjoints to base change
 
-This may seem somewhat far removed from the intuition we provided earlier,
-but it turns out that the two notions are equivalent! Proving this is
-a bit involved though, so we will need some intermediate lemmas first.
+This may seem somewhat far removed from the intuition we provided
+earlier, but it turns out that the two notions are equivalent! Proving
+this is a bit involved though, so we will need some intermediate lemmas
+first.
 
 <!--
 ```agda
@@ -167,9 +174,9 @@ module _
 ```
 -->
 
-In particular, let us consider a commuting square of morphisms $fg = hk$ in
-$\cB$ such that we have cocartesian lifts over $f, k$, and cartesian lifts
-over $g, h$, as in the following diagram.
+In particular, let us consider a commuting square of morphisms $fg = hk$
+in $\cB$ such that we have cocartesian lifts over $f, k$, and cartesian
+lifts over $g, h$, as in the following diagram.
 
 ~~~{.quiver}
 \begin{tikzcd}
@@ -212,9 +219,9 @@ over $g, h$, as in the following diagram.
 ```
 -->
 
-Now, fix some $B' : \cE_{B}$. We can form the following immortal pentagonal
-diagram by repeatedly performing taking lifts of $B'$ and applying various
-universal properties.
+Now, fix some $B' : \cE_{B}$. We can form the following immortal
+pentagonal diagram by repeatedly performing taking lifts of $B'$ and
+applying various universal properties.
 
 ~~~{.quiver}
 \begin{tikzcd}
@@ -267,9 +274,9 @@ universal properties.
 ```
 
 The immortal pentagon diagram above *almost* lets us "interpolate" $B'$
-around the entire square in the base, but there is a conspicuous gap between $h^*f_!(B')$
-and $k_!g^*(B')$; this is precisely the missing map that the Beck-Chevalley condition
-ought to give us.
+around the entire square in the base, but there is a conspicuous gap
+between $h^*f_!(B')$ and $k_!g^*(B')$; this is precisely the missing map
+that the Beck-Chevalley condition ought to give us.
 
 ```agda
     left-beck-chevalley→comparison-invertible
@@ -278,8 +285,8 @@ ought to give us.
 ```
 
 First, observe that the map $(\iota \circ \pi)^{*}$ fits into a square
-with 2 cartesian sides and 1 cocartesian side; so can apply Beck-Chevalley
-to deduce that it is cocartesian.
+with 2 cartesian sides and 1 cocartesian side; so can apply
+Beck-Chevalley to deduce that it is cocartesian.
 
 ~~~{.quiver}
 \begin{tikzcd}
@@ -318,20 +325,21 @@ to deduce that it is cocartesian.
         module h^*-interp = is-cocartesian h^*-interp-cocartesian
 ```
 
-Notably, this lets us factor the map $\iota : \cE_{k}(g^{*}(B'),k_{!}g^{*}(B'))$
-to get a vertical map $\cE(h^{*}f_{!}(B'), k_{!}g^{*}(B'))$ that fits neatly
-into the gap in the pentagon.
+Notably, this lets us factor the map $\iota :
+\cE_{k}(g^{*}(B'),k_{!}g^{*}(B'))$ to get a vertical map
+$\cE(h^{*}f_{!}(B'), k_{!}g^{*}(B'))$ that fits neatly into the gap in
+the pentagon.
 
 ```agda
         comparison⁻¹ : Hom[ id ] (h.^* (f.^! b')) (k.^! (g.^* b'))
         comparison⁻¹ = h^*-interp.universalv (k.ι (g.^* b'))
 ```
 
-We can show that our putative inverse is a left inverse of the comparison
-map by appealing to uniqueness of both maps into and maps out of $h^*f_!(B')$,
-as it is simultaneously a cartesian and a cocartesian lift. This
-yields the following hexagonal goal, which we can show commutes by a short
-diagram chase.
+We can show that our putative inverse is a left inverse of the
+comparison map by appealing to uniqueness of both maps into and maps out
+of $h^*f_!(B')$, as it is simultaneously a cartesian and a cocartesian
+lift. This yields the following hexagonal goal, which we can show
+commutes by a short diagram chase.
 
 ~~~{.quiver}
 \begin{tikzcd}
@@ -360,9 +368,9 @@ diagram chase.
             f.ι b' ∘' g.π b'                                                         ∎
 ```
 
-The right inverse is a bit trickier. We start by appealing to the uniqueness
-of maps into the cocartesian lift $k_{!}g^{*}(B')$, which reduces the
-goal to the following diagram.
+The right inverse is a bit trickier. We start by appealing to the
+uniqueness of maps into the cocartesian lift $k_{!}g^{*}(B')$, which
+reduces the goal to the following diagram.
 
 ~~~{.quiver}
 \begin{tikzcd}
@@ -384,9 +392,9 @@ This means that we have:
 
 $$((\iota \circ \pi)_{!})^{*} \circ \iota = ((\iota \circ \pi)^{*})_{!} \circ \iota = (\iota \circ \pi)^{*}$$
 
-This reduces the problem to showing that $\iota_{!} \circ (\iota \circ \pi)^{*} = \iota$,
-which follows immediately from commutativity of $(\iota \circ \pi)^{*}$ as
-a cocartesian map.
+This reduces the problem to showing that $\iota_{!} \circ (\iota \circ
+\pi)^{*} = \iota$, which follows immediately from commutativity of
+$(\iota \circ \pi)^{*}$ as a cocartesian map.
 
 ```agda
         left-beck-invr : comparison⁻¹ ∘' h^*k^!-comparison b' ≡[ idl id ] id'
@@ -398,13 +406,14 @@ a cocartesian map.
           k.ι (g.^* b')                                            ∎
 ```
 
-We shall now show the converse of our previous statement: if
-the comparison map from earlier is invertible, then the Beck-Chevalley
-property holds for our square. At a first glance, this seems a bit tricky:
-the Beck-Chevalley property talks about an arbitrary square of (co)cartesian
-morphisms, but the comparison map only refers to a *particular* square.
-Luckily, we can reduce the Beck-Chevalley property to checking if the
-interpolation map $(\iota \circ \pi)^{*}$ is cocartesian.
+We shall now show the converse of our previous statement: if the
+comparison map from earlier is invertible, then the Beck-Chevalley
+property holds for our square. At a first glance, this seems a bit
+tricky: the Beck-Chevalley property talks about an arbitrary square of
+(co)cartesian morphisms, but the comparison map only refers to a
+*particular* square.  Luckily, we can reduce the Beck-Chevalley property
+to checking if the interpolation map $(\iota \circ \pi)^{*}$ is
+cocartesian.
 
 ```agda
     interp-cocartesian→left-beck-chevalley
@@ -413,13 +422,15 @@ interpolation map $(\iota \circ \pi)^{*}$ is cocartesian.
 ```
 
 <details>
-<summary>The full proof is rather tedious, so we shall only present a
-short sketch. The key fact we shall use is that the (co)domains of (co)cartesian
-morphisms over the same map in the base are vertically isomorphic. This lets us
-connect an arbitrary square of (co)cartesian morphisms to the square formed
-via lifts with a bunch of vertical isos, which lets us transfer the Beck-Chevalley
-property.
+<summary>
+The full proof is rather tedious, so we shall only present a short
+sketch. The key fact we shall use is that the (co)domains of
+(co)cartesian morphisms over the same map in the base are vertically
+isomorphic. This lets us connect an arbitrary square of (co)cartesian
+morphisms to the square formed via lifts with a bunch of vertical isos,
+which lets us transfer the Beck-Chevalley property.
 </summary>
+
 ```agda
     interp-cocartesian→left-beck-chevalley h^*interp-cocart {a'} {b'} {c'} {d'} {f'} {g'} {h'} {k'} q f'-cocart g'-cart h'-cart =
       coe0→1 (λ i → is-cocartesian E ((cancell (idl _) ∙ idr _) i) (square i))
@@ -469,12 +480,12 @@ property.
 ```
 </details>
 
-On to the converse! Suppose that the comparison map
-is invertible, and denote the inverse $\alpha$. By our previous lemma,
-it suffices to show that the interpolant $(\iota \circ \pi)^{*}$ is cocartesian.
-Moreover, cocartesian maps are stable under precomposition of isomorphisms,
-so it suffices to show that $\alpha \circ (\iota \circ \pi)^{*}$ is cocartesian.
-A short calculation reveals that:
+On to the converse! Suppose that the comparison map is invertible, and
+denote the inverse $\alpha$. By our previous lemma, it suffices to show
+that the interpolant $(\iota \circ \pi)^{*}$ is cocartesian.  Moreover,
+cocartesian maps are stable under precomposition of isomorphisms, so it
+suffices to show that $\alpha \circ (\iota \circ \pi)^{*}$ is
+cocartesian.  A short calculation reveals that:
 
 $$
 \begin{align*}
@@ -485,8 +496,8 @@ $$
 \end{align*}
 $$
 
-Finally, since $((\iota \circ\ \pi)_{!})^{*}$ is monic, we have $\alpha \circ (\iota \circ \pi)^{*} = \iota$,
-which is cocartesian!
+Finally, since $((\iota \circ\ \pi)_{!})^{*}$ is monic, we have $\alpha
+\circ (\iota \circ \pi)^{*} = \iota$, which is cocartesian!
 
 ```agda
     comparison-invertible→left-beck-chevalley
@@ -513,11 +524,12 @@ which is cocartesian!
 ```
 
 Now that we have our arsenal of lemmas, we shall tackle our original
-question: how are adjoints to base change related to our formulation
-of Beck-Chevalley? To start, suppose that we have a commutative square
-$fg = hk$, and left adjoints $f_{!}$ and $k_{!}$ to base change along $f$ and $k$,
-respectively. Moreover, recall that [cocartesian lifts are left adjoints to base change],
-so we have cocartesian lifts along $f$ and $k$.
+question: how are adjoints to base change related to our formulation of
+Beck-Chevalley? To start, suppose that we have a commutative square $fg
+= hk$, and left adjoints $f_{!}$ and $k_{!}$ to base change along $f$
+and $k$, respectively. Moreover, recall that [cocartesian lifts are left
+adjoints to base change], so we have cocartesian lifts along $f$ and
+$k$.
 
 [cocartesian lifts are left adjoints to base change]: Cat.Displayed.Cocartesian.Weak.html#weak-cocartesian-morphisms-as-left-adjoints-to-base-change
 
@@ -557,9 +569,9 @@ so we have cocartesian lifts along $f$ and $k$.
 ```
 -->
 
-The commutative square $fg = hk$ lifts to a natural iso $g^{*}f^{*} \iso k^{*}f^{*}$,
-which yields a natural transformation $k_{!}g^{*} \to h^{*}f_{!}$ via
-the calculus of [[mates]].
+The commutative square $fg = hk$ lifts to a natural iso $g^{*}f^{*} \iso
+k^{*}f^{*}$, which yields a natural transformation $k_{!}g^{*} \to
+h^{*}f_{!}$ via the calculus of [[mates]].
 
 ```agda
       private
@@ -570,8 +582,9 @@ the calculus of [[mates]].
             (Isoⁿ.to (base-change-square-ni E E-fib p)) .η b'
 ```
 
-Moreover, the comparison map we get from the mate of $g^{*}f^{*} \iso k^{*}f^{*}$
-is the same comparison map we defined in the previous section.
+Moreover, the comparison map we get from the mate of $g^{*}f^{*} \iso
+k^{*}f^{*}$ is the same comparison map we defined in the previous
+section.
 
 ```agda
         opaque
@@ -582,7 +595,8 @@ is the same comparison map we defined in the previous section.
 ```
 
 <details>
-<summary>This essentially *has* to hold, as there are so many universal
+<summary>
+This essentially *has* to hold, as there are so many universal
 properties floating around. Unfortunately, the proof is a bit more
 tedious than one would hope, so we omit the details.
 </summary>
@@ -601,9 +615,10 @@ tedious than one would hope, so we omit the details.
 ```
 </details>
 
-We can combine this with our previous results about squares of (co)cartesian
-lifts to deduce that the Beck-Chevalley condition holds if and only if
-the comparison map derived from the aforementioned mate is invertible.
+We can combine this with our previous results about squares of
+(co)cartesian lifts to deduce that the Beck-Chevalley condition holds if
+and only if the comparison map derived from the aforementioned mate is
+invertible.
 
 ```agda
       left-beck-chevalley→mate-invertible
@@ -633,9 +648,10 @@ the comparison map derived from the aforementioned mate is invertible.
 ## Right Beck-Chevalley conditions
 
 Left Beck-Chevalley conditions require stability of cocartesian maps
-under cartesian maps. We can dualize this to obtain the **right Beck-Chevalley
-conditions**, which ensures stability of cartesian maps under pushforward
-along cocartesian maps. As before, this is best understood diagrammatically:
+under cartesian maps. We can dualize this to obtain the **right
+Beck-Chevalley conditions**, which ensures stability of cartesian maps
+under pushforward along cocartesian maps. As before, this is best
+understood diagrammatically:
 
 ~~~{.quiver}
 \begin{tikzcd}

--- a/src/Cat/Displayed/BeckChevalley.lagda.md
+++ b/src/Cat/Displayed/BeckChevalley.lagda.md
@@ -65,7 +65,7 @@ surprisingly, this does not always hold; we always have a map
 
 $$\exists_{X}((\sigma \times \id)^{*} P) \to (\sigma)^*{\exists_{X} P}$$
 
-that comes from some adjoint yoga, but this map is not neccesarily invertible!
+that comes from some adjoint yoga, but this map is not necessarily invertible!
 This leads us to the main topic of this page: the **Beck-Chevalley**
 conditions are a set of properties that ensure that the aforementioned
 map is invertible, which in turn ensures that our quantifiers are stable
@@ -84,7 +84,7 @@ be missing some cartesian maps.
 Explicitly, a square $fg = hk$ in $\cB$ satisfies the left Beck-Chevalley
 condition if for every square $f'g' = h'interp$ over $fg = hk$, if $g'$ and
 $h'$ are cartesian and $f'$ is cocartesian, then $interp$ is cocartesian.
-This is best understood diagramatically: suppose we are in a situation
+This is best understood diagrammatically: suppose we are in a situation
 like the diagram below:
 
 ~~~{.quiver}
@@ -272,7 +272,7 @@ universal properties.
 ```
 
 The immortal pentagon diagram above *almost* lets us "interpolate" $B'$
-around the entire square in the base, but there is a conspicous gap between $h^*f_!(B')$
+around the entire square in the base, but there is a conspicuous gap between $h^*f_!(B')$
 and $k_!g^*(B')$; this is precisely the missing map that the Beck-Chevalley condition
 ought to give us.
 
@@ -387,7 +387,7 @@ apply the universal property of $k$ followed by the universal property
 of $h$, or we can apply the universal property of $k$ followed by $h$.
 This means that we have:
 
-$$((\iota \circ \pi)_{!})^{*} \circ \iota = ((\iota \circ \pi)^{*})_{!} \circ \iota = (\iota \circ \pi)^{*}$
+$$((\iota \circ \pi)_{!})^{*} \circ \iota = ((\iota \circ \pi)^{*})_{!} \circ \iota = (\iota \circ \pi)^{*}$$
 
 This reduces the problem to showing that $\iota_{!} \circ (\iota \circ \pi)^{*} = \iota$,
 which follows immediately from commutativity of $(\iota \circ \pi)^{*}$ as

--- a/src/Cat/Displayed/BeckChevalley.lagda.md
+++ b/src/Cat/Displayed/BeckChevalley.lagda.md
@@ -4,6 +4,7 @@ description: |
 ---
 <!--
 ```agda
+open import Cat.Displayed.Cocartesian.Weak
 open import Cat.Displayed.Cocartesian
 open import Cat.Displayed.Cartesian
 open import Cat.Displayed.Fibre
@@ -12,12 +13,14 @@ open import Cat.Functor.Adjoint.Mate
 open import Cat.Functor.Naturality
 open import Cat.Functor.Adjoint
 open import Cat.Prelude
+open import Cat.Displayed.Cartesian.Indexing
 
+import Cat.Displayed.Fibre.Reasoning
 import Cat.Displayed.Reasoning
 import Cat.Displayed.Morphism
+import Cat.Functor.Reasoning
 import Cat.Reasoning
 
-import Cat.Displayed.Cartesian.Indexing
 ```
 -->
 ```agda
@@ -80,8 +83,8 @@ be missing some cartesian maps.
 
 :::{.definition #left-beck-chevalley-condition}
 Explicitly, a square $fg = hk$ in $\cB$ satisfies the left Beck-Chevalley
-condition if for every square $f'g' = h'k'$ over $fg = hk$, if $g'$ and
-$h'$ are cartesian and $f'$ is cocartesian, then $k'$ is cocartesian.
+condition if for every square $f'g' = h'interp$ over $fg = hk$, if $g'$ and
+$h'$ are cartesian and $f'$ is cocartesian, then $interp$ is cocartesian.
 This is best understood diagramatically: suppose we are in a situation
 like the diagram below:
 
@@ -126,25 +129,25 @@ module _
 -->
 
 ```agda
-  record left-beck-chevalley
-    {a b c d : Ob}
-    (f : Hom b d) (g : Hom a b) (h : Hom c d) (k : Hom a c)
-    (p : f ∘ g ≡ h ∘ k)
-    : Type (o ⊔ ℓ ⊔ o' ⊔ ℓ') where
-    no-eta-equality
-    field
-      cocart-stable
-        : {a' : Ob[ a ]} {b' : Ob[ b ]} {c' : Ob[ c ]} {d' : Ob[ d ]}
-        → {f' : Hom[ f ] b' d'} {g' : Hom[ g ] a' b'}
-        → {h' : Hom[ h ] c' d'} {k' : Hom[ k ] a' c'}
-        → f' ∘' g' ≡[ p ] h' ∘' k'
-        → is-cocartesian E f f' → is-cartesian E g g'
-        → is-cartesian E h h' → is-cocartesian E k k'
+  left-beck-chevalley
+    : {a b c d : Ob}
+    → (f : Hom b d) (g : Hom a b) (h : Hom c d) (k : Hom a c)
+    → (p : f ∘ g ≡ h ∘ k)
+    → Type _
+  left-beck-chevalley {a} {b} {c} {d} f g h k p =
+    ∀ {a' : Ob[ a ]} {b' : Ob[ b ]} {c' : Ob[ c ]} {d' : Ob[ d ]}
+    → {f' : Hom[ f ] b' d'} {g' : Hom[ g ] a' b'}
+    → {h' : Hom[ h ] c' d'} {k' : Hom[ k ] a' c'}
+    → f' ∘' g' ≡[ p ] h' ∘' k'
+    → is-cocartesian E f f' → is-cartesian E g g'
+    → is-cartesian E h h' → is-cocartesian E k k'
 ```
 
-This may seem somewhat far removed from the intuition we provided earlier,
-so we shall spend some time proving that the two notions are, in fact, equivalent.
+## Beck-Chevalley and left adjoints to base change
 
+This may seem somewhat far removed from the intuition we provided earlier,
+but it turns out that the two notions are equivalent! Proving this is
+a bit involved though, so we will need some intermediate lemmas first.
 
 <!--
 ```agda
@@ -152,27 +155,14 @@ module _
   {o ℓ o' ℓ'}
   {B : Precategory o ℓ}
   {E : Displayed B o' ℓ'}
-  (E-fib : Cartesian-fibration E)
   where
-  open Precategory B
+  open Cat.Reasoning B
   open Displayed E
 
-  open Cat.Displayed.Cartesian.Indexing E E-fib
   open Cat.Displayed.Reasoning E
   open Cat.Displayed.Morphism E
 
-  module E↓ {x} = Precategory (Fibre E x)
-  module _ {x y : Ob} (f : Hom x y) (y' : Ob[ y ]) where
-    open Cartesian-lift (Cartesian-fibration.has-lift E-fib f y')
-      using ()
-      renaming (x' to _^*_; lifting to π*)
-      public
-
-  module π* {x y : Ob} {f : Hom x y} {y' : Ob[ y ]} where
-    open Cartesian-lift (Cartesian-fibration.has-lift E-fib f y')
-      hiding (x'; lifting)
-      public
-
+  module Fib = Cat.Displayed.Fibre.Reasoning E
   open Functor
   open _=>_
 
@@ -183,66 +173,466 @@ module _
 ```
 -->
 
+In particular, let us consider a commuting square of morphisms $fg = hk$ in
+$\cB$ such that we have cocartesian lifts over $f, k$, and cartesian lifts
+over $g, h$, as in the following diagram.
+
+~~~{.quiver}
+\begin{tikzcd}
+  && C \\
+  A &&&& D \\
+  && B
+  \arrow["h"{description}, from=1-3, to=2-5]
+  \arrow["k"{description}, from=2-1, to=1-3]
+  \arrow["g"{description}, from=2-1, to=3-3]
+  \arrow["f"{description}, from=3-3, to=2-5]
+\end{tikzcd}
+~~~
 
 ```agda
-  left-beck-iso
-    : {Lᵍ : Functor (Fibre E a) (Fibre E b)}
-    → {Lʰ : Functor (Fibre E c) (Fibre E d)}
-    → Lᵍ ⊣ base-change g
-    → Lʰ ⊣ base-change h
-    → (p : f ∘ g ≡ h ∘ k)
-    → left-beck-chevalley E f g h k p
-    → ∀ {c'} → (Lᵍ .F₀ (k ^* c')) ≅↓ (f ^* Lʰ .F₀ c')
-  left-beck-iso {g = g} {h = h} {f = f} {k = k} {Lᵍ = Lᵍ} {Lʰ = Lʰ} L⊣g^* L⊣h^* p left-bc {c'} = {!!} where
-    module Lᵍ where
-      open Functor Lᵍ public
-      open _⊣_ L⊣g^* public
+  module _
+    {a b c d}
+    {f : Hom b d} {g : Hom a b} {h : Hom c d} {k : Hom a c}
+    (p : f ∘ g ≡ h ∘ k)
+    (f^! : ∀ b' → Cocartesian-lift E f b')
+    (g^* : ∀ b' → Cartesian-lift E g b')
+    (h^* : ∀ c' → Cartesian-lift E h c')
+    (k^! : ∀ c' → Cocartesian-lift E k c')
+    where
+```
 
-    module Lʰ where
-      open Functor Lʰ public
-      open _⊣_ L⊣h^* public
+<!--
+```agda
+    private
+      module f (b' : Ob[ b ]) where
+        open Cocartesian-lift (f^! b') renaming (y' to ^!_; lifting to ι) public
 
-    open left-beck-chevalley left-bc
+      module g (b' : Ob[ b ]) where
+        open Cartesian-lift (g^* b') renaming (x' to ^*; lifting to π) public
 
-    comparison : Lᵍ F∘ base-change k => base-change f F∘ Lʰ
-    comparison =
-      mate L⊣h^* L⊣g^* (base-change k) (base-change f)
-        (Isoⁿ.from (base-change-square-ni p))
+      module h (d' : Ob[ d ]) where
+        open Cartesian-lift (h^* d') renaming (x' to ^*; lifting to π) public
 
-    -- α : Hom[ g ] (k ^* c') (f ^* Lʰ.₀ c')
-    -- α = π*.universal' {!!} (π* h (Lʰ.F₀ c') ∘' Lʰ.η c' ∘' π* k c')
-    α : Hom[ k ] (g ^* Lᵍ.F₀ (k ^* c')) (h ^* {!!})
-    α = {!!}
+      module k (a' : Ob[ a ]) where
+        open Cocartesian-lift (k^! a') renaming (y' to ^!_; lifting to ι) public
+```
+-->
 
-    α-cocartesian : is-cocartesian E k α
-    α-cocartesian = cocart-stable {!!} {!!} π*.cartesian π*.cartesian
+Now, fix some $B' : \cE_{B}$. We can form the following immortal pentagonal
+diagram by repeatedly performing taking lifts of $B$ and applying various
+universal properties.
 
-    module α = is-cocartesian α-cocartesian
+~~~{.quiver}
+\begin{tikzcd}
+  & {h^*f_!(B')} && {k_!g^*(B')} \\
+  \\
+  {g^*B'} & C && C & {f_!B'} \\
+  && {B'} \\
+  A &&&& D \\
+  && B
+  \arrow["{((\iota \circ \pi)_{!})^*}"{description}, curve={height=12pt}, to=1-4, from=1-2]
+  \arrow["{((\iota \circ \pi)^{*})_!}"{description}, curve={height=-12pt}, to=1-4, from=1-2]
+  \arrow[shorten <=3pt, shorten >=3pt, equals, from=1, to=0]
+  \arrow[lies over, from=1-2, to=3-2]
+  \arrow[lies over, from=1-4, to=3-4]
+  \arrow["{(\iota \circ \pi)_{!}}"{description}, from=1-4, to=3-5]
+  \arrow["{(\iota \circ \pi)^{*}}"{description}, from=3-1, to=1-2]
+  \arrow["\pi"{description}, from=3-1, to=4-3]
+  \arrow[lies over, from=3-1, to=5-1]
+  \arrow["\id"{description}, from=3-2, to=3-4]
+  \arrow[lies over, from=3-4, to=5-5]
+  \arrow[lies over, from=3-5, to=5-5]
+  \arrow["\iota"{description}, from=4-3, to=3-5]
+  \arrow[lies over, from=4-3, to=6-3]
+  \arrow["k"{description}, from=5-1, to=3-2]
+  \arrow["g"{description}, from=5-1, to=6-3]
+  \arrow["f"{description}, from=6-3, to=5-5]
+\end{tikzcd}
+~~~
 
-    comparison⁻¹ : Hom[ id ] (f ^* Lʰ.₀ c') (Lᵍ.₀ (k ^* c'))
-    comparison⁻¹ = {!α.universalv!}
-    --   let module foo = is-cocartesian (cocart-stable {a' = g ^* Lᵍ.₀ (k ^* c')} {b' = Lᵍ.₀ (k ^* c')} {c' = h ^* Lʰ.₀ c'} {d' = Lʰ.₀ c'}
-    --              {f' = {!!}}
-    --              {k' = hom[ {!!} ] ({!!} ∘' {!!} ∘' π* g (Lᵍ.₀ (k ^* c')))} {!!} {!!} π*.cartesian π*.cartesian)
-    --   in {!!}
+```agda
+    private
+      h^*-interp : ∀ b' → Hom[ k ] (g.^* b') (h.^* (f.^! b'))
+      h^*-interp b' = h.universal' (f.^! b') (sym p) (f.ι b' ∘' g.π b')
+
+      k^!-interp : ∀ b' → Hom[ h ] (k.^! g.^* b') (f.^! b')
+      k^!-interp b' = k.universal' (g.^* b') (sym p) (f.ι b' ∘' g.π b')
+
+      h^*k^!-comparison : ∀ b' → Hom[ id ] (k.^! (g.^* b')) (h.^* (f.^! b'))
+      h^*k^!-comparison b' = h.universalv (f.^! b') (k^!-interp b')
+
+      k^!h^*-comparison : ∀ b' → Hom[ id ] (k.^! (g.^* b')) (h.^* (f.^! b'))
+      k^!h^*-comparison b' = k.universalv (g.^* b') (h^*-interp b')
+
+      comparison-square : ∀ {b'} → h^*k^!-comparison b' ≡ k^!h^*-comparison b'
+      comparison-square {b'} =
+        h.uniquep₂ (f.^! b') _ _ (idr _) _ _
+          (h.commutesv _ _)
+          (k.uniquep (g.^* b') _ (idr _) _ _
+            (pullr[] _ (k.commutesv (g.^* b') _)
+             ∙[] h.commutesp _ (sym p) (f.ι b' ∘' g.π b')))
+```
+
+The immortal pentagon diagram above *almost* lets us "interpolate" $B'$
+around the entire square in the base, but there is a conspicous gap between $h^*f_!(B')$
+and $k_!g^*(B')$; this is precisely the missing map that the Beck-Chevalley condition
+ought to give us.
+
+```agda
+    left-beck-chevalley→comparison-invertible
+      : left-beck-chevalley E f g h k p
+      → ∀ {b'} → is-invertible↓ (h^*k^!-comparison b')
+```
+
+First, observe that the map $(\iota \circ \pi)^{*}$ fits into a square
+with 2 cartesian sides and 1 cocartesian side; so can apply Beck-Chevalley
+to deduce that $(\iota \circ \pi)^{*}$ is cocartesian.
+
+~~~{.quiver}
+\begin{tikzcd}
+  &&& {h^*k_!(B')} \\
+  {g^*(B')} &&&&& {f_!(B')} \\
+  && {B'} & C \\
+  A &&&&& D \\
+  && B
+  \arrow["\pi"{description}, color={rgb,255:red,214;green,92;blue,92}, from=1-4, to=2-6]
+  \arrow[from=1-4, to=3-4]
+  \arrow["{(\iota \circ \pi)^*}"{description}, color={rgb,255:red,92;green,92;blue,214}, from=2-1, to=1-4]
+  \arrow["\pi"{description}, color={rgb,255:red,214;green,92;blue,92}, from=2-1, to=3-3]
+  \arrow[lies over, from=2-1, to=4-1]
+  \arrow[lies over, from=2-6, to=4-6]
+  \arrow["\iota"{description}, color={rgb,255:red,214;green,92;blue,92}, from=3-3, to=2-6]
+  \arrow[lies over, from=3-3, to=5-3]
+  \arrow["h"{description}, from=3-4, to=4-6]
+  \arrow["k"{description}, from=4-1, to=3-4]
+  \arrow["g"{description}, from=4-1, to=5-3]
+  \arrow["f"{description}, from=5-3, to=4-6]
+\end{tikzcd}
+~~~
+
+```agda
+    left-beck-chevalley→comparison-invertible left-bc {b'} =
+      make-invertible↓ comparison⁻¹ left-beck-invl left-beck-invr
+      where
+        h^*-interp-cocartesian : is-cocartesian E k (h^*-interp b')
+        h^*-interp-cocartesian =
+          left-bc
+            (symP (h.commutesp (f.^! b') (sym p) (f.ι b' ∘' g.π b')))
+            (f.cocartesian b')
+            (g.cartesian b')
+            (h.cartesian (f.^! b'))
+
+        module h^*-interp = is-cocartesian h^*-interp-cocartesian
+```
+
+Notably, this lets us factor the map $\iota : \cE_{k}(g^{*}(B'),k_{!}g^{*}(B'))$
+to get a vertical map $\cE()^{*}f_{!}(B'), k_{!}g^{*}(B'))$ that fits neatly
+into the gap in the pentagon.
+
+```agda
+        comparison⁻¹ : Hom[ id ] (h.^* (f.^! b')) (k.^! (g.^* b'))
+        comparison⁻¹ = h^*-interp.universalv (k.ι (g.^* b'))
+```
+
+We can show that our putative inverse is a left inverse of the comparison
+map by appealing to uniqueness of both maps into and maps out of $h^*f_!(B')$,
+as $h^*f_!(B')$ is simultaneously a cartesian and a cocartesian lift. This
+yields the following hexagonal goal, which we can show commutes by a short
+diagram chase.
+
+~~~{.quiver}
+\begin{tikzcd}
+  && {k_{!}g^{*}(B')} \\
+  {h^{*}f_{!}(b')} &&&& {h^{*}f_{!}(b')} \\
+  \\
+  {g^{*}(B')} &&&& {f_!(B')} \\
+  && {B'}
+  \arrow["{((\iota \circ \pi)_{!})^{*}}"{description}, from=1-3, to=2-5]
+  \arrow["{\iota_!}"{description}, from=2-1, to=1-3]
+  \arrow["\pi"{description}, from=2-5, to=4-5]
+  \arrow["{(\iota \circ \pi)^*}"{description}, from=4-1, to=2-1]
+  \arrow["\pi"{description}, from=4-1, to=5-3]
+  \arrow["\iota"{description}, from=5-3, to=4-5]
+\end{tikzcd}
+~~~
+
+```agda
+        left-beck-invl : h^*k^!-comparison b' ∘' comparison⁻¹ ≡[ idl id ] id'
+        left-beck-invl =
+          symP $ h.uniquep₂ _ _ _ (elimr (idl id)) _ _ (idr' _) $
+          symP $ h^*-interp.uniquep₂ _ _ _ _ _ (h.commutesp _ (sym p) (f.ι b' ∘' g.π b')) $
+            (h.π (f.^! b') ∘' h^*k^!-comparison b' ∘' comparison⁻¹) ∘' h^*-interp b' ≡[]⟨ pullr[] _ (pullr[] _ (h^*-interp.commutesv _)) ⟩
+            h.π (f.^! b') ∘' h^*k^!-comparison b' ∘' k.ι (g.^* b')                   ≡[]⟨ pulll[] _ (h.commutesv (f.^! b') _) ⟩
+            k^!-interp b' ∘' k.ι (g.^* b')                                           ≡[]⟨ k.commutesp _ (sym p) (f.ι b' ∘' g.π b') ⟩
+            f.ι b' ∘' g.π b'                                                         ∎
+```
+
+The right inverse is a bit trickier. We start by appealing to the uniqueness
+of maps into the cocartesian lift $k_{!}g^{*}(B')$, which reduces the
+goal to the following diagram.
+
+~~~{.quiver}
+\begin{tikzcd}
+  {f_{!}g^{*}(B')} && {h^{*}f_{!}(B')} \\
+  \\
+  {g^{*}} && {f_{!}g^{*}(B')}
+  \arrow["{((\iota \circ \pi)_{!})^{*}}"{description}, from=1-1, to=1-3]
+  \arrow["{\iota_!}"{description}, from=1-3, to=3-3]
+  \arrow["\iota"{description}, from=3-1, to=1-1]
+  \arrow["\iota"{description}, from=3-1, to=3-3]
+\end{tikzcd}
+~~~
+
+If we go back to the immortal pentagon, we will notice that we actually
+have two equivalent ways of writing the comparison map: we can either
+apply the universal property of $k$ followed by the universal property
+of $h$, or we can apply the universal property of $k$ followed by $h$.
+This means that we have:
+
+$$((\iota \circ \pi)_{!})^{*} \circ \iota = ((\iota \circ \pi)^{*})_{!} \circ \iota = (\iota \circ \pi)^{*}$
+
+This reduces the problem to showing that $\iota_{!} \circ (\iota \circ \pi)^{*} = \iota$,
+which follows immediately from commutativity of $(\iota \circ \pi)^{*}$ as
+a cocartesian map.
+
+```agda
+        left-beck-invr : comparison⁻¹ ∘' h^*k^!-comparison b' ≡[ idl id ] id'
+        left-beck-invr =
+          symP $ k.uniquep₂ _ _ _ _ _ _ (idl' _) $
+          (comparison⁻¹ ∘' h^*k^!-comparison b') ∘' k.ι (g.^* b')  ≡[]⟨ (refl⟩∘'⟨ comparison-square) ⟩∘'⟨refl ⟩
+          (comparison⁻¹ ∘' k^!h^*-comparison b') ∘' k.ι (g.^* b')  ≡[]⟨ pullr[] _ (k.commutesv (g.^* b') _) ⟩
+          comparison⁻¹ ∘' h^*-interp b'                            ≡[]⟨ h^*-interp.commutesv _ ⟩
+          k.ι (g.^* b')                                            ∎
+```
+
+We shall now show the converse of our previous statement: if
+the comparison map from earlier is invertible, then the Beck-Chevalley
+property holds for our square. At a first glance, this seems a bit tricky:
+the Beck-Chevalley property talks about an arbitrary square of (co)cartesian
+morphisms, but the comparison map only references from a *particular* square.
+Luckily, we can reduce the Beck-Chevalley property to checking if the
+interpolation map $(\iota \circ \pi)^{*}$ is cocartesian.
+
+```agda
+    interp-cocartesian→left-beck-chevalley
+      : (∀ b' → is-cocartesian E k (h^*-interp b'))
+      → left-beck-chevalley E f g h k p
+```
+
+<details>
+<summary>The full proof is rather tedious, so we shall only present a
+short sketch. The key fact we shall use is that the (co)domains of (co)cartesian
+morphisms over the same map in the base are vertically isomorphic. This lets us
+connect an arbitrary square of (co)cartesian morphisms to the square formed
+via lifts with a bunch of vertical isos, which lets us transfer the Beck-Chevalley
+property.
+</summary>
+```agda
+    interp-cocartesian→left-beck-chevalley h^*interp-cocart {a'} {b'} {c'} {d'} {f'} {g'} {h'} {k'} q f'-cocart g'-cart h'-cart =
+      coe0→1 (λ i → is-cocartesian E ((cancell (idl _) ∙ idr _) i) (square i))
+        (cocartesian-∘ E (iso→cocartesian E γ) $
+         cocartesian-∘ E (iso→cocartesian E h^*δ) $
+         cocartesian-∘ E (h^*interp-cocart b') $
+         iso→cocartesian E α)
+      where
+        open _≅[_]_
+        module h' = is-cartesian h'-cart
+
+        α : a' ≅↓ g.^* b'
+        α = cartesian-domain-unique E g'-cart (g.cartesian b')
+
+        γ : h.^* d' ≅↓ c'
+        γ = cartesian-domain-unique E (h.cartesian d') h'-cart
+
+        δ : (f.^! b') ≅↓ d'
+        δ = cocartesian-codomain-unique E (f.cocartesian b') f'-cocart
+
+        h^*δ : h.^* (f.^! b') ≅↓ h.^* d'
+        h^*δ =
+          make-vertical-iso
+            (h.universal' d' id-comm (δ .to' ∘' h.π (f.^! b')))
+            (h.universal' (f.^! b') id-comm (δ .from' ∘' h.π d'))
+          (h.uniquep₂ _ _ _ _ _ _
+            (pulll[] _ (h.commutesp _ id-comm _)
+             ∙[] pullr[] _ (h.commutesp _ id-comm _)
+             ∙[] cancell[] _ (δ .invl'))
+            (idr' _))
+          (h.uniquep₂ _ _ _ _ _ _
+            (pulll[] _ (h.commutesp _ id-comm _)
+             ∙[] pullr[] _ (h.commutesp _ id-comm _)
+             ∙[] cancell[] _ (δ .invr'))
+            (idr' _))
+
+        abstract
+          square : γ .to' ∘' h^*δ .to' ∘' h^*-interp b' ∘' α .to' ≡[ cancell (idl _) ∙ idr _ ] k'
+          square =
+            h'.uniquep₂ _ _ _ _ _
+              (pulll[] _ (h'.commutesp (idr _) _)
+               ∙[] pulll[] _ (h.commutesp _ id-comm _)
+               ∙[] pullr[] _ (pulll[] _ (h.commutesp _ (sym p) _))
+               ∙[] pulll[] _ (pulll[] _ (f.commutesp _ (idl _) _))
+               ∙[] pullr[] _ (g.commutesp _ (idr _) _))
+              (symP q)
+```
+</details>
+
+On to the converse! Suppose that the comparison map
+is invertible, and denote the inverse $\alpha$. By our previous lemma,$((\iota \circ\ pi)_{!})^{*}$
+it suffices to show that the interpolant $(\iota \circ \pi)^{*}$ is cocartesian.
+Moreover, cocartesian maps are stable under precomposition of isomorphisms,
+so it suffices to show that $\alpha \circ (\iota \circ \pi)^{*}$ is cocartesian.
+A short calculation reveals that:
+
+$$
+\begin{align*}
+  ((\iota \circ\ pi)_{!})^{*} \circ \alpha \circ (\iota \circ \pi)^{*}
+  &= (\iota \circ \pi)^{*} \\
+  &= ((\iota \circ\ pi)^{*})_{!} \circ \iota \\
+  &= ((\iota \circ\ pi)_{!})^{*} \circ \iota \\
+\end{align*}
+$$
+
+Finally, $((\iota \circ\ pi)_{!})^{*}$ is monic, so we have $\alpha \circ (\iota \circ \pi)^{*} = \iota$,
+which is cocartesian!
+
+```agda
+    comparison-invertible→left-beck-chevalley
+      : (∀ b' → is-invertible↓ (h^*k^!-comparison b'))
+      → left-beck-chevalley E f g h k p
+    comparison-invertible→left-beck-chevalley comparison-inv =
+      interp-cocartesian→left-beck-chevalley λ b' →
+        cocartesian-vertical-section-stable E
+          (k.cocartesian (g.^* b'))
+          (invertible[]→from-has-retract[] (comparison-inv b'))
+          (comparison-inv-interp b')
+      where
+        module comparison b' = is-invertible[_] (comparison-inv b')
+
+        abstract
+          comparison-inv-interp : ∀ b' → comparison.inv' b' ∘' h^*-interp b' ≡[ idl k ] k.ι (g.^* b')
+          comparison-inv-interp b' =
+            cast[] $
+            invertible[]→monic[] (comparison-inv b') _ _ _ $
+            h^*k^!-comparison b' ∘' comparison.inv' b' ∘' h^*-interp b' ≡[]⟨ cancell[] _ (comparison.invl' b') ⟩
+            h^*-interp b'                                               ≡[]˘⟨ k.commutesv (g.^* b') (h^*-interp b') ⟩
+            k^!h^*-comparison b' ∘' k.ι (g.^* b')                       ≡[]˘⟨ comparison-square ⟩∘'⟨refl ⟩
+            h^*k^!-comparison b' ∘' k.ι (g.^* b')                       ∎
+```
+
+Now that we have our arsenal of lemmas, we shall tackle our original
+question: how are adjoints to base change related to our formulation
+of Beck-Chevalley? To start, suppose that we have a commutative square
+$fg = hk$, and left adjoints $f_{!}$ and $k_{!}$ to base change along $f$ and $k$,
+respectively. Moreover, recall that [cocartesian lifts are left adjoints to base change];
+so we have cocartesian lifts along $f$ and $k$.
+
+[cocartesian lifts are left adjoints to base change]: Cat.Displayed.Cocartesian.Weak.html#weak-cocartesian-morphisms-as-left-adjoints-to-base-change
+
+```agda
+  module _
+    (E-fib : Cartesian-fibration E)
+    {Lᶠ : Functor (Fibre E b) (Fibre E d)}
+    {Lᵏ : Functor (Fibre E a) (Fibre E c)}
+    (Lᶠ⊣f^* : Lᶠ ⊣ base-change E E-fib f)
+    (Lᵏ⊣k^* : Lᵏ ⊣ base-change E E-fib k)
+    (p : f ∘ g ≡ h ∘ k)
 ```
 
 
--- ## The dual case
+<!--
+```agda
+    where
+      open Cartesian-fibration E E-fib
+      private
+        module Lᶠ where
+          open Functor Lᶠ public
+          open _⊣_ Lᶠ⊣f^* public
 
--- ```agda
---   record cartesian-beck-chevalley
---     {a b c d : Ob}
---     (f : Hom b d) (g : Hom a b) (h : Hom c d) (k : Hom a c)
---     (p : f ∘ g ≡ h ∘ k)
---     : Type (o ⊔ ℓ ⊔ o' ⊔ ℓ') where
---     no-eta-equality
---     field
---       cart-stable
---         : {a' : Ob[ a ]} {b' : Ob[ b ]} {c' : Ob[ c ]} {d' : Ob[ d ]}
---         → {f' : Hom[ f ] b' d'} {g' : Hom[ g ] a' b'}
---         → {h' : Hom[ h ] c' d'} {k' : Hom[ k ] a' c'}
---         → f' ∘' g' ≡[ p ] h' ∘' k'
---         → is-cocartesian E f f' → is-cartesian E g g'
---         → is-cocartesian E k k' → is-cartesian E h h'
--- ```
+        module Lᵏ where
+          open Cat.Functor.Reasoning Lᵏ public
+          open _⊣_ Lᵏ⊣k^* public
+
+        module f (b' : Ob[ b ]) where
+          open Cocartesian-lift (left-adjoint→cocartesian-lift E E-fib Lᶠ⊣f^* b')
+            renaming (y' to ^!_; lifting to ι)
+            public
+
+        module k (b' : Ob[ a ]) where
+          open Cocartesian-lift (left-adjoint→cocartesian-lift E E-fib Lᵏ⊣k^* b')
+            renaming (y' to ^!_; lifting to ι)
+            public
+```
+-->
+
+The commutative square $fg = hk$ lifts to a natural iso $g^{*}f^{*} \iso k^{*}f^{*}$,
+which yields a natural transformation $k_{!}g^{*} \to h^{*}f_{!}$ via
+the calculus of [[mates]].
+
+```agda
+      private
+        comparison : ∀ b' → Hom[ id ] (k.^! (g ^* b')) (h ^* (f.^! b'))
+        comparison b' =
+          mate Lᶠ⊣f^* Lᵏ⊣k^*
+            (base-change E E-fib g) (base-change E E-fib h)
+            (Isoⁿ.to (base-change-square-ni E E-fib p)) .η b'
+```
+
+Moreover, the comparison map we get from the mate of $g^{*}f^{*} \iso k^{*}f^{*}$
+is the same comparison map we defined in the previous section.
+
+```agda
+        opaque
+          unfolding base-change-square
+          mate-comparison
+            : ∀ {b'}
+            → comparison b' ≡ π*.universalv (k.universal' _ (sym p) (f.ι b' ∘' π* g b'))
+```
+
+<details>
+<summary>This essentially *has* to hold, as there are so many universal
+properties floating around. Unfortunately, the proof is a bit more
+tedious than one would hope, so we omit the details.
+</summary>
+
+```agda
+          mate-comparison {b'} =
+            π*.uniquev (comparison b') $
+            k.uniquep _ _ _ _ _ $
+            extendr[] _ (Fib.extendrf (Fib.pullrf (left-adjoint→cocartesian-lift-natural E E-fib Lᵏ⊣k^* _)))
+            ∙[] extendr[] _ (Fib.pullrf (pulll[] _ (left-adjoint→cocartesian-lift-natural E E-fib Lᵏ⊣k^* _)))
+            ∙[] extendr[] _ (extendl[] _ (pulll[] _ (left-adjoint→counit-commutesv E E-fib Lᵏ⊣k^*)))
+            ∙[] pullr[] _ (pulll[] _ (π*.commutesv _))
+            ∙[] pulll[] _ (π*.commutesp (sym p) _)
+            ∙[] pullr[] _ (π*.commutesp id-comm _)
+            ∙[] pulll[] _ (wrap (idr f))
+```
+</details>
+
+We can combine this with our previous results about squares of (co)cartesian
+lifts to deduce that the Beck-Chevalley condition holds if and only if
+the comparison map derived from the aforementioned mate is invertible.
+
+```agda
+      left-beck-chevalley→mate-invertible
+        : left-beck-chevalley E f g h k p
+        → ∀ {b'} → is-invertible↓ (comparison b')
+      left-beck-chevalley→mate-invertible left-bc =
+        subst is-invertible↓ (sym mate-comparison) $
+        left-beck-chevalley→comparison-invertible p
+          (left-adjoint→cocartesian-lift E E-fib Lᶠ⊣f^*)
+          (E-fib g)
+          (E-fib h)
+          (left-adjoint→cocartesian-lift E E-fib Lᵏ⊣k^*)
+          left-bc
+
+      mate-invertible→left-beck-chevalley
+        : (∀ b' → is-invertible↓ (comparison b'))
+        → left-beck-chevalley E f g h k p
+      mate-invertible→left-beck-chevalley mate-inv =
+        comparison-invertible→left-beck-chevalley p
+          (left-adjoint→cocartesian-lift E E-fib Lᶠ⊣f^*)
+          (E-fib g)
+          (E-fib h)
+          (left-adjoint→cocartesian-lift E E-fib Lᵏ⊣k^*)
+          (λ b' → subst is-invertible↓ mate-comparison (mate-inv b'))
+```

--- a/src/Cat/Displayed/BeckChevalley.lagda.md
+++ b/src/Cat/Displayed/BeckChevalley.lagda.md
@@ -6,8 +6,18 @@ description: |
 ```agda
 open import Cat.Displayed.Cocartesian
 open import Cat.Displayed.Cartesian
+open import Cat.Displayed.Fibre
 open import Cat.Displayed.Base
+open import Cat.Functor.Adjoint.Mate
+open import Cat.Functor.Naturality
+open import Cat.Functor.Adjoint
 open import Cat.Prelude
+
+import Cat.Displayed.Reasoning
+import Cat.Displayed.Morphism
+import Cat.Reasoning
+
+import Cat.Displayed.Cartesian.Indexing
 ```
 -->
 ```agda
@@ -16,6 +26,92 @@ module Cat.Displayed.BeckChevalley where
 
 # Beck-Chevalley conditions
 
+Let $\cE \to \cB$ be a [[cartesian fibration]], which we shall view
+as a setting for some sort of logic or type theory. In particular, we
+shall view the corresponding [[base change]] functors $f^{*} : \cE_{Y} \to \cE_{X}$
+as an operation of substitution on predicates/types. This leads to a particularly
+tidy definition of quantifiers as [[adjoints]] to base change.
+
+For instance, we can describe existential quantifiers as left adjoints
+$\exists_{Y} : \cE_{X \times Y} \to \cE{X}$ to base changes along projections
+$\pi : X \times Y \to X$:
+
+- The introduction rule is given by the unit $\eta : \cE_{X}(P, \exists_{Y} (\pi^{*} P))$
+- The elimination rule is given by the counit $\eps : \cE_{X \times Y}(\pi^{*}\exists_{Y} P, P)$
+- The $\beta$ and $\eta$ rules are given by the zig-zag equations.
+
+This story is quite elegant, but there is a missing piece: how do substitutions
+interact with $\exists$, or, in categorical terms, how do base change functors
+commute with their left adjoints? In particular, consider the following
+diagram:
+
+~~~{.quiver}
+\begin{tikzcd}
+  {\mathcal{E}_{\Gamma \times X}} && {\mathcal{E}_{\Gamma}} \\
+  \\
+  {\mathcal{E}_{\Delta \times X} && {\mathcal{E}_{\Delta}}
+  \arrow["{\exists_{X}}", from=1-1, to=1-3]
+  \arrow["{(\sigma \times \id)^*}"', from=1-1, to=3-1]
+  \arrow["{\sigma^{*}}", from=1-3, to=3-3]
+  \arrow["{\exist_{X}}"', from=3-1, to=3-3]
+\end{tikzcd}
+~~~
+
+Ideally, we'd like $(\sigma)^*{\exists_{X} P} \iso \exists_{X}((\sigma \times \id)^{*} P)$;
+this corresponds to the usual substitution rule for quantifiers. Somewhat
+surprisingly, this does not always hold; we always have a map
+
+$$\exists_{X}((\sigma \times \id)^{*} P) \to (\sigma)^*{\exists_{X} P}$$
+
+that comes from some adjoint yoga, but this map is not neccesarily invertible!
+This leads us to the main topic of this page: the **Beck-Chevalley**
+conditions are a set of properties that ensure that the aforementioned
+map is invertible, which in turn ensures that our quantifiers are stable
+under substitution.
+
+## Left Beck-Chevalley conditions
+
+A **left Beck-Chevalley condition** characterises well-behaved left adjoints
+to base change. Typically, this is done by appealing to properties of
+base change, but we opt to use a a more local definition in
+terms of [[cartesian|cartesian map]] and [[cocartesian|cocartesian map]]
+maps. This has the benefit of working in displayed categories that may
+be missing some cartesian maps.
+
+:::{.definition #left-beck-chevalley-condition}
+Explicitly, a square $fg = hk$ in $\cB$ satisfies the left Beck-Chevalley
+condition if for every square $f'g' = h'k'$ over $fg = hk$, if $g'$ and
+$h'$ are cartesian and $f'$ is cocartesian, then $k'$ is cocartesian.
+This is best understood diagramatically: suppose we are in a situation
+like the diagram below:
+
+~~~{.quiver}
+\begin{tikzcd}
+  {A'} &&& {C'} \\
+  & {B'} &&& {D'} \\
+  A &&& C \\
+  & B &&& D
+  \arrow["{\mathrm{cocart}}"{description}, color={rgb,255:red,92;green,92;blue,214}, from=1-1, to=1-4]
+  \arrow["{\mathrm{cart}}"{description}, color={rgb,255:red,214;green,92;blue,92}, from=1-1, to=2-2]
+  \arrow[from=1-1, lies over, to=3-1]
+  \arrow["{\mathrm{cart}}"{description}, color={rgb,255:red,214;green,92;blue,92}, from=1-4, to=2-5]
+  \arrow[from=1-4, lies over, to=3-4]
+  \arrow["{\mathrm{cocart}}"{description}, color={rgb,255:red,214;green,92;blue,92}, from=2-2, to=2-5]
+  \arrow[from=2-2, lies over, to=4-2]
+  \arrow[from=2-5, lies over, to=4-5]
+  \arrow["k"{description}, from=3-1, to=3-4]
+  \arrow["g"{description}, from=3-1, to=4-2]
+  \arrow["h"{description}, from=3-4, to=4-5]
+  \arrow["f"{description}, from=4-2, to=4-5]
+\end{tikzcd}
+~~~
+
+If all the morphisms marked in red are (co)cartesian, then the morphism
+marked in blue must be cocartesian. To put things more succinctly, cocartesian
+morphisms can be pulled back along pairs of cartesian morphisms.
+:::
+
+
 <!--
 ```agda
 module _
@@ -23,13 +119,14 @@ module _
   {B : Precategory o ℓ}
   (E : Displayed B o' ℓ')
   where
-  open Precategory B
+  open Cat.Reasoning B
   open Displayed E
+  open Cat.Displayed.Reasoning E
 ```
 -->
 
 ```agda
-  record cocartesian-beck-chevalley
+  record left-beck-chevalley
     {a b c d : Ob}
     (f : Hom b d) (g : Hom a b) (h : Hom c d) (k : Hom a c)
     (p : f ∘ g ≡ h ∘ k)
@@ -43,22 +140,109 @@ module _
         → f' ∘' g' ≡[ p ] h' ∘' k'
         → is-cocartesian E f f' → is-cartesian E g g'
         → is-cartesian E h h' → is-cocartesian E k k'
-
 ```
+
+This may seem somewhat far removed from the intuition we provided earlier,
+so we shall spend some time proving that the two notions are, in fact, equivalent.
+
+
+<!--
+```agda
+module _
+  {o ℓ o' ℓ'}
+  {B : Precategory o ℓ}
+  {E : Displayed B o' ℓ'}
+  (E-fib : Cartesian-fibration E)
+  where
+  open Precategory B
+  open Displayed E
+
+  open Cat.Displayed.Cartesian.Indexing E E-fib
+  open Cat.Displayed.Reasoning E
+  open Cat.Displayed.Morphism E
+
+  module E↓ {x} = Precategory (Fibre E x)
+  module _ {x y : Ob} (f : Hom x y) (y' : Ob[ y ]) where
+    open Cartesian-lift (Cartesian-fibration.has-lift E-fib f y')
+      using ()
+      renaming (x' to _^*_; lifting to π*)
+      public
+
+  module π* {x y : Ob} {f : Hom x y} {y' : Ob[ y ]} where
+    open Cartesian-lift (Cartesian-fibration.has-lift E-fib f y')
+      hiding (x'; lifting)
+      public
+
+  open Functor
+  open _=>_
+
+  private
+    variable
+      a b c d : Ob
+      f g h k : Hom a b
+```
+-->
+
 
 ```agda
-  record cartesian-beck-chevalley
-    {a b c d : Ob}
-    (f : Hom b d) (g : Hom a b) (h : Hom c d) (k : Hom a c)
-    (p : f ∘ g ≡ h ∘ k)
-    : Type (o ⊔ ℓ ⊔ o' ⊔ ℓ') where
-    no-eta-equality
-    field
-      cart-stable
-        : {a' : Ob[ a ]} {b' : Ob[ b ]} {c' : Ob[ c ]} {d' : Ob[ d ]}
-        → {f' : Hom[ f ] b' d'} {g' : Hom[ g ] a' b'}
-        → {h' : Hom[ h ] c' d'} {k' : Hom[ k ] a' c'}
-        → f' ∘' g' ≡[ p ] h' ∘' k'
-        → is-cocartesian E f f' → is-cartesian E g g'
-        → is-cocartesian E k k' → is-cartesian E h h'
+  left-beck-iso
+    : {Lᵍ : Functor (Fibre E a) (Fibre E b)}
+    → {Lʰ : Functor (Fibre E c) (Fibre E d)}
+    → Lᵍ ⊣ base-change g
+    → Lʰ ⊣ base-change h
+    → (p : f ∘ g ≡ h ∘ k)
+    → left-beck-chevalley E f g h k p
+    → ∀ {c'} → (Lᵍ .F₀ (k ^* c')) ≅↓ (f ^* Lʰ .F₀ c')
+  left-beck-iso {g = g} {h = h} {f = f} {k = k} {Lᵍ = Lᵍ} {Lʰ = Lʰ} L⊣g^* L⊣h^* p left-bc {c'} = {!!} where
+    module Lᵍ where
+      open Functor Lᵍ public
+      open _⊣_ L⊣g^* public
+
+    module Lʰ where
+      open Functor Lʰ public
+      open _⊣_ L⊣h^* public
+
+    open left-beck-chevalley left-bc
+
+    comparison : Lᵍ F∘ base-change k => base-change f F∘ Lʰ
+    comparison =
+      mate L⊣h^* L⊣g^* (base-change k) (base-change f)
+        (Isoⁿ.from (base-change-square-ni p))
+
+    -- α : Hom[ g ] (k ^* c') (f ^* Lʰ.₀ c')
+    -- α = π*.universal' {!!} (π* h (Lʰ.F₀ c') ∘' Lʰ.η c' ∘' π* k c')
+    α : Hom[ k ] (g ^* Lᵍ.F₀ (k ^* c')) (h ^* {!!})
+    α = {!!}
+
+    α-cocartesian : is-cocartesian E k α
+    α-cocartesian = cocart-stable {!!} {!!} π*.cartesian π*.cartesian
+
+    module α = is-cocartesian α-cocartesian
+
+    comparison⁻¹ : Hom[ id ] (f ^* Lʰ.₀ c') (Lᵍ.₀ (k ^* c'))
+    comparison⁻¹ = {!α.universalv!}
+    --   let module foo = is-cocartesian (cocart-stable {a' = g ^* Lᵍ.₀ (k ^* c')} {b' = Lᵍ.₀ (k ^* c')} {c' = h ^* Lʰ.₀ c'} {d' = Lʰ.₀ c'}
+    --              {f' = {!!}}
+    --              {k' = hom[ {!!} ] ({!!} ∘' {!!} ∘' π* g (Lᵍ.₀ (k ^* c')))} {!!} {!!} π*.cartesian π*.cartesian)
+    --   in {!!}
 ```
+
+
+-- ## The dual case
+
+-- ```agda
+--   record cartesian-beck-chevalley
+--     {a b c d : Ob}
+--     (f : Hom b d) (g : Hom a b) (h : Hom c d) (k : Hom a c)
+--     (p : f ∘ g ≡ h ∘ k)
+--     : Type (o ⊔ ℓ ⊔ o' ⊔ ℓ') where
+--     no-eta-equality
+--     field
+--       cart-stable
+--         : {a' : Ob[ a ]} {b' : Ob[ b ]} {c' : Ob[ c ]} {d' : Ob[ d ]}
+--         → {f' : Hom[ f ] b' d'} {g' : Hom[ g ] a' b'}
+--         → {h' : Hom[ h ] c' d'} {k' : Hom[ k ] a' c'}
+--         → f' ∘' g' ≡[ p ] h' ∘' k'
+--         → is-cocartesian E f f' → is-cartesian E g g'
+--         → is-cocartesian E k k' → is-cartesian E h h'
+-- ```

--- a/src/Cat/Displayed/Bifibration.lagda.md
+++ b/src/Cat/Displayed/Bifibration.lagda.md
@@ -125,7 +125,7 @@ module _ (fib : Cartesian-fibration) where
     → (∀ {x y} → (f : Hom x y) → (L f ⊣ base-change f))
     → Cocartesian-fibration
   left-adjoint-base-change→opfibration L adj =
-    cartesian+weak-opfibration→opfibration fib $
+    fibration+weak-opfibration→opfibration fib $
     hom-iso→weak-opfibration L λ u →
       adjunct-hom-iso-from (adj u) _ ni⁻¹ ∘ni fibration→hom-iso-from fib u
 ```

--- a/src/Cat/Displayed/Cartesian.lagda.md
+++ b/src/Cat/Displayed/Cartesian.lagda.md
@@ -339,6 +339,17 @@ invertible→cartesian
     hom[] (f'-inv.inv' ∘' h')       ∎
 ```
 
+<!--
+```agda
+iso→cartesian
+  : ∀ {x y x' y'} {f : x ≅ y}
+  → (f' : x' ≅[ f ] y')
+  → is-cartesian (f .to) (f' .to')
+iso→cartesian {f = f} f' =
+  invertible→cartesian (iso→invertible f) (iso[]→invertible[] f')
+```
+-->
+
 If $f$ is cartesian, it's also a [weak monomorphism].
 
 [weak monomorphism]: Cat.Displayed.Morphism.html#weak-monos

--- a/src/Cat/Displayed/Cartesian/Weak.lagda.md
+++ b/src/Cat/Displayed/Cartesian/Weak.lagda.md
@@ -177,7 +177,6 @@ postcompose-equiv→weak-cartesian f' eqv .universal h' =
   equiv→inverse eqv h'
 postcompose-equiv→weak-cartesian f' eqv .commutes h' =
   to-pathp (equiv→counit eqv h')
-  -- to-pathp⁻ (equiv→counit eqv h')
 postcompose-equiv→weak-cartesian f' eqv .unique m' p =
   sym (equiv→unit eqv m') ∙ ap (equiv→inverse eqv) (from-pathp p)
 

--- a/src/Cat/Displayed/Cartesian/Weak.lagda.md
+++ b/src/Cat/Displayed/Cartesian/Weak.lagda.md
@@ -171,24 +171,25 @@ postcomposition of $f'$ onto vertical maps is an equivalence.
 postcompose-equiv→weak-cartesian
   : ∀ {x y x' y'} {f : Hom x y}
   → (f' : Hom[ f ] x' y')
-  → (∀ {x''} → is-equiv {A = Hom[ id ] x'' x'} (f' ∘'_))
+  → (∀ {x''} → is-equiv {A = Hom[ id ] x'' x'} (λ h' → hom[ idr _ ] (f' ∘' h')))
   → is-weak-cartesian f f'
 postcompose-equiv→weak-cartesian f' eqv .universal h' =
-  equiv→inverse eqv (hom[ idr _ ]⁻ h')
+  equiv→inverse eqv h'
 postcompose-equiv→weak-cartesian f' eqv .commutes h' =
-  to-pathp⁻ (equiv→counit eqv (hom[ idr _ ]⁻ h'))
+  to-pathp (equiv→counit eqv h')
+  -- to-pathp⁻ (equiv→counit eqv h')
 postcompose-equiv→weak-cartesian f' eqv .unique m' p =
-  (sym $ equiv→unit eqv m') ∙ ap (equiv→inverse eqv) (from-pathp⁻ p)
+  sym (equiv→unit eqv m') ∙ ap (equiv→inverse eqv) (from-pathp p)
 
 weak-cartesian→postcompose-equiv
   : ∀ {x y x' x'' y'} {f : Hom x y} {f' : Hom[ f ] x' y'}
   → is-weak-cartesian f f'
-  → is-equiv {A = Hom[ id ] x'' x'} (f' ∘'_)
+  → is-equiv {A = Hom[ id ] x'' x'} (λ h' → hom[ idr _ ] (f' ∘' h'))
 weak-cartesian→postcompose-equiv wcart =
   is-iso→is-equiv $
-    iso (λ h' → wcart .universal (hom[ idr _ ] h'))
-        (λ h' → from-pathp⁻ (wcart .commutes _) ·· hom[]-∙ _ _ ·· liberate _)
-        (λ h' → sym $ wcart .unique _ (to-pathp refl))
+    iso (λ h' → wcart .universal h')
+      (λ h' → from-pathp (wcart .commutes h'))
+      (λ h' → sym (wcart .unique _ (wrap (idr _))))
 ```
 
 ## Weak cartesian lifts {defines=weak-cartesian-fibration}

--- a/src/Cat/Displayed/Cocartesian.lagda.md
+++ b/src/Cat/Displayed/Cocartesian.lagda.md
@@ -322,7 +322,6 @@ invertible→cocartesian f-inv f'-inv =
   invertible→cartesian _ _ (invertible[]→co-invertible[] f'-inv)
 
 cocartesian→weak-epic cocart =
-
   cartesian→weak-monic (ℰ ^total-op) (cocartesian→co-cartesian cocart)
 
 cocartesian-codomain-unique f'-cocart f''-cocart =
@@ -350,6 +349,17 @@ vertical+cocartesian→invertible cocart =
     (cocartesian→co-cartesian cocart)
 ```
 </details>
+
+<!--
+```agda
+iso→cocartesian
+  : ∀ {x y x' y'} {f : x ≅ y}
+  → (f' : x' ≅[ f ] y')
+  → is-cocartesian (f .to) (f' .to')
+iso→cocartesian {f = f} f' =
+  invertible→cocartesian (iso→invertible f) (iso[]→invertible[] f')
+```
+-->
 
 Furthermore, $f' : x' \to_{f} y'$ is cocartesian if and only if the
 function $- \cdot' f$ is an equivalence.

--- a/src/Cat/Displayed/Cocartesian/Indexing.lagda.md
+++ b/src/Cat/Displayed/Cocartesian/Indexing.lagda.md
@@ -27,7 +27,7 @@ open Functor
 ```
 -->
 
-# Opreindexing for cocartesian fibrations
+# Opreindexing for cocartesian fibrations {defines="cobase-change"}
 
 [Opfibrations] are dual to [fibrations], so they inherit the ability
 to [reindex along morphisms in the base]. However, this reindexing is

--- a/src/Cat/Displayed/Cocartesian/Weak.lagda.md
+++ b/src/Cat/Displayed/Cocartesian/Weak.lagda.md
@@ -3,11 +3,11 @@
 open import Cat.Displayed.Cartesian.Weak
 open import Cat.Functor.Hom.Displayed
 open import Cat.Displayed.Cartesian
+open import Cat.Functor.Adjoint.Hom
 open import Cat.Displayed.Total.Op
 open import Cat.Instances.Functor
 open import Cat.Instances.Product
 open import Cat.Displayed.Fibre
-open import Cat.Functor.Adjoint.Hom
 open import Cat.Functor.Adjoint
 open import Cat.Displayed.Base
 open import Cat.Functor.Hom
@@ -16,11 +16,11 @@ open import Cat.Prelude
 import Cat.Displayed.Cocartesian.Indexing
 import Cat.Displayed.Cartesian.Indexing
 import Cat.Displayed.Morphism.Duality
-import Cat.Displayed.Cocartesian as Cocart
 import Cat.Displayed.Fibre.Reasoning
-import Cat.Functor.Reasoning
+import Cat.Displayed.Cocartesian as Cocart
 import Cat.Displayed.Reasoning
 import Cat.Displayed.Morphism
+import Cat.Functor.Reasoning
 import Cat.Reasoning as CR
 ```
 -->

--- a/src/Cat/Displayed/Cocartesian/Weak.lagda.md
+++ b/src/Cat/Displayed/Cocartesian/Weak.lagda.md
@@ -717,14 +717,14 @@ module _ (fib : Cartesian-fibration ℰ) where
 
 We start by assuming that base change $f^* : \cE_Y \to \cE_X$ along each
 $f : X \to Y$ admits a left adjoint $f_!$, and showing that for each $X'
-\liesover X$, the object $f_!(X')$ is the codomain of [[cocartesian
+\liesover X$, the object $f_!(X')$ is the codomain of a [[cocartesian
 morphism]] over $f$. This map is obtained as the composite of the unit
 $\eta : X' \to f^*f_!(X')$ with the cartesian projection out of
 this latter object.
 
 ~~~{.quiver}
 \begin{tikzcd}
-  {X'} & {f^*f_!(X')} && {f_!(X)} \\
+  {X'} & {f^*f_!(X')} && {f_!(X')} \\
   \\
   & X && Y
   \arrow["{\eta_{X'}}", from=1-1, to=1-2]
@@ -752,31 +752,35 @@ this latter object.
 ```
 
 We can prove that our putative lift $\iota = \pi \circ \eta_{X'}$ is
-weakly cocartesian via a nice equivalence chase. First, recall that $f'$
-is weakly cocartesian iff. precomposition $- \circ f$ induces an
+weakly cocartesian via a nice equivalence chase. First, recall that a morphism
+$f'$ is weakly cocartesian iff. precomposition $- \circ f'$ induces an
 [[equivalence]] on vertical maps. Moreover, the universal maps into a
 cartesian lift also assemble into an equivalence, so by 2-out-of-3 it
-suffices to show that the map taking a vertical $f' : f_!(X') \to Y'$ to
-the dashed composite in the diagram
+suffices to show that the map taking a vertical $h' : f_!(X') \to Y'$ to
+the dashed morphism in the diagram
 
 ~~~{.quiver}
 \begin{tikzcd}
-  {X'} \\
-  & {f^*f_!(X')} && {f_{!}(X')} \\
-  X \\
-  & X && Y
-  \arrow["{\exists!}"', dashed, from=1-1, to=2-2]
-  \arrow["{f' \circ \pi \circ \eta_{X'}}", curve={height=-12pt}, from=1-1, to=2-4]
-  \arrow[from=1-1, to=3-1]
-  \arrow["\pi"', from=2-2, to=2-4]
-  \arrow[from=2-2, to=4-2]
-  \arrow[from=2-4, to=4-4]
-  \arrow["\id"{description}, from=3-1, to=4-2]
-  \arrow["f"{description}, from=4-2, to=4-4]
+  & {f^*(Y')} && {Y'} \\
+  {X'} & {f^*f_!(X')} & {f_!(X')} \\
+  &&& Y \\
+  X & X & Y
+  \arrow["{\pi_{Y'}}", from=1-2, to=1-4]
+  \arrow[lies over, from=1-4, to=3-4]
+  \arrow["{\exists!}", dashed, from=2-1, to=1-2]
+  \arrow["{\eta_{X'}}"', from=2-1, to=2-2]
+  \arrow[lies over, from=2-1, to=4-1]
+  \arrow["{\pi_{f_!(X')}}"', from=2-2, to=2-3]
+  \arrow[lies over, from=2-2, to=4-2]
+  \arrow["{h'}"', from=2-3, to=1-4]
+  \arrow[lies over, from=2-3, to=4-3]
+  \arrow["{\mathrm{id}}"', from=4-1, to=4-2]
+  \arrow["f"', from=4-2, to=4-3]
+  \arrow["{\mathrm{id}}"', from=4-3, to=3-4]
 \end{tikzcd}
 ~~~
 
-is an equivalence. However, this map sends each $f'$ to its [[left
+is an equivalence. However, this map sends each $h'$ to its [[left
 adjunct]] under the adjunction $f_! \dashv f^*$ (up to transports), and
 assigning adjuncts is an equivalence!
 
@@ -787,14 +791,14 @@ assigning adjuncts is an equivalence!
       subst is-equiv (funext (coh y')) (L-adjunct-is-equiv f^!⊣f^*)
       where abstract
         coh
-           : ∀ y' (f' : Hom[ id ] (f^!.₀ x') y')
-           → hom[ idl _ ] (π*.universal' id-comm (f' ∘' π* f _) ∘' η x')
-           ≡ π*.universalv (hom[ idl _ ] (f' ∘' ι!))
-        coh y' f' =
+           : ∀ y' (h' : Hom[ id ] (f^!.₀ x') y')
+           → hom[ idl _ ] (π*.universal' id-comm (h' ∘' π* f _) ∘' η x')
+           ≡ π*.universalv (hom[ idl _ ] (h' ∘' ι!))
+        coh y' h' =
           from-pathp $ π*.uniquep _ (idl _) (idr _) _ $
-            π* f y' ∘' π*.universal' _ (f' ∘' π* f (f^!.₀ x')) ∘' η x' ≡[]⟨ pulll[] _ (π*.commutesp id-comm _) ⟩
-            (f' ∘' π* f (f^!.₀ x')) ∘' η x'                            ≡[]⟨ (pullr[] (idr _) (wrap (idr _)) ∙[] wrap (idl _)) ⟩
-            hom[ idl f ] (f' ∘' ι!)                                    ∎
+            π* f y' ∘' π*.universal' _ (h' ∘' π* f (f^!.₀ x')) ∘' η x' ≡[]⟨ pulll[] _ (π*.commutesp id-comm _) ⟩
+            (h' ∘' π* f (f^!.₀ x')) ∘' η x'                            ≡[]⟨ (pullr[] (idr _) (wrap (idr _)) ∙[] wrap (idl _)) ⟩
+            hom[ idl f ] (h' ∘' ι!)                                    ∎
 ```
 
 The converse follows from some more equivalence yoga. First, recall that

--- a/src/Cat/Displayed/Cocartesian/Weak.lagda.md
+++ b/src/Cat/Displayed/Cocartesian/Weak.lagda.md
@@ -630,14 +630,13 @@ fibration+weak-cocartesian-lift→cocartesian-lift {f = f} {x' = x'} fib wcocart
 
 # Weak cocartesian morphisms as left adjoints to base change
 
-If $\cE$ is a [[cocartesian fibration]], we can define [[cobase change]]
-functors $f_! : \cE_{X} \to \cE_{Y}$ for every $f : X \to Y$. However, the
-requirement that $\cE$ is cocartesian is overly strong[^1]; all we need to define
-a base change functor $f_! : \cE_{X} \to \cE_{Y}$ is a family of *weak*
-cocartesian lifts of $f$.
+[[Cobase change]] functors $f_! : \cE_X \to \cE_Y$ over a map $f : X \to
+Y$ are most naturally[^1] defined when $\cE$ is a [[cocartesian fibration]],
+but they can be constructed as soon as $f$ admits a family of *weak*
+cocartesian lifts.
 
 [^1]: Note that these functors are only well-behaved if $\cE$ is in fact
-cocartesian, so the loss of generality is minimal in the long run.
+cocartesian, so this is only a slight generalisation.
 
 ```agda
 weak-cocartesian-lift→cobase-change
@@ -647,10 +646,11 @@ weak-cocartesian-lift→cobase-change
   → Functor (Fibre ℰ x) (Fibre ℰ y)
 ```
 
-The reason that weak cocartesian morphisms suffice is that we only need
-to consider vertical structure when performing cobase change, so the weaker
-universal property is enough. This is reflected in the action on morphisms,
-which is identical to the definition of cobase change for a cocartesian fibration.
+The reason that weak cocartesian lifts suffice is that we only need to
+consider vertical structure when performing cobase change, so the weaker
+universal property is enough. This is reflected in the action on
+morphisms, which is identical to the definition of cobase change for a
+cocartesian fibration.
 
 ```agda
 weak-cocartesian-lift→cobase-change {x = x} {y = y} f wcocart = f-cobase-change where
@@ -691,10 +691,10 @@ unique, though this is rather tedious to show.
 ```
 </details>
 
-The existence of cobase change functors also provides an alternative universal
-property for weak cocartesian lifts when $\cE$ is a [[cartesian fibration]];
-namely, a family of cocartesian lifts is equivalent to the existence of a
-[[left adjoint]] to a [[base change]] functor.
+The existence of cobase change functors also provides an alternative
+universal property for weak cocartesian lifts when $\cE$ is a
+[[cartesian fibration]], namely through the existence of [[left
+adjoints]] to each [[base change]] functor.
 
 ```agda
 module _ (fib : Cartesian-fibration ℰ) where
@@ -715,11 +715,12 @@ module _ (fib : Cartesian-fibration ℰ) where
     → weak-cocartesian-lift→cobase-change f f^! ⊣ base-change f
 ```
 
-We shall start by showing a left adjoint $f^! : \cE_{x} \to \cE_{y}$ to base change along $f$
-induces cocartesian lifts for every $x'$. The object $f_{!}(X')$ is the only
-possible candidate for our lift, and we can construct a map $X' \to f_{!}(X')$
-by composing the unit $\eta_{X'} : X' \to f^{*}f_{!}(X')$ with the projection
-out of $f^{*}f_{!}(X')$.
+We start by assuming that base change $f^* : \cE_Y \to \cE_X$ along each
+$f : X \to Y$ admits a left adjoint $f_!$, and showing that for each $X'
+\liesover X$, the object $f_!(X')$ is the codomain of [[cocartesian
+morphism]] over $f$. This map is obtained as the composite of the unit
+$\eta : X' \to f^*f_!(X')$ with the cartesian projection out of
+this latter object.
 
 ~~~{.quiver}
 \begin{tikzcd}
@@ -727,10 +728,10 @@ out of $f^{*}f_{!}(X')$.
   \\
   & X && Y
   \arrow["{\eta_{X'}}", from=1-1, to=1-2]
-  \arrow[from=1-1, to=3-2]
+  \arrow[lies over, from=1-1, to=3-2]
   \arrow["\pi", from=1-2, to=1-4]
-  \arrow[from=1-2, to=3-2]
-  \arrow[from=1-4, to=3-4]
+  \arrow[lies over, from=1-2, to=3-2]
+  \arrow[lies over, from=1-4, to=3-4]
   \arrow["f", from=3-2, to=3-4]
 \end{tikzcd}
 ~~~
@@ -750,13 +751,13 @@ out of $f^{*}f_{!}(X')$.
     f-lift .lifting = ι!
 ```
 
-We can prove that our putative lift $\iota = \pi \circ \eta_{X'}$ is weakly
-cocartesian via a nice equivalence chase. First, recall that a map is weakly
-cocartesian if and only if precomposition with a vertical map is an [[equivalence]].
-Moreover, the universal map of a cartesian fibration is also an equivalence,
-so by 2-out-of-3 it suffices to show that the function that takes a vertical
-map $f' : f_{!}(X') \to Y'$ to the universal factorization indicated in the
-following diagram is an equivalence.
+We can prove that our putative lift $\iota = \pi \circ \eta_{X'}$ is
+weakly cocartesian via a nice equivalence chase. First, recall that $f'$
+is weakly cocartesian iff. precomposition $- \circ f$ induces an
+[[equivalence]] on vertical maps. Moreover, the universal maps into a
+cartesian lift also assemble into an equivalence, so by 2-out-of-3 it
+suffices to show that the map taking a vertical $f' : f_!(X') \to Y'$ to
+the dashed composite in the diagram
 
 ~~~{.quiver}
 \begin{tikzcd}
@@ -775,8 +776,9 @@ following diagram is an equivalence.
 \end{tikzcd}
 ~~~
 
-However, this is just the [[left adjunct]] of the adjoint up to some
-transport gunk, which is an equivalence!
+is an equivalence. However, this map sends each $f'$ to its [[left
+adjunct]] under the adjunction $f_! \dashv f^*$ (up to transports), and
+assigning adjuncts is an equivalence!
 
 ```agda
     f-lift .weak-cocartesian =
@@ -795,15 +797,18 @@ transport gunk, which is an equivalence!
             hom[ idl f ] (f' ∘' ι!)                                    ∎
 ```
 
-The reverse direction follows from some more equivalence yoga. First,
-recall that we can present [[adjoints as hom isomorphisms]]; this means that it
-suffices to construct an equivalence between $f_{!}(X) \to y$ and
-$X \to f^*{Y}$. Moreover, we already have equivalences that characterise
-these two types: these are just the universal properties of weak cocartesian and
-cartesian maps, resp.
+The converse follows from some more equivalence yoga. First, recall that
+we can show $f_! \dashv f^*$ by exhibiting a natural isomorphism
+$$\hom_{\cE_X}(X, f^*Y) \cong \hom_{\cE_X}(f_!(X), Y)$$. But, by the
+universal properties of cartesian and cocartesian maps, respectively,
+these types are both equivalent to maps $X \to Y$ over $f$.
 
 ```agda
   weak-cocartesian-lift→left-adjoint {x = x} {y = y} f wcocart = f-cobase-change-adj where
+```
+
+<!--
+```agda
     module wcocart (x' : Ob[ x ]) where
       open Weak-cocartesian-lift (wcocart x')
         renaming (y' to f^!_; lifting to ι!)
@@ -812,7 +817,10 @@ cartesian maps, resp.
     open wcocart
     open _=>_
     open _⊣_
+```
+-->
 
+```agda
     f-cobase-change-adj : weak-cocartesian-lift→cobase-change f wcocart ⊣ base-change f
     f-cobase-change-adj =
       hom-iso→adjoints
@@ -850,6 +858,7 @@ Note that we can strengthen this result somewhat: every weak cocartesian
 lift in a fibration is in fact cocartesian, so left adjoints to base
 change give a family of cocartesian lifts.
 
+<!--
 ```agda
   module _
     {x y} {f : Hom x y}
@@ -859,26 +868,31 @@ change give a family of cocartesian lifts.
     private
       module f^! = Cat.Functor.Reasoning f^!
       open _⊣_ f^!⊣f^*
+```
+-->
 
+```agda
     left-adjoint→cocartesian-lift : ∀ x' → Cocartesian-lift f x'
     left-adjoint→cocartesian-lift x' =
       fibration+weak-cocartesian-lift→cocartesian-lift
-        fib
-        (left-adjoint→weak-cocartesian-lift f f^! f^!⊣f^* x')
+        fib (left-adjoint→weak-cocartesian-lift f f^! f^!⊣f^* x')
 ```
 
 Moreover, these choices of lifts are natural!
 
+<!--
 ```agda
     private
       module f (x' : Ob[ x ]) where
         open Cocartesian-lift (left-adjoint→cocartesian-lift x')
           renaming (y' to ^!_; lifting to ι)
           public
+```
+-->
 
+```agda
     left-adjoint→cocartesian-lift-natural
-      : ∀ {x' x''}
-      → (h' : Hom[ id ] x' x'')
+      : ∀ {x' x''} (h' : Hom[ id ] x' x'')
       → f^!.₁ h' ∘' f.ι x' ≡[ id-comm-sym ] f.ι x'' ∘' h'
 ```
 

--- a/src/Cat/Displayed/Comprehension/Coproduct.lagda.md
+++ b/src/Cat/Displayed/Comprehension/Coproduct.lagda.md
@@ -1,6 +1,7 @@
 <!--
 ```agda
 open import Cat.Displayed.Cartesian.Indexing
+open import Cat.Displayed.BeckChevalley
 open import Cat.Displayed.Comprehension
 open import Cat.Displayed.Cocartesian
 open import Cat.Displayed.Cartesian
@@ -115,20 +116,25 @@ record has-comprehension-coproducts : Type (ob ⊔ ℓb ⊔ od ⊔ ℓd ⊔ oe �
     ⟨⟩-cocartesian
       : ∀ {Γ} → (x : E.Ob[ Γ ]) (a : D.Ob[ Γ ⨾ x ])
       → is-cocartesian D πᶜ ⟨ x , a ⟩
-    cocartesian-stable
-      : ∀ {Γ Δ x y a a' b b'} {σ : Hom Γ Δ} {f : E.Hom[ σ ] x y}
-      → {r : D.Hom[ πᶜ ] a a'} {h : D.Hom[ σ ] a' b'}
-      → {g : D.Hom[ σ ⨾ˢ f ] a b} {s : D.Hom[ πᶜ ] b b'}
+    ∐-beck-chevalley
+      : ∀ {Γ Δ x y} {σ : Hom Γ Δ} {f : E.Hom[ σ ] x y}
       → is-cartesian E σ f
-      → s D.∘' g D.≡[ sub-proj f ] h D.∘' r
-      → is-cocartesian D πᶜ s
-      → is-cartesian D (σ ⨾ˢ f) g
-      → is-cartesian D σ h
-      → is-cocartesian D πᶜ r
+      → cocartesian-beck-chevalley D
+          πᶜ (σ ⨾ˢ f) σ πᶜ
+          (sub-proj f)
+```
 
+<!--
+```agda
   module ⟨⟩-cocartesian {Γ} (x : E.Ob[ Γ ]) (a : D.Ob[ Γ ⨾ x ]) =
     is-cocartesian (⟨⟩-cocartesian x a)
+
+  module ∐-beck-chevalley
+    {Γ Δ x y} {σ : Hom Γ Δ} {f : E.Hom[ σ ] x y}
+    (f-cart : is-cartesian E σ f) =
+    cocartesian-beck-chevalley (∐-beck-chevalley f-cart)
 ```
+-->
 
 Now, some general facts about coproducts. To start, note that forming
 coproducts is a functorial operation. The proof is very routine --- if
@@ -336,7 +342,7 @@ introduction rule is also natural.
       → is-cartesian E σ f → (a : D.Ob[ Δ ⨾ y ])
       → is-cocartesian D πᶜ ⟨ f ⨾ a ⟩
     ⟨⨾⟩-cocartesian {x = x} {y = y} {σ = σ} {f = f} cart a =
-      cocartesian-stable cart
+      ∐-beck-chevalley.cocart-stable cart
         (symP (⟨⨾⟩-weaken f a))
         (⟨⟩-cocartesian y a)
         D.π*.cartesian

--- a/src/Cat/Displayed/Comprehension/Coproduct.lagda.md
+++ b/src/Cat/Displayed/Comprehension/Coproduct.lagda.md
@@ -119,20 +119,13 @@ record has-comprehension-coproducts : Type (ob ⊔ ℓb ⊔ od ⊔ ℓd ⊔ oe �
     ∐-beck-chevalley
       : ∀ {Γ Δ x y} {σ : Hom Γ Δ} {f : E.Hom[ σ ] x y}
       → is-cartesian E σ f
-      → cocartesian-beck-chevalley D
-          πᶜ (σ ⨾ˢ f) σ πᶜ
-          (sub-proj f)
+      → left-beck-chevalley D πᶜ (σ ⨾ˢ f) σ πᶜ (sub-proj f)
 ```
 
 <!--
 ```agda
   module ⟨⟩-cocartesian {Γ} (x : E.Ob[ Γ ]) (a : D.Ob[ Γ ⨾ x ]) =
     is-cocartesian (⟨⟩-cocartesian x a)
-
-  module ∐-beck-chevalley
-    {Γ Δ x y} {σ : Hom Γ Δ} {f : E.Hom[ σ ] x y}
-    (f-cart : is-cartesian E σ f) =
-    cocartesian-beck-chevalley (∐-beck-chevalley f-cart)
 ```
 -->
 
@@ -342,7 +335,7 @@ introduction rule is also natural.
       → is-cartesian E σ f → (a : D.Ob[ Δ ⨾ y ])
       → is-cocartesian D πᶜ ⟨ f ⨾ a ⟩
     ⟨⨾⟩-cocartesian {x = x} {y = y} {σ = σ} {f = f} cart a =
-      ∐-beck-chevalley.cocart-stable cart
+      ∐-beck-chevalley cart
         (symP (⟨⨾⟩-weaken f a))
         (⟨⟩-cocartesian y a)
         D.π*.cartesian

--- a/src/Cat/Displayed/Instances/Lifting.lagda.md
+++ b/src/Cat/Displayed/Instances/Lifting.lagda.md
@@ -267,7 +267,7 @@ composition.
 ```agda
   idntl : ∀ {F : Functor J B} {F' : Lifting E F} → F' =[ idnt ]=>l F'
   idntl .η' j = id'
-  idntl .is-natural' i j f = idl' _ ∙[] symP (idr' _)
+  idntl .is-natural' i j f = cast[] $ idl' _ ∙[] symP (idr' _)
 
   _∘ntl_
     : ∀ {F G H : Functor J B} {F' : Lifting E F} {G' : Lifting E G} {H' : Lifting E H}

--- a/src/Cat/Displayed/Instances/Subobjects.lagda.md
+++ b/src/Cat/Displayed/Instances/Subobjects.lagda.md
@@ -261,7 +261,7 @@ Subobject-opfibration
   : (∀ {x y} (f : Hom x y) → Image B f)
   → (pb : has-pullbacks B)
   → Cocartesian-fibration Subobjects
-Subobject-opfibration images pb = cartesian+weak-opfibration→opfibration _
+Subobject-opfibration images pb = fibration+weak-opfibration→opfibration _
   (Subobject-fibration pb)
   (Subobject-weak-opfibration images)
 ```

--- a/src/Cat/Displayed/Morphism.lagda.md
+++ b/src/Cat/Displayed/Morphism.lagda.md
@@ -379,6 +379,17 @@ make-iso[ inv ] f' g' p q .from' = g'
 make-iso[ inv ] f' g' p q .inverses' .Inverses[_].invl' = p
 make-iso[ inv ] f' g' p q .inverses' .Inverses[_].invr' = q
 
+make-invertible[_]
+  : ∀ {a b a' b'} {f : Hom a b} {f' : Hom[ f ] a' b'}
+  → (f-inv : is-invertible f)
+  → (f-inv' : Hom[ is-invertible.inv f-inv ] b' a')
+  → f' ∘' f-inv' ≡[ is-invertible.invl f-inv ] id'
+  → f-inv' ∘' f' ≡[ is-invertible.invr f-inv ] id'
+  → is-invertible[ f-inv ] f'
+make-invertible[ f-inv ] f-inv' p q .is-invertible[_].inv' = f-inv'
+make-invertible[ f-inv ] f-inv' p q .is-invertible[_].inverses' .Inverses[_].invl' = p
+make-invertible[ f-inv ] f-inv' p q .is-invertible[_].inverses' .Inverses[_].invr' = q
+
 make-vertical-iso
   : ∀ {x} {x' x'' : Ob[ x ]}
   → (f' : Hom[ id ] x' x'') (g' : Hom[ id ] x'' x')
@@ -398,6 +409,14 @@ invertible[]→iso[] {f' = f'} i =
     (is-invertible[_].inv' i)
     (is-invertible[_].invl' i)
     (is-invertible[_].invr' i)
+
+iso[]→invertible[]
+  : ∀ {a b a' b'}
+  → {i : a ≅ b}
+  → (i' : a' ≅[ i ] b')
+  → is-invertible[ iso→invertible i ] (i' .to')
+iso[]→invertible[] {i = i} i' =
+  make-invertible[ (iso→invertible i) ] (i' .from') (i' .invl') (i' .invr')
 
 ≅[]-path
   : {x y : Ob} {A : Ob[ x ]} {B : Ob[ y ]} {f : x ≅ y}
@@ -421,6 +440,15 @@ instance
     → ⦃ sa : Extensional (Hom[ f .to ] x' y') ℓr ⦄
     → Extensional (x' ≅[ f ] y') ℓr
   Extensional-≅[] ⦃ sa ⦄ = injection→extensional! ≅[]-path sa
+
+_Iso[]⁻¹
+  : ∀ {a b a' b'} {i : a ≅ b}
+  → a' ≅[ i ] b'
+  → b' ≅[ i Iso⁻¹ ] a'
+(i' Iso[]⁻¹) .to' = i' .from'
+(i' Iso[]⁻¹) .from' = i' .to'
+(i' Iso[]⁻¹) .inverses' .Inverses[_].invl' = i' .invr'
+(i' Iso[]⁻¹) .inverses' .Inverses[_].invr' = i' .invl'
 ```
 -->
 
@@ -466,6 +494,34 @@ inverses[]→from-has-retract[]
   → has-retract[ inverses→from-has-retract inv ] g'
 inverses[]→from-has-retract[] {f' = f'} inv' .retract' = f'
 inverses[]→from-has-retract[] inv' .is-retract' = Inverses[_].invl' inv'
+
+module _
+  {f : Hom a b} {f' : Hom[ f ] a' b'}
+  {f-inv : is-invertible f}
+  (f'-inv : is-invertible[ f-inv ] f')
+  where
+  private module f' = is-invertible[_] f'-inv
+
+  invertible[]→to-has-section[] : has-section[ invertible→to-has-section f-inv ] f'
+  invertible[]→to-has-section[] .section' = f'.inv'
+  invertible[]→to-has-section[] .is-section' = f'.invl'
+
+  invertible[]→from-has-section[] : has-section[ invertible→from-has-section f-inv ] f'.inv'
+  invertible[]→from-has-section[] .section' = f'
+  invertible[]→from-has-section[] .is-section' = f'.invr'
+
+  invertible[]→to-has-retract[] : has-retract[ invertible→to-has-retract f-inv ] f'
+  invertible[]→to-has-retract[] .retract' = f'.inv'
+  invertible[]→to-has-retract[] .is-retract' = f'.invr'
+
+  invertible[]→from-has-retract[] : has-retract[ invertible→from-has-retract f-inv ] f'.inv'
+  invertible[]→from-has-retract[] .retract' = f'
+  invertible[]→from-has-retract[] .is-retract' = f'.invl'
+
+  invertible[]→monic[] : is-monic[ invertible→monic f-inv ] f'
+  invertible[]→monic[] g' h' p p' =
+    cast[] $ introl[] _ f'.invr' ∙[] extendr[] _ p' ∙[] eliml[] _ f'.invr'
+
 
 iso[]→to-has-section[]
   : {f : a ≅ b} → (f' : a' ≅[ f ] b')

--- a/src/Cat/Functor/Adjoint.lagda.md
+++ b/src/Cat/Functor/Adjoint.lagda.md
@@ -200,19 +200,20 @@ these functions are inverse _equivalences_ between the hom-sets
 $\hom(La,b) \cong \hom(a,Rb)$.
 
 ```agda
-  L-R-adjunct : ∀ {a b} → is-right-inverse (R-adjunct {a} {b}) L-adjunct
-  L-R-adjunct f =
-    R.₁ (adj.ε _ D.∘ L.₁ f) C.∘ adj.η _        ≡⟨ R.pushl refl ⟩
-    R.₁ (adj.ε _) C.∘ R.₁ (L.₁ f) C.∘ adj.η _  ≡˘⟨ C.refl⟩∘⟨ adj.unit.is-natural _ _ _ ⟩
-    R.₁ (adj.ε _) C.∘ adj.η _ C.∘ f            ≡⟨ C.cancell adj.zag ⟩
-    f                                          ∎
+  abstract
+    L-R-adjunct : ∀ {a b} → is-right-inverse (R-adjunct {a} {b}) L-adjunct
+    L-R-adjunct f =
+      R.₁ (adj.ε _ D.∘ L.₁ f) C.∘ adj.η _        ≡⟨ R.pushl refl ⟩
+      R.₁ (adj.ε _) C.∘ R.₁ (L.₁ f) C.∘ adj.η _  ≡˘⟨ C.refl⟩∘⟨ adj.unit.is-natural _ _ _ ⟩
+      R.₁ (adj.ε _) C.∘ adj.η _ C.∘ f            ≡⟨ C.cancell adj.zag ⟩
+      f                                          ∎
 
-  R-L-adjunct : ∀ {a b} → is-left-inverse (R-adjunct {a} {b}) L-adjunct
-  R-L-adjunct f =
-    adj.ε _ D.∘ L.₁ (R.₁ f C.∘ adj.η _)       ≡⟨ D.refl⟩∘⟨ L.F-∘ _ _ ⟩
-    adj.ε _ D.∘ L.₁ (R.₁ f) D.∘ L.₁ (adj.η _) ≡⟨ D.extendl (adj.counit.is-natural _ _ _) ⟩
-    f D.∘ adj.ε _ D.∘ L.₁ (adj.η _)           ≡⟨ D.elimr adj.zig ⟩
-    f                                         ∎
+    R-L-adjunct : ∀ {a b} → is-left-inverse (R-adjunct {a} {b}) L-adjunct
+    R-L-adjunct f =
+      adj.ε _ D.∘ L.₁ (R.₁ f C.∘ adj.η _)       ≡⟨ D.refl⟩∘⟨ L.F-∘ _ _ ⟩
+      adj.ε _ D.∘ L.₁ (R.₁ f) D.∘ L.₁ (adj.η _) ≡⟨ D.extendl (adj.counit.is-natural _ _ _) ⟩
+      f D.∘ adj.ε _ D.∘ L.₁ (adj.η _)           ≡⟨ D.elimr adj.zig ⟩
+      f                                         ∎
 
   L-adjunct-is-equiv : ∀ {a b} → is-equiv (L-adjunct {a} {b})
   L-adjunct-is-equiv = is-iso→is-equiv

--- a/src/Cat/Functor/Adjoint.lagda.md
+++ b/src/Cat/Functor/Adjoint.lagda.md
@@ -49,7 +49,7 @@ set of maps $x \to y$). Going further, we have structures at the level
 of 2-groupoids, which could be given an interesting _category_ of
 relations, etc.
 
-:::{.definition #adjunction alias="left-adjoint right-adjoint adjoint-functor"}
+:::{.definition #adjunction alias="left-adjoint right-adjoint adjoint-functor adjoint"}
 A particularly important relationship is, of course, "sameness". Going
 up the ladder of category number, we have equality at the (-1)-level,
 isomorphism at the 0-level, and what's generally referred to as

--- a/src/Cat/Functor/Adjoint/Mate.lagda.md
+++ b/src/Cat/Functor/Adjoint/Mate.lagda.md
@@ -12,7 +12,7 @@ import Cat.Reasoning
 module Cat.Functor.Adjoint.Mate where
 ```
 
-# Mates
+# Mates {defines="mate"}
 
 Let $F \dashv U : A \to B$, $F' \dashv U' : A' \to B'$ be a pair of
 adjunctions, and let $X : A \to A'$ and $Y : B \to B'$ be a pair of

--- a/src/Cat/Morphism.lagda.md
+++ b/src/Cat/Morphism.lagda.md
@@ -862,19 +862,30 @@ inverses→from-has-retract inv .is-retract = Inverses.invl inv
 
 <!--
 ```agda
-invertible→to-has-section : is-invertible f → has-section f
-invertible→to-has-section f-inv .section = is-invertible.inv f-inv
-invertible→to-has-section f-inv .is-section = is-invertible.invl f-inv
+module _ {f : Hom a b} (f-inv : is-invertible f) where
+  private module f = is-invertible f-inv
+  invertible→to-has-section : has-section f
+  invertible→to-has-section .section = f.inv
+  invertible→to-has-section .is-section = f.invl
 
-invertible→to-has-retract : is-invertible f → has-retract f
-invertible→to-has-retract f-inv .retract = is-invertible.inv f-inv
-invertible→to-has-retract f-inv .is-retract = is-invertible.invr f-inv
+  invertible→to-has-retract : has-retract f
+  invertible→to-has-retract .retract = f.inv
+  invertible→to-has-retract .is-retract = f.invr
 
-invertible→to-split-monic : is-invertible f → is-split-monic f
-invertible→to-split-monic f-inv = pure (invertible→to-has-retract f-inv)
+  invertible→to-split-monic : is-split-monic f
+  invertible→to-split-monic = pure invertible→to-has-retract
 
-invertible→to-split-epic : is-invertible f → is-split-epic f
-invertible→to-split-epic f-inv = pure (invertible→to-has-section f-inv)
+  invertible→to-split-epic : is-split-epic f
+  invertible→to-split-epic = pure invertible→to-has-section
+
+  invertible→from-has-section : has-section f.inv
+  invertible→from-has-section .section = f
+  invertible→from-has-section .is-section = f.invr
+
+  invertible→from-has-retract : has-retract f.inv
+  invertible→from-has-retract .retract = f
+  invertible→from-has-retract .is-retract = f.invl
+
 
 iso→to-has-section : (f : a ≅ b) → has-section (f .to)
 iso→to-has-section f .section = f .from

--- a/src/Cat/Reasoning.lagda.md
+++ b/src/Cat/Reasoning.lagda.md
@@ -53,14 +53,21 @@ module _ {w x y z} {a : Hom y z} {b : Hom x y} {c : Hom w x} {f : Hom w z} where
 ## Identity morphisms
 
 ```agda
-id-comm : ∀ {a b} {f : Hom a b} → f ∘ id ≡ id ∘ f
-id-comm {f = f} = idr f ∙ sym (idl f)
+abstract
+  id-comm : ∀ {a b} {f : Hom a b} → f ∘ id ≡ id ∘ f
+  id-comm {f = f} = idr f ∙ sym (idl f)
 
-id-comm-sym : ∀ {a b} {f : Hom a b} → id ∘ f ≡ f ∘ id
-id-comm-sym {f = f} = idl f ∙ sym (idr f)
+  id-comm-sym : ∀ {a b} {f : Hom a b} → id ∘ f ≡ f ∘ id
+  id-comm-sym {f = f} = idl f ∙ sym (idr f)
 
-idr2 : ∀ {a b c} (f : Hom b c) (g : Hom a b) → f ∘ g ∘ id ≡ f ∘ g
-idr2 f g = ap (f ∘_) (idr g)
+  id2 : ∀ {x} → id {x} ∘ id {x} ≡ id
+  id2 = idl _
+
+  idr2 : ∀ {a b c} (f : Hom b c) (g : Hom a b) → f ∘ g ∘ id ≡ f ∘ g
+  idr2 f g = ap (f ∘_) (idr g)
+
+  idl2 : ∀ {a b c} (f : Hom b c) (g : Hom a b) → (id ∘ f) ∘ g ≡ f ∘ g
+  idl2 f g = ap (_∘ g) (idl f)
 
 module _ (a≡id : a ≡ id) where abstract
   eliml : a ∘ f ≡ f


### PR DESCRIPTION
# Description

This PR defines a general notion of a Beck-Chevalley condition over a commutative square, and proves that it
is equivalent to the usual definition that involves the invertibility of a comparison map. Unfortunately, suffering
is conserved, so all of the usual annoying proofs about comparison maps got compressed into a pair of _very_
annoying proofs, but at least this only needs to be done once!

This is intended to be used in #456, and should be merged first.

## Checklist

Before submitting a merge request, please check the items below:

- [x] I've read [the contributing guidelines](https://github.com/plt-amy/1lab/blob/main/CONTRIBUTING.md).
- [x] The imports of new modules have been sorted with `support/sort-imports.hs` (or `nix run --experimental-features nix-command -f . sort-imports`).
- [x] All new code blocks have "agda" as their language.

If your change affects many files without adding substantial content, and
you don't want your name to appear on those pages (for example, treewide
refactorings or reformattings), start the commit message and PR title with `chore:`.
