### PR TITLE
improvements to Glue usability

### DIFF
--- a/src/1Lab/Path.lagda.md
+++ b/src/1Lab/Path.lagda.md
@@ -17,7 +17,7 @@ module 1Lab.Path where
 ```agda
 open Prim.Extension public
 open Prim.Interval public
-open Prim.Kan public
+open Prim.Kan hiding (module hcomp-sys ; module comp-sys) public
 
 -- Slightly ugly type to demonstrate the algebraic properties of the
 -- interval.

--- a/src/1Lab/Path.lagda.md
+++ b/src/1Lab/Path.lagda.md
@@ -1467,11 +1467,18 @@ face for the [square] at the start of this section.
 _··_··_ : ∀ {ℓ} {A : Type ℓ} {w x y z : A}
         → w ≡ x → x ≡ y → y ≡ z
         → w ≡ z
-(p ·· q ·· r) i = hcomp (∂ i) λ where
-  j (i = i0) → p (~ j)
-  j (i = i1) → r j
-  j (j = i0) → q i
+(p ·· q ·· r) i = hcomp (∂ i) sys module ··-sys where
+  sys : ∀ j → Partial (∂ i ∨ ~ j) _
+  sys j (i = i0) = p (~ j)
+  sys j (i = i1) = r j
+  sys j (j = i0) = q i
 ```
+
+<!--
+```agda
+{-# DISPLAY hcomp _ (··-sys.sys {ℓ} {A} {w} {x} {y} {z} p q r i) = _··_··_ {ℓ} {A} {w} {x} {y} {z} p q r i #-}
+```
+-->
 
 Since it will be useful later, we also give an explicit name for the
 *filler* of the double composition square. Since `Square`{.Agda}

--- a/src/1Lab/Prelude.agda
+++ b/src/1Lab/Prelude.agda
@@ -35,6 +35,7 @@ open import 1Lab.Biimp public
 open import 1Lab.Function.Surjection public
 
 open import 1Lab.Univalence public
+
 open import 1Lab.Univalence.SIP
   renaming (_≃[_]_ to _≃[_]s_)
   public
@@ -53,6 +54,7 @@ open import 1Lab.Reflection.Record
   public
 open import 1Lab.Reflection.HLevel public
 open import 1Lab.Reflection.Regularity public
+open import 1Lab.Reflection.Univalence public
 
 open import 1Lab.Resizing public
 

--- a/src/1Lab/Reflection/Univalence.agda
+++ b/src/1Lab/Reflection/Univalence.agda
@@ -1,0 +1,48 @@
+open import 1Lab.Reflection
+open import 1Lab.Univalence
+open import 1Lab.Type
+
+open import Prim.Extension
+open import Prim.HCompU
+open import Prim.Kan
+
+import 1Lab.Univalence as U
+
+module 1Lab.Reflection.Univalence where
+
+name-of-glue : Name
+unquoteDef name-of-glue = do
+  nm ← resetting do
+    def nm _ ← reduce (def (quote Glue) (unknown v∷ unknown v∷ []))
+      where anything → typeError ("insane: Glue did not reduce to a defined type?\n" ∷ termErr anything ∷ [])
+    pure nm
+
+  define-function name-of-glue (clause [] [] (lit (name nm)) ∷ [])
+
+macro
+  -- Simple helper macro to shadow the 'unglue' function with something
+  -- that can actually infer the φ argument.
+
+  unglue : Term → Term → TC ⊤
+  unglue x goal = do
+    let
+      fail : Term → TC ⊤
+      fail ty = typeError
+        [ "unglue: the argument " , termErr x , " does not have a Glue type. instead, it is\n"
+        , "  " , termErr ty
+        ]
+
+    ty ← wait-for-type =<< reduce =<< infer-type x
+    case ty of λ where
+      (def (quote primHComp) (ℓ h∷ _ h∷ φ h∷ s v∷ b v∷ [])) → unify goal
+        (def (quote prim^unglueU)
+          (unknown h∷ φ h∷ s h∷ def (quote inS) (b v∷ []) h∷ x v∷ []))
+
+      ty@(def a (_ h∷ _ h∷ _ v∷ φ h∷ _)) → case a ≡? name-of-glue of λ where
+        (yes _) → do
+          wait-for-type φ
+          unify goal (def (quote U.unattach) (φ v∷ x v∷ []))
+        (no _) → fail ty
+      ty → fail ty
+
+{-# DISPLAY unattach _ x = unglue x #-}

--- a/src/1Lab/Univalence/Fibrewise.lagda.md
+++ b/src/1Lab/Univalence/Fibrewise.lagda.md
@@ -28,7 +28,7 @@ private variable
 # Univalence for type families
 
 Any [[equivalence]] $e : A \simeq B$ lets us compare type families $P
-\liesover A$ and $Q \liesover Q$, by forming the type of [[fibrewise
+\liesover A$ and $Q \liesover B$, by forming the type of [[fibrewise
 equivalences|equivalence over]] $e$ between $P$ and $Q$. A useful
 univalence-type result in this setting would be to show that equivalent
 type families are actually identical (over the path induced by $e$),

--- a/src/1Lab/Univalence/Fibrewise.lagda.md
+++ b/src/1Lab/Univalence/Fibrewise.lagda.md
@@ -1,0 +1,106 @@
+<!--
+```agda
+open import 1Lab.Reflection.Univalence
+open import 1Lab.Equiv.Fibrewise
+open import 1Lab.Path.Cartesian
+open import 1Lab.Type.Sigma
+open import 1Lab.Univalence
+open import 1Lab.Type.Pi
+open import 1Lab.Equiv
+open import 1Lab.Path
+open import 1Lab.Type
+```
+-->
+
+```agda
+module 1Lab.Univalence.Fibrewise where
+```
+
+<!--
+```agda
+private variable
+  ℓ ℓ' ℓ'' : Level
+  A B X Y : Type ℓ
+  P Q : A → Type ℓ'
+```
+-->
+
+# Univalence for type families
+
+Any [[equivalence]] $e : A \simeq B$ lets us compare type families $P
+\liesover A$ and $Q \liesover Q$, by forming the type of [[fibrewise
+equivalences|equivalence over]] $e$ between $P$ and $Q$. A useful
+univalence-type result in this setting would be to show that equivalent
+type families are actually identical (over the path induced by $e$),
+and, indeed, we can prove this:
+
+<!--
+```agda
+private module _ where private
+  _ = comp
+```
+-->
+
+```agda
+  ua-over : (e : A ≃ B) (e' : P ≃[ e ] Q) → PathP (λ i → ua e i → Type _) P Q
+  ua-over e e' = ua→ λ a → ua (e' a (e .fst a) refl)
+```
+
+The trouble with this definition arises when we want to consider paths
+over it, since then we need to consider the precise definition of
+`ua→`{.Agda} in terms of `comp`{.Agda}. Still, we can put together a
+function for showing that sections of $P \liesover A$ and $Q \liesover
+B$ are identical:
+
+```agda
+  ua-over-pathp
+    : (e : A ≃ B) (e' : P ≃[ e ] Q) {f : ∀ x → P x} {g : ∀ x → Q x}
+    → ((a : A) → e' a _ refl .fst (f a) ≡ g (e .fst a))
+    → PathP (λ i → (x : ua e i) → ua-over e e' i x) f g
+  ua-over-pathp e e' {f} {g} p = funext-dep λ {x₀} {x₁} q i →
+    comp (λ j → ua→.filler {e = e} {λ _ _ → Type _} (λ a → ua (e' a (e .fst a) refl)) i j (q i)) (∂ i) λ where
+      k (k = i0) → g (unglue (q i))
+      k (i = i0) → attach (∂ k) (λ { (k = i0) → _ ; (k = i1) → _ }) (inS (p x₀ (~ k)))
+      k (i = i1) → g x₁
+```
+
+For practical formalisation, we prefer to define `ua-over`{.Agda}
+directly as a [[glue type]]. In particular, in a context with $i : \bI$
+and $x : \rm{ua}(e,i)$, the type $Q(\operatorname{unglue} x)$ is
+equivalent to both $P x$ (through the assumed equivalence over $e$) and
+$Q x$ (by the identity equivalence).
+
+```agda
+module _ {A B : Type ℓ} {P : A → Type ℓ'} {Q : B → Type ℓ'} (e : A ≃ B) (e' : P ≃[ e ] Q) where
+  ua-over : PathP (λ i → ua e i → Type ℓ') P Q
+  ua-over i x = Glue (Q (unglue x)) λ where
+    (i = i0) → P x , e' x _ refl
+    (i = i1) → Q x , id≃
+```
+
+We can then use the constructor for `Glue`{.Agda} types to put together
+a proof that a section of $P$ is identical to a section of $B$ when it
+commutes with the given equivalences.
+
+```agda
+  ua-over-pathp
+    : {f : ∀ x → P x} {g : ∀ x → Q x}
+    → ((a : A) → e' a _ refl .fst (f a) ≡ g (e .fst a))
+    → PathP (λ i → (x : ua e i) → ua-over i x) f g
+  ua-over-pathp {g = g} h i x = attach (∂ i) (λ { (i = i0) → _ ; (i = i1) → _ }) (inS
+    (hcomp (∂ i) λ where
+      k (k = i0) → g (unglue x)
+      k (i = i0) → h x (~ k)
+      k (i = i1) → g x))
+```
+
+We can also *destruct* a `Glue`{.Agda} type, which gives us a converse
+to the above.
+
+```agda
+  pathp-ua-over
+    : {f : ∀ x → P x} {g : ∀ x → Q x}
+    → PathP (λ i → (x : ua e i) → ua-over i x) f g
+    → ∀ x → e' x _ refl .fst (f x) ≡ g (e .fst x)
+  pathp-ua-over p x i = unglue (p i (ua-inc e x i))
+```

--- a/src/1Lab/Univalence/Fibrewise.lagda.md
+++ b/src/1Lab/Univalence/Fibrewise.lagda.md
@@ -79,19 +79,19 @@ module _ {A B : Type ℓ} {P : A → Type ℓ'} {Q : B → Type ℓ'} (e : A ≃
 ```
 
 We can then use the constructor for `Glue`{.Agda} types to put together
-a proof that a section of $P$ is identical to a section of $B$ when it
+a proof that a section of $P$ is identical to a section of $Q$ when it
 commutes with the given equivalences.
 
 ```agda
   ua-over-pathp
-    : {f : ∀ x → P x} {g : ∀ x → Q x}
-    → ((a : A) → e' a _ refl .fst (f a) ≡ g (e .fst a))
-    → PathP (λ i → (x : ua e i) → ua-over i x) f g
-  ua-over-pathp {g = g} h i x = attach (∂ i) (λ { (i = i0) → _ ; (i = i1) → _ }) (inS
+    : ∀ {x : A} {y : B} (u : PathP (λ i → ua e i) x y) {x' : P x} {y' : Q y}
+    → e' x y (ua-pathp→path e u) .fst x' ≡ y'
+    → PathP (λ i → ua-over i (u i)) x' y'
+  ua-over-pathp u {x'} {y'} p i = attach (∂ i) (λ { (i = i0) → _ ; (i = i1) → _}) (inS
     (hcomp (∂ i) λ where
-      k (k = i0) → g (unglue x)
-      k (i = i0) → h x (~ k)
-      k (i = i1) → g x))
+      j (j = i0) → e' _ _ (λ k → unglue (u (i ∧ k))) .fst x'
+      j (i = i0) → e' _ _ refl .fst x'
+      j (i = i1) → p j))
 ```
 
 We can also *destruct* a `Glue`{.Agda} type, which gives us a converse
@@ -99,8 +99,11 @@ to the above.
 
 ```agda
   pathp-ua-over
-    : {f : ∀ x → P x} {g : ∀ x → Q x}
-    → PathP (λ i → (x : ua e i) → ua-over i x) f g
-    → ∀ x → e' x _ refl .fst (f x) ≡ g (e .fst x)
-  pathp-ua-over p x i = unglue (p i (ua-inc e x i))
+    : ∀ {x : A} {y : B} (u : PathP (λ i → ua e i) x y) {x' : P x} {y' : Q y}
+    → PathP (λ i → ua-over i (u i)) x' y'
+    → e' x y (ua-pathp→path e u) .fst x' ≡ y'
+  pathp-ua-over u {x'} {y'} p i = comp (λ j → Q (unglue (u (~ i ∨ j)))) (∂ i) λ where
+    j (j = i0) → e' _ _ (λ k → unglue (u (~ i ∧ k))) .fst x'
+    j (i = i0) → e' _ _ (λ j → unglue (u j)) .fst x'
+    j (i = i1) → unglue (p j)
 ```

--- a/src/Algebra/Group/Homotopy/BAut.lagda.md
+++ b/src/Algebra/Group/Homotopy/BAut.lagda.md
@@ -68,10 +68,7 @@ identifies $X \equiv T$.
   decode∘encode : ∀ b (p : base ≡ b) → decode b (encode b p) ≡ p
   decode∘encode b =
     J (λ b p → decode b (encode b p) ≡ p)
-      (Σ-prop-square (λ _ → squash) sq)
-    where
-      sq : ua (encode base refl) ≡ refl
-      sq = ap ua path→equiv-refl ∙ ua-id-equiv
+      (Σ-prop-square (λ _ → squash) (ua.ε refl))
 ```
 
 `Encode`{.Agda ident=encode} and `decode`{.Agda} are inverses by a

--- a/src/Cat/Displayed/Path.lagda.md
+++ b/src/Cat/Displayed/Path.lagda.md
@@ -223,7 +223,7 @@ like
 
 ```agda
     p1 : PathP (λ i → ps i .Ob → Type o') ℰ.Ob[_] ℱ.Ob[_]
-    p1 i x = Glue ℱ.Ob[ unglue (∂ i) x ] λ where
+    p1 i x = Glue ℱ.Ob[ unglue x ] λ where
       (i = i0) → ℰ.Ob[ x ] , G.F₀' , obeqv x
       (i = i1) → ℱ.Ob[ x ] , _ , id-equiv
 ```
@@ -235,17 +235,12 @@ $x$, giving a line of type families `p1`{.Agda} ranging from $\cE[-]
 \to \cF[-]$. The situation for Hom spaces is analogous.
 
 ```agda
-    sys : ∀ i (x y : ps i .Ob) (f : ps i .Hom x y) (x' : p1 i x) (y' : p1 i y)
-        → Partial (i ∨ ~ i) _
-    sys i x y f x' y' (i = i0) = ℰ.Hom[ f ] x' y' , G.F₁' , homeqv
-    sys i x y f x' y' (i = i1) = ℱ.Hom[ f ] x' y' , _ , id-equiv
-
     p2 : PathP
       (λ i → {x y : ps i .Ob} (f : ps i .Hom x y) → p1 i x → p1 i y → Type ℓ')
       ℰ.Hom[_] ℱ.Hom[_]
-    p2 i {x} {y} f x' y' = Glue
-      (ℱ.Hom[ unglue (∂ i) f ] (unglue (∂ i) x') (unglue (∂ i) y'))
-      (sys i x y f x' y')
+    p2 i {x} {y} f x' y' = Glue (ℱ.Hom[ unglue f ] (unglue x') (unglue y')) λ where
+      (i = i0) → ℰ.Hom[ f ] x' y' , G.F₁' , homeqv
+      (i = i1) → ℱ.Hom[ f ] x' y' , id≃
 
     open displayed-pathp-data
     input : displayed-pathp-data
@@ -263,15 +258,14 @@ $F_1'$ and ungluing the domain/codomain, between the identity maps in
 $\cE$ and $\cF$.
 
 ```agda
-    input .idp i {x} {x'} = glue-inc (∂ i)
-      {Tf = sys i x x (ps i .id {x}) x' x'}
+    input .idp i {x} {x'} = attach (∂ i)
       (λ { (i = i0) → ℰ.id' ; (i = i1) → ℱ.id' })
-      (inS (comp (λ j → ℱ.Hom[ p (~ j) ] (unglue (∂ i) x') (unglue (∂ i) x')) (∂ i)
+      (inS (comp (λ j → ℱ.Hom[ p (~ j) ] (unglue x') (unglue x')) (∂ i)
         λ { j (j = i0) → ℱ.id'
           ; j (i = i0) → G.F-id' (~ j)
           ; j (i = i1) → ℱ.id' }))
       where
-        p : unglue (∂ i) (ps i .id {x}) ≡ C.id
+        p : unglue (ps i .id {x}) ≡ C.id
         p j = hfill (∂ i) (~ j) λ where
           k (k = i0) → C.id
           k (i = i0) → F.F-id (~ k)
@@ -283,21 +277,18 @@ $\cE$ and $\cF$.
 I won't comment on it. You can't make me.</summary>
 
 ```agda
-    input .compp i {x} {y} {z} {f} {g} {x'} {y'} {z'} f' g' = glue-inc (∂ i)
-        {Tf = sys i x z (ps i ._∘_ {x} {y} {z} f g) x' z'}
-        (λ { (i = i0) → f' ℰ.∘' g' ; (i = i1) → f' ℱ.∘' g' })
-        (inS (comp (λ j → ℱ.Hom[ p j ] (unglue (∂ i) x') (unglue (∂ i) z')) (∂ i)
-          λ { k (k = i0) →
-                   unglue (∂ i) {T = λ .∂i=i1 → sys i y z f y' z' ∂i=i1 .fst} f'
-              ℱ.∘' unglue (∂ i) g'
-            ; k (i = i0) → G.F-∘' {f' = f'} {g' = g'} (~ k)
-            ; k (i = i1) → f' ℱ.∘' g' }))
+    input .compp i {x} {y} {z} {f} {g} {x'} {y'} {z'} f' g' = attach _
+      (λ { (i = i0) → f' ℰ.∘' g' ; (i = i1) → f' ℱ.∘' g' })
+      (inS (comp (λ j → ℱ.Hom[ p j ] (unglue x') (unglue z')) (∂ i)
+        λ { k (k = i0) → unglue f' ℱ.∘' unglue g'
+          ; k (i = i0) → G.F-∘' {f' = f'} {g' = g'} (~ k)
+          ; k (i = i1) → f' ℱ.∘' g' }))
       where
-        p : I → C .Hom (unglue (i ∨ ~ i) x) (unglue (i ∨ ~ i) z)
+        p : I → C .Hom (unglue x) (unglue z)
         p j = hfill (∂ i) j λ where
           k (i = i0) → F.F-∘ f g (~ k)
           k (i = i1) → f C.∘ g
-          k (k = i0) → unglue (∂ i) f C.∘ unglue (∂ i) g
+          k (k = i0) → unglue f C.∘ unglue g
 ```
 
 </details>

--- a/src/Cat/Instances/Sets.lagda.md
+++ b/src/Cat/Instances/Sets.lagda.md
@@ -144,11 +144,7 @@ This fact lets us re-use the `to-path`{.Agda} component of `Sets-is-category`{.A
 
 ```agda
   Sets^op-is-category : is-category (Sets ℓ ^op)
-  Sets^op-is-category .to-path = Sets-is-category .to-path ⊙ transport (ua iso-op-invariant)
-  Sets^op-is-category .to-path-over {a} {b} p = Sets^op.≅-pathp refl _ $ funext-dep λ {x₀} {x₁} q →
-    x₀                                                    ≡˘⟨ ap (_$ x₀) p.invr ⟩
-    p.to ⌜ p.from x₀ ⌝                                    ≡˘⟨ ap¡ Regularity.reduce! ⟩
-    p.to ⌜ transport refl $ p.from $ transport refl x₀ ⌝  ≡⟨ ap! (λ i → unglue (∂ i) (q i)) ⟩
-    p.to x₁                                               ∎
+  Sets^op-is-category .to-path = Sets-is-category .to-path ⊙ iso-op-invariant .fst
+  Sets^op-is-category .to-path-over {a} {b} p = Sets^op.≅-pathp refl _ $ ua→ λ a → sym (p.invr $ₚ a)
     where module p = Sets^op._≅_ p
 ```

--- a/src/Homotopy/Space/Circle.lagda.md
+++ b/src/Homotopy/Space/Circle.lagda.md
@@ -230,7 +230,7 @@ face has a dotted boundary.
 
 ```agda
   decode (loop i) n j = hcomp (∂ i ∨ ∂ j) λ where
-    k (k = i0) → loopⁿ (unglue (∂ i) n) j
+    k (k = i0) → loopⁿ (unglue n) j
     k (i = i0) → ∙→square (loopⁿ⁺¹ n) (~ k) j
     k (i = i1) → loopⁿ n j
     k (j = i0) → base

--- a/src/Homotopy/Space/Delooping.lagda.md
+++ b/src/Homotopy/Space/Delooping.lagda.md
@@ -227,7 +227,7 @@ to `Code`{.Agda}. For decoding, we do induction on `Deloop`{.Agda} with
   decode = go where
     coh : ∀ x → PathP (λ i → Code ʻ path x i → base ≡ path x i) path path
     coh x i c j = hcomp (∂ i ∨ ∂ j) λ where
-      k (k = i0) → path (ua-unglue (Code.path-case.eqv x) i c) j
+      k (k = i0) → path (unglue c) j
       k (i = i0) → path-sq c x (~ k) j
       k (i = i1) → path c j
       k (j = i0) → base

--- a/src/Order/Univalent.lagda.md
+++ b/src/Order/Univalent.lagda.md
@@ -89,7 +89,7 @@ equivalences. And since the missing left-hand-side is precisely the
 statement "$f$ is an order-embedding", we can:
 
 ```agda
-  order i x y = Glue (unglue (∂ i) x Q.≤ unglue (∂ i) y) λ where
+  order i x y = Glue (unglue x Q.≤ unglue y) λ where
     (i = i0) → x P.≤ y , order-iso-is-order-embedding f
     (i = i1) → x Q.≤ y , _ , id-equiv
 ```

--- a/src/Prim/Kan.lagda.md
+++ b/src/Prim/Kan.lagda.md
@@ -75,7 +75,7 @@ caseⁱ x return P of f = f x (λ i → x)
 {-# INLINE caseⁱ_of_ #-}
 {-# INLINE caseⁱ_return_of_ #-}
 
-{-# DISPLAY X.primHComp {_} {_} {φ} (hcomp-sys.sys _ u) _ = hcomp φ u #-}
+{-# DISPLAY X.primHComp {ℓ} {A} {φ} (hcomp-sys.sys _ u) _ = hcomp {ℓ} {A} φ u #-}
 {-# DISPLAY X.primHComp {_} {_} {φ} (comp-sys.sys A _ u) _ = comp A φ u #-}
 ```
 -->

--- a/src/Prim/Kan.lagda.md
+++ b/src/Prim/Kan.lagda.md
@@ -30,7 +30,9 @@ hcomp
   : ∀ {ℓ} {A : Type ℓ} (φ : I)
   → (u : (i : I) → Partial (φ ∨ ~ i) A)
   → A
-hcomp φ u = X.primHComp (λ j .o → u j (leftIs1 φ (~ j) o)) (u i0 1=1)
+hcomp {A = A} φ u = X.primHComp sys (u i0 1=1) module hcomp-sys where
+  sys : ∀ j → Partial φ A
+  sys j (φ = i1) = u j 1=1
 
 ∂ : I → I
 ∂ i = i ∨ ~ i
@@ -39,7 +41,9 @@ comp
   : ∀ {ℓ : I → Level} (A : (i : I) → Type (ℓ i)) (φ : I)
   → (u : (i : I) → Partial (φ ∨ ~ i) (A i))
   → A i1
-comp A φ u = X.primComp A (λ j .o → u j (leftIs1 φ (~ j) o)) (u i0 1=1)
+comp A φ u = X.primHComp sys (transp (λ i → A i) i0 (u i0 1=1)) module comp-sys where
+  sys : ∀ j → Partial φ (A i1)
+  sys i (φ = i1) = transp (λ j → A (i ∨ j)) i (u i 1=1)
 ```
 
 We also define the type of dependent paths, and of non-dependent paths.
@@ -70,5 +74,8 @@ caseⁱ x return P of f = f x (λ i → x)
 
 {-# INLINE caseⁱ_of_ #-}
 {-# INLINE caseⁱ_return_of_ #-}
+
+{-# DISPLAY X.primHComp {_} {_} {φ} (hcomp-sys.sys _ u) _ = hcomp φ u #-}
+{-# DISPLAY X.primHComp {_} {_} {φ} (comp-sys.sys A _ u) _ = comp A φ u #-}
 ```
 -->


### PR DESCRIPTION
* Replaces the definition of the `comp`, `hcomp` and `Glue` wrappers
  with something that we can write display forms for; also display forms
  for the primitive `unglue` (exposed as `unattach`) and `glue` (exposed
  as `attach` since a lot of code uses `glue` as a higher constructor).

  The types of `unattach` and `attach` had to be slightly revised so you
  only have to specify the cofibration to Glue against (everything else
  is inferrable if we use the primitive directly).

* A new wrapper macro to replace `unglue` which can actually infer the
  cofibration when given an argument in `Glue` (or `hcomp {Type _}`).

* Lots of minor tweaks to proofs about gluing stuff to use `attach` more
  directly. A new module about comparing type families over equivalent
  bases to demonstrate how to make paths `ua e i → Type` directly with
  `Glue` instead of `ua→ λ _ → ua _`.