### PR TITLE
Fix typoes in Cat.Monoidal.Instances.Day

### DIFF
--- a/src/Cat/Monoidal/Instances/Day.lagda.md
+++ b/src/Cat/Monoidal/Instances/Day.lagda.md
@@ -176,20 +176,20 @@ isomorphism, but this turns out to be too strong: we can simply take the
 product with the $\hom$-set into the product:
 
 $$
-(F \otimes^D G)(x) = \int^{c_1, c_2 : \cC} \hom_{\cC}(c, c_1 \otimes c_2) \times X(c_1) \times Y(c_2)
+(F \otimes^D G)(x) = \int^{x_1, x_2 : \cC} \hom_{\cC}(x, x_1 \otimes x_2) \times F(x_1) \times G(x_2)
 $$
 
 ::: warning
 It's worth taking a second to read the formalised definition, below, if
 you are unfamiliar with coends. We must express the "integrand" as a
 functor $(C \times C)\op \times C \times C$. This provides us with
-"polarised" versions of the variables $c_1, c_2$, which we write
-$c_1^-/c_1^+$ and $c_2^-/c_2^+$.
+"polarised" versions of the variables $x_1, x_2$, which we write
+$x_1^-/x_1^+$ and $x_2^-/x_2^+$.
 
 We then distribute these variables according to the polarities of each
 functor. Since $\hom$ is covariant in its second argument, it sees
 $c_1^+ \otimes c_2^+$; but the presheaves are contravariant, so we have
-factors $X(c_1^-)$ and $Y(c_2^-)$.
+factors $F(x_1^-)$ and $G(x_2^-)$.
 :::
 
 ```agda


### PR DESCRIPTION
# Description

There are some confusions in the coend diagram on this page trying to match notation both from the previous equation (of a convolution) and the following agda equations (between F,G/X,Y and x/c).

I've chosen to amend the diagram to completely match the one before, since the prose seems to be primarily attempting to compare the two.