### PR TITLE
chore: bump agda

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,6 +59,7 @@ jobs:
           NIX_BUILD_SHELL: bash
           build_command: |
             set -eu
+            agda --setup
             1lab-shake -j all
             eval "$installPhase"
 

--- a/default.nix
+++ b/default.nix
@@ -45,7 +45,7 @@ let
 
   deps = with pkgs; [
     # For driving the compilation:
-    shakefile
+    shakefile our-ghc
 
     # For building the text and maths:
     gitMinimal nodePackages.sass
@@ -53,10 +53,8 @@ let
     # For building diagrams:
     poppler_utils our-texlive
   ] ++ (if interactive then [
-    our-ghc
     sort-imports
   ] else [
-    labHaskellPackages.Agda.data
     labHaskellPackages.pandoc.data
   ]);
 in

--- a/support/nix/dep/Agda/github.json
+++ b/support/nix/dep/Agda/github.json
@@ -1,8 +1,8 @@
 {
   "owner": "agda",
   "repo": "agda",
-  "branch": "master",
+  "branch": "aliao/instance-perf",
   "private": false,
-  "rev": "0f79dcc236242f7f1682aad0ca30070b15ed20d5",
-  "sha256": "1yq0wg44rbwk3akinh0j1bmv95mdcqy3qnmrak46zavyc1dslwp9"
+  "rev": "4f80b0ce86ef029e59a148b658abab59a1f69ddf",
+  "sha256": "0zdv3hj66bzh2h82p6kkp6k0ifzkngqh34n430lqi8jb8qxvlkf4"
 }

--- a/support/nix/dep/Agda/github.json
+++ b/support/nix/dep/Agda/github.json
@@ -1,8 +1,8 @@
 {
   "owner": "agda",
   "repo": "agda",
-  "branch": "aliao/instance-perf",
+  "branch": "master",
   "private": false,
-  "rev": "4f80b0ce86ef029e59a148b658abab59a1f69ddf",
-  "sha256": "0zdv3hj66bzh2h82p6kkp6k0ifzkngqh34n430lqi8jb8qxvlkf4"
+  "rev": "f9f2714a214543269e2e6e6b25e067f210261654",
+  "sha256": "121sysbmgf606yl79vizxn5cbfm0vbzcixj0861xx2r75ii48b2k"
 }


### PR DESCRIPTION
While working on elementary topoi, I got so mad that a module felt slower than it should, that I went to fix the compiler.

This bumps us past https://github.com/agda/agda/commit/9e0eae64b2a31750af4e30a0c52ca3cd63cc10ef so @ncfavier @TOTBWF @4e554c4c the next time you try to run our Agda you'll have to e.g.

```bash
nix-shell . --run 'agda --setup'
```

to write out the primitive modules even though we don't use them.