### PR TITLE
Discreteness and H-Levels of W-types

### DIFF
--- a/src/1Lab/Type/Pi.lagda.md
+++ b/src/1Lab/Type/Pi.lagda.md
@@ -249,6 +249,13 @@ funext-square p i j a = p a i j
   .is-iso.rinv b → ap (λ e → subst B e b) (is-contr→is-set c _ _ _ _) ∙ transport-refl b
   .is-iso.linv b → funext λ a → from-pathp (ap b (c .paths a))
 
+Π-dom-empty-is-contr
+  : ∀ {ℓ ℓ'} {A : Type ℓ} {B : A → Type ℓ'}
+  → ¬ A
+  → is-contr (∀ (x : A) → B x)
+Π-dom-empty-is-contr ¬A .centre x = absurd (¬A x)
+Π-dom-empty-is-contr ¬A .paths f = funext λ x → absurd (¬A x)
+
 flip
   : ∀ {ℓ ℓ' ℓ''} {A : Type ℓ} {B : Type ℓ'} {C : A → B → Type ℓ''}
   → (∀ a b → C a b) → (∀ b a → C a b)

--- a/src/Data/Wellfounded/W.lagda.md
+++ b/src/Data/Wellfounded/W.lagda.md
@@ -42,8 +42,15 @@ by the "is a subtree of" relation!
 
 ```agda
 module _ {ℓ ℓ'} {A : Type ℓ} {B : A → Type ℓ'} where
+
+  label : W A B → A
+  label (sup l f) = l
+
+  subtree : (w : W A B) → B (label w) → W A B
+  subtree (sup l f) b = f b
+
   _<_ : W A B → W A B → Type _
-  x < sup i f = ∃[ j ∈ B i ] (f j ≡ x)
+  w < v = ∃[ j ∈ B (label v) ] (subtree v j ≡ w)
 ```
 
 This order is actually well-founded: if we want to prove a property of

--- a/src/Data/Wellfounded/W.lagda.md
+++ b/src/Data/Wellfounded/W.lagda.md
@@ -186,6 +186,33 @@ Luckily, this is completely straightforward.
     coherent = transpose (flip₁ (∙-filler _ _))
 ```
 
+<!--
+```agda
+module _ {ℓ ℓ'} {A : Type ℓ} {B : A → Type ℓ'} where
+```
+-->
+
+Initiality of W-types also lets us show that $W\; A\; B$ is a fixpoint of the functor
+$X \mapsto \Sigma (a : A).\; B(a) \to X$. This is a consequence of [[Lambek's lemma]],
+but this is easy enough to prove by hand.
+
+```agda
+  W-fixpoint : W A B ≃ (Σ[ a ∈ A ] (B a → W A B))
+  W-fixpoint = Iso→Equiv (to , iso from invr invl)
+    where
+      to : W A B → Σ[ a ∈ A ] (B a → W A B)
+      to w = label w , subtree w
+
+      from : (Σ[ a ∈ A ] (B a → W A B)) → W A B
+      from (l , f) = sup l f
+
+      invr : is-right-inverse from to
+      invr (l , f) = refl
+
+      invl : is-left-inverse from to
+      invl (sup l f) = refl
+```
+
 ## Initial algebras are inductive types
 
 We will now show the other direction of the correspondence: given an

--- a/src/Data/Wellfounded/W.lagda.md
+++ b/src/Data/Wellfounded/W.lagda.md
@@ -30,10 +30,17 @@ data W {ℓ ℓ'} (A : Type ℓ) (B : A → Type ℓ') : Type (ℓ ⊔ ℓ') whe
 
 <!--
 ```agda
-W-elim : ∀ {ℓ ℓ' ℓ''} {A : Type ℓ} {B : A → Type ℓ'} {C : W A B → Type ℓ''}
-       → ({a : A} {f : B a → W A B} → (∀ ba → C (f ba)) → C (sup a f))
-       → (w : W A B) → C w
+W-elim
+  : ∀ {ℓ ℓ' ℓ''} {A : Type ℓ} {B : A → Type ℓ'} {C : W A B → Type ℓ''}
+  → ({a : A} {f : B a → W A B} → (∀ ba → C (f ba)) → C (sup a f))
+  → (w : W A B) → C w
 W-elim {C = C} ps (sup a f) = ps (λ ba → W-elim {C = C} ps (f ba))
+
+W-elim₂
+  : ∀ {ℓ ℓ' ℓ''} {A : Type ℓ} {B : A → Type ℓ'} {C : W A B → W A B → Type ℓ''}
+  → ({x y : A} {f : B x → W A B} {g : B y → W A B} → (∀ bx by → C (f bx) (g by)) → C (sup x f) (sup y g))
+  → (w₁ w₂ : W A B) → C w₁ w₂
+W-elim₂ {C = C} ps (sup x f) (sup y g) = ps (λ bx by → W-elim₂ {C = C} ps (f bx) (g by))
 ```
 -->
 


### PR DESCRIPTION
# Description

This PR proves that a W-type `W A B` is discrete when `A` is discrete and `B x` is `Listable` for every `x`. I've also added
a characterisation of equality types of W-types. These should make arguments about decidable equality a bit easier to make for inductive types: instead of doing a giant $O(n^2)$ case bash, we can construct an equivalence with a W-type instead. Some automation on this front would be useful, but I've spent enough time shaving this yak already :)

## Checklist

Before submitting a merge request, please check the items below:

- [x] I've read [the contributing guidelines](https://github.com/plt-amy/1lab/blob/main/CONTRIBUTING.md).
- [x] The imports of new modules have been sorted with `support/sort-imports.hs` (or `nix run --experimental-features nix-command -f . sort-imports`).
- [x] All new code blocks have "agda" as their language.

If your change affects many files without adding substantial content, and
you don't want your name to appear on those pages (for example, treewide
refactorings or reformattings), start the commit message and PR title with `chore:`.
