### PR TITLE
reflection.induction: handle erased constructors

### DIFF
--- a/src/1Lab/Reflection.lagda.md
+++ b/src/1Lab/Reflection.lagda.md
@@ -103,6 +103,9 @@ private module P where
   -- "blocking" constraints.
     noConstraints : ∀ {a} {A : Type a} → TC A → TC A
 
+  -- Run the given computation at the type level, allowing use of erased things.
+    work-on-types : ∀ {a} {A : Type a} → TC A → TC A
+
   -- Run the given TC action and return the first component. Resets to
   -- the old TC state if the second component is 'false', or keep the
   -- new TC state if it is 'true'.
@@ -158,6 +161,7 @@ private module P where
   {-# BUILTIN AGDATCMASKEXPANDLAST     askExpandLast              #-}
   {-# BUILTIN AGDATCMASKREDUCEDEFS     askReduceDefs              #-}
   {-# BUILTIN AGDATCMNOCONSTRAINTS     noConstraints              #-}
+  {-# BUILTIN AGDATCMWORKONTYPES       work-on-types              #-}
   {-# BUILTIN AGDATCMRUNSPECULATIVE    run-speculative            #-}
   {-# BUILTIN AGDATCMGETINSTANCES      get-instances              #-}
   {-# BUILTIN AGDATCMDECLAREDATA       declareData                #-}

--- a/src/1Lab/Reflection/Deriving/Show.agda
+++ b/src/1Lab/Reflection/Deriving/Show.agda
@@ -105,7 +105,7 @@ private
 
   -- Create the clause of shows-prec for a constructor.
   show-clause : Constructor → TC Clause
-  show-clause (conhead conm _ args _) = do
+  show-clause (conhead conm _ _ args _) = do
     let
       -- We'll only show the visible arguments to the constructor.
       -- Moreover, since Agda can infer the types in the telescope

--- a/src/1Lab/Reflection/Induction.agda
+++ b/src/1Lab/Reflection/Induction.agda
@@ -235,15 +235,17 @@ private
           -- Otherwise, add m : T to the telescope and replace the corresponding
           -- constructor with m henceforth.
           method ← ("P" <>_) <$> render-name c
+          q ← get-con-quantity c
+          let argC = arg (arginfo visible (modality relevant q))
           let
             ps = raise 1 ps
             P = raise 1 P
             rs = (c' , var 0 []) ∷ raise 1 rs
-          extend-context method (argN methodT) (go ps P rs cs) <&>
-            ×-map₁₂ ((method , argN methodT) ∷_) (α ∷_)
+          extend-context method (argC methodT) (go ps P rs cs) <&>
+            ×-map₁₂ ((method , argC methodT) ∷_) (α ∷_)
 
 make-elim-with : Elim-options → Name → Name → TC ⊤
-make-elim-with opts elim D = withNormalisation true do
+make-elim-with opts elim D = work-on-types $ withNormalisation true do
   DT ← get-type D >>= normalise -- D : (ps : Γ) (is : Ξ) → Type _
   data-type pars cs ← get-definition D
     where _ → typeError [ "not a data type: " , nameErr D ]


### PR DESCRIPTION
Inspired by https://github.com/cmcmA20/cubical-mini/pull/48. Also adds `work-on-types` so that the macro works at all when `--erasure` is used (see https://github.com/agda/agda/issues/6124).