### PR TITLE
Subobjects form a set in a univalent category

### DIFF
--- a/src/Cat/Diagram/Product/Indexed.lagda.md
+++ b/src/Cat/Diagram/Product/Indexed.lagda.md
@@ -32,7 +32,7 @@ context, indexed by types which are not sets.
 That's where $I$-indexed products come in: Rather than having a
 _functor_ giving the objects to take the limit over, we have an
 arbitrary map $F$ from $I$ to the space of objects of $\cC$. An _indexed
-product_ for this "diagram" is then an object admitting an universal
+product_ for this "diagram" is then an object admitting a universal
 family of maps $\pi_i : (\prod F) \to F_i$.
 
 ```agda
@@ -286,8 +286,8 @@ lying over our isomorphism.
 ## Properties
 
 Let $X : \Sigma A B \to \cC$ be a family of objects in $\cC$. If the
-the indexed products $\Pi_{a, b : \Sigma A B} X_{a,b}$ and
-$\Pi_{a : A} \Pi_{b : B(a)} X_{a, b}$ exists, then they are isomorphic.
+indexed products $\Pi_{a, b : \Sigma A B} X_{a,b}$ and
+$\Pi_{a : A} \Pi_{b : B(a)} X_{a, b}$ exist, then they are isomorphic.
 
 ```agda
 is-indexed-product-assoc

--- a/src/Cat/Displayed/Doctrine.lagda.md
+++ b/src/Cat/Displayed/Doctrine.lagda.md
@@ -11,6 +11,7 @@ open import Cat.Displayed.Base
 open import Cat.Prelude
 
 open import Order.Base
+open import Order.Cat
 
 import Cat.Displayed.Reasoning as Disp
 import Cat.Reasoning as Cat
@@ -67,24 +68,28 @@ predicates; we therefore write $\phi \vdash_\Gamma \psi$.
 However, having an entire _category_ of predicates is hard to make
 well-behaved: that would lend itself more to an interpretation of
 dependent type theory, rather than the first-order logic we are
-concerned with. Therefore, we impose the following three restrictions on
+concerned with. Therefore, we impose the following two restrictions on
 $\bP$:
 
 ```agda
   field
-    has-is-set     : ∀ Γ → is-set ℙ.Ob[ Γ ]
     has-is-thin    : ∀ {x y} {f : Hom x y} x' y' → is-prop (ℙ.Hom[ f ] x' y')
     has-univalence : ∀ x → is-category (Fibre ℙ x)
 ```
 
-First, the space of predicates over $\Gamma$ must be a [[set]]. Second,
-the entailment relation $\phi \vdash_\Gamma \psi$ must be a
+First, the entailment relation $\phi \vdash_\Gamma \psi$ must be a
 [[proposition]], rather than an arbitrary set --- which we will use as
-justification to omit the names of its inhabitants. Finally, each
+justification to omit the names of its inhabitants. Second, each
 [[fibre category]] $\bP(\Gamma)$ must be [[univalent|univalent
 category]]. In light of the previous restriction, this means that each
 fibre satisfies _antisymmetry_, or, specialising to logic, that
-inter-derivable propositions are indistinguishable.
+inter-derivable propositions are indistinguishable. To put it more
+concisely, this means that every fibre $\bP(\Gamma)$ is a [[poset]]:
+
+```agda
+  ≤-Poset : ∀ {x : Ob} → Poset o' ℓ'
+  ≤-Poset {x = x} = thin→poset (Fibre ℙ x) has-is-thin (has-univalence x)
+```
 
 Next, each fibre $\bP(\Gamma)$ must be [[finitely complete]]. The binary
 products interpret conjunction, and the terminal object interprets the
@@ -92,6 +97,7 @@ true proposition; since we are working with posets, these two shapes of
 limit suffice to have full finite completeness.
 
 ```agda
+  field
     fibrewise-meet : ∀ {x} x' y' → Product (Fibre ℙ x) x' y'
     fibrewise-top  : ∀ x → Terminal (Fibre ℙ x)
 ```
@@ -242,14 +248,9 @@ the Beck-Chevalley condition.
 
 <!--
 ```agda
-  ≤-Poset : ∀ {x : Ob} → Poset o' ℓ'
-  ≤-Poset {x = x} .Poset.Ob = ℙ.Ob[ x ]
-  ≤-Poset {x = x} .Poset._≤_ = ℙ.Hom[ id ]
-  ≤-Poset {x = x} .Poset.≤-thin = has-is-thin _ _
-  ≤-Poset {x = x} .Poset.≤-refl = ℙ.id'
-  ≤-Poset {x = x} .Poset.≤-trans α β = Precategory._∘_ (Fibre ℙ _) β α
-  ≤-Poset {x = x} .Poset.≤-antisym α β = has-univalence _ .to-path $
-      Cat.make-iso (Fibre ℙ _) α β (has-is-thin _ _ _ _) (has-is-thin _ _ _ _)
+  abstract
+    has-is-set : ∀ Γ → is-set ℙ.Ob[ Γ ]
+    has-is-set Γ = Poset.Ob-is-set ≤-Poset
 
   module _ {x} where
     open Order.Reasoning (≤-Poset {x}) hiding (Ob-is-set ; Ob) public

--- a/src/Cat/Displayed/Doctrine/Frame.lagda.md
+++ b/src/Cat/Displayed/Doctrine/Frame.lagda.md
@@ -193,7 +193,6 @@ We're ready to put everything together. By construction, we have a
 ```agda
   idx : Regular-hyperdoctrine (Sets κ) _ _
   idx .ℙ                = disp
-  idx .has-is-set  x    = Π-is-hlevel 2 λ _ → F.Ob-is-set
   idx .has-is-thin f g  = hlevel 1
   idx .has-univalence S = set-identity-system
     (λ _ _ _ _ → Cat.≅-path (Fibre disp _) prop!)

--- a/src/Cat/Displayed/Instances/Subobjects.lagda.md
+++ b/src/Cat/Displayed/Instances/Subobjects.lagda.md
@@ -15,6 +15,9 @@ open import Cat.Displayed.Base
 open import Cat.Diagram.Image
 open import Cat.Prelude
 
+open import Order.Base
+open import Order.Cat
+
 import Cat.Reasoning as Cr
 ```
 -->
@@ -382,7 +385,7 @@ Sub-products {y} pb a b = prod where
 
 ## Univalence
 
-Since identity of $m, n : \Sub(y)$ is given by identity of they
+Since identity of $m, n : \Sub(y)$ is given by identity of the
 underlying objects and identity-over of the corresponding morphisms, if
 $\cB$ is univalent, we can conclude that $\Sub(y)$ is, too. Since
 $\Sub(y)$ is always thin, we can summarise the situation by saying that
@@ -399,4 +402,13 @@ Sub-is-category b-cat .to-path {a} {b} x =
     i = make-iso (x .Sub.to .map) (x .Sub.from .map) (ap map (Sub.invl x)) (ap map (Sub.invr x))
 Sub-is-category b-cat .to-path-over p =
   Sub.≅-pathp refl _ prop!
+```
+
+As a consequence, the collection of subobjects of any object of a
+univalent category forms a [[set]].
+
+```agda
+Subobject-is-set : is-category B → ∀ {A} → is-set (Subobject A)
+Subobject-is-set b-cat {A} = Poset.Ob-is-set $
+  thin→poset (Sub A) (λ _ _ → ≤-over-is-prop) (Sub-is-category b-cat)
 ```

--- a/src/Order/Base.lagda.md
+++ b/src/Order/Base.lagda.md
@@ -114,8 +114,7 @@ which, _a priori_, might not be a proposition: we have not included the
 assumption that `Ob`{.Agda} is actually a set. Therefore, it might be
 the case that an identification between posets does _not_ correspond to
 an identification of the underlying types and one of the relation.
-However, since the "symmetric part" of $\le$, the relation
-iff.
+However, since the "symmetric part" of $\le$, the relation defined by
 
 $$
 x \sim y = (x \le y) \land (y \le x)


### PR DESCRIPTION
Mostly putting together stuff we already have: a thin univalent category is a poset, hence each collection of subobjects in a univalent category forms a set.