### PR TITLE
Split Surjectivity

### DIFF
--- a/src/1Lab/Classical.lagda.md
+++ b/src/1Lab/Classical.lagda.md
@@ -122,7 +122,7 @@ Surjections-split =
   ∀ {ℓ ℓ'} {A : Type ℓ} {B : Type ℓ'} → is-set A → is-set B
   → (f : A → B)
   → is-surjective f
-  → ∥ (∀ b → fibre f b) ∥
+  → is-split-surjective f
 ```
 
 We show that these two statements are logically equivalent^[they are also

--- a/src/1Lab/Equiv.lagda.md
+++ b/src/1Lab/Equiv.lagda.md
@@ -1083,6 +1083,9 @@ x ≃⟨⟩ x≡y = x≡y
 
 _≃∎ : ∀ {ℓ} (A : Type ℓ) → A ≃ A
 x ≃∎ = id≃
+
+begin-≃⁻¹_ : ∀ {ℓ ℓ'} {A : Type ℓ} {B : Type ℓ'} → A ≃ B → B ≃ A
+begin-≃⁻¹_ = _e⁻¹
 ```
 
 <!--
@@ -1090,6 +1093,7 @@ x ≃∎ = id≃
 infixr 30 _∙e_
 infix 31 _e⁻¹
 
+infix 1 begin-≃⁻¹_
 infixr 2 ≃⟨⟩-syntax _≃⟨⟩_ _≃˘⟨_⟩_
 infix  3 _≃∎
 infix 21 _≃_

--- a/src/1Lab/Equiv.lagda.md
+++ b/src/1Lab/Equiv.lagda.md
@@ -71,8 +71,9 @@ Here in the 1Lab, we formalise three acceptable notions of equivalence:
 <!--
 ```agda
 private variable
-  ℓ₁ ℓ₂ : Level
-  A A' B B' C : Type ℓ₁
+  ℓ ℓ₁ ℓ₂ : Level
+  A A' B B' C : Type ℓ
+  P : A → Type ℓ
 ```
 -->
 
@@ -1094,7 +1095,37 @@ infix  3 _≃∎
 infix 21 _≃_
 
 syntax ≃⟨⟩-syntax x q p = x ≃⟨ p ⟩ q
+```
+-->
 
+## Some useful equivalences
+
+We can extend `subst`{.Agda} to an equivalence between `Σ[ y ∈ A ] (y ≡ x × P y)`
+and `P x` for every `x : A` and `P : A → Type`.
+
+```agda
+subst≃
+  : (x : A) → (Σ[ y ∈ A ] (y ≡ x × P y)) ≃ P x
+subst≃ {A = A} {P = P} x = Iso→Equiv (to , iso from invr invl)
+  where
+    to : Σ[ y ∈ A ] (y ≡ x × P y) → P x
+    to (y , y=x , py) = subst P y=x py
+
+    from : P x → Σ[ y ∈ A ] (y ≡ x × P y)
+    from px = x , refl , px
+
+    invr : is-right-inverse from to
+    invr = transport-refl
+
+    invl : is-left-inverse from to
+    invl (y , y=x , py) i =
+      (y=x (~ i)) ,
+      (λ j → y=x (~ i ∨ j)) ,
+      transp (λ j → P (y=x (~ i ∧ j))) i py
+```
+
+<!--
+```agda
 lift-inj
   : ∀ {ℓ ℓ'} {A : Type ℓ} {a b : A}
   → lift {ℓ = ℓ'} a ≡ lift {ℓ = ℓ'} b → a ≡ b

--- a/src/1Lab/Equiv.lagda.md
+++ b/src/1Lab/Equiv.lagda.md
@@ -1083,9 +1083,6 @@ x ≃⟨⟩ x≡y = x≡y
 
 _≃∎ : ∀ {ℓ} (A : Type ℓ) → A ≃ A
 x ≃∎ = id≃
-
-begin-≃⁻¹_ : ∀ {ℓ ℓ'} {A : Type ℓ} {B : Type ℓ'} → A ≃ B → B ≃ A
-begin-≃⁻¹_ = _e⁻¹
 ```
 
 <!--
@@ -1093,7 +1090,6 @@ begin-≃⁻¹_ = _e⁻¹
 infixr 30 _∙e_
 infix 31 _e⁻¹
 
-infix 1 begin-≃⁻¹_
 infixr 2 ≃⟨⟩-syntax _≃⟨⟩_ _≃˘⟨_⟩_
 infix  3 _≃∎
 infix 21 _≃_

--- a/src/1Lab/Equiv.lagda.md
+++ b/src/1Lab/Equiv.lagda.md
@@ -1126,6 +1126,26 @@ subst≃ {A = A} {P = P} x = Iso→Equiv (to , iso from invr invl)
 
 <!--
 ```agda
+is-equiv≃fibre-is-contr
+  : ∀ {ℓ ℓ'} {A : Type ℓ} {B : Type ℓ'}
+  → {f : A → B}
+  → is-equiv f ≃ (∀ x → is-contr (fibre f x))
+is-equiv≃fibre-is-contr {f = f} =
+  prop-ext
+    (is-equiv-is-prop f)
+    (λ f g i x → is-contr-is-prop (f x) (g x) i)
+    is-eqv
+    (λ fib-contr → record { is-eqv = fib-contr })
+
+-- This ideally would go in 1Lab.HLevel, but we don't have equivalences
+-- defined that early in the bootrapping process.
+is-prop→is-contr-iff-inhabited
+  : ∀ {ℓ} {A : Type ℓ}
+  → is-prop A
+  → is-contr A ≃ A
+is-prop→is-contr-iff-inhabited A-prop =
+  prop-ext is-contr-is-prop A-prop centre (is-prop∙→is-contr A-prop)
+
 lift-inj
   : ∀ {ℓ ℓ'} {A : Type ℓ} {a b : A}
   → lift {ℓ = ℓ'} a ≡ lift {ℓ = ℓ'} b → a ≡ b

--- a/src/1Lab/Equiv.lagda.md
+++ b/src/1Lab/Equiv.lagda.md
@@ -1101,7 +1101,9 @@ syntax ≃⟨⟩-syntax x q p = x ≃⟨ p ⟩ q
 ## Some useful equivalences
 
 We can extend `subst`{.Agda} to an equivalence between `Σ[ y ∈ A ] (y ≡ x × P y)`
-and `P x` for every `x : A` and `P : A → Type`.
+and `P x` for every `x : A` and `P : A → Type`. In informal mathematical practice,
+applying this equivalence is sometimes called "contracting $y$ away", alluding to
+the [[contractibility of singletons]].
 
 ```agda
 subst≃

--- a/src/1Lab/Function/Surjection.lagda.md
+++ b/src/1Lab/Function/Surjection.lagda.md
@@ -175,7 +175,7 @@ is equivalent to asking that the the type of mere fibres be [[contractible]],
 as the type of mere fibres is a [[proposition]]. Moreover, the type
 of mere fibres of $f$ is equivalent to the fibres of the inclusion of
 the image of $f$. This means that we have a choice of mere fibres
-of $f^{-1}(b)$ for every $b$ exactly when the fibres of the image inclusion
+of $f^*(b)$ for every $b$ exactly when the fibres of the image inclusion
 are contractible, i.e. the image inclusion is an equivalence.
 
 ```agda
@@ -211,7 +211,7 @@ cod-contr→surjective-splitting≃dom
 ```
 
 First, recall that functions out of contractible types are equivalences, so
-a choice of fibres $(b : B) \to f^{-1}(b)$ is equivalent to a single fibre
+a choice of fibres $(b : B) \to f^*(b)$ is equivalent to a single fibre
 at the centre of contraction of $B$. Moreover, the type of paths in $B$ is
 also contractible, so the type of fibres of $f : A \to B$ is equivalent to $A$.
 

--- a/src/1Lab/Function/Surjection.lagda.md
+++ b/src/1Lab/Function/Surjection.lagda.md
@@ -248,7 +248,6 @@ is-split-surjective→is-surjective f-split-surj b = do
 Note that we do not have a converse to this constructively: the statement that
 every surjective function between [[sets]] splits is [[equivalent to the axiom of choice|axiom-of-choice]]!
 
-
 ## Split surjective functions and sections
 
 The type of surjective splittings of a function $f : A \to B$ is equivalent
@@ -300,6 +299,7 @@ Like their non-split counterparts, split surjective functions are closed under c
 <details>
 <summary> The proof is essentially identical to the non-split case.
 </summary>
+
 ```agda
 ∘-surjective-splitting {f = f} f-split g-split c =
   let (f*c , p) = f-split c
@@ -350,6 +350,7 @@ is-split-surjective-cancelr
 <details>
 <summary>These proofs are also essentially identical to the non-split versions.
 </summary>
+
 ```agda
 surjective-splitting-cancelr {g = g} fg-split c =
   let (fg*c , p) = fg-split c

--- a/src/1Lab/Function/Surjection.lagda.md
+++ b/src/1Lab/Function/Surjection.lagda.md
@@ -253,9 +253,18 @@ is-split-surjective : (A → B) → Type _
 is-split-surjective f = ∥ surjective-splitting f ∥
 ```
 
-Split surjectivity is much a much stronger property than surjectivity in constructive
-settings: the statement that every surjective function splits is
-[[equivalent to the axiom of choice|axiom-of-choice]]!
+Every split surjective map is surjective.
+
+```agda
+is-split-surjective→is-surjective : is-split-surjective f → is-surjective f
+is-split-surjective→is-surjective f-split-surj b = do
+  f-splitting ← f-split-surj
+  pure (f-splitting b)
+```
+
+Note that we do not have a converse to this constructively: the statement that
+every surjective function between [[sets]] splits is [[equivalent to the axiom of choice|axiom-of-choice]]!
+
 
 ## Split surjective functions and sections
 
@@ -368,6 +377,22 @@ is-split-surjective-cancelr fg-split =
   map surjective-splitting-cancelr fg-split
 ```
 </details>
+
+A function is an equivalence if and only if it is a split-surjective
+[[embedding]].
+
+```agda
+embedding-split-surjective≃is-equiv
+  : {f : A → B}
+  → (is-embedding f × is-split-surjective f) ≃ is-equiv f
+embedding-split-surjective≃is-equiv {f = f} =
+  prop-ext!
+    (λ (f-emb , f-split-surj) →
+      embedding-surjective→is-equiv
+        f-emb
+        (is-split-surjective→is-surjective f-split-surj))
+    (λ f-equiv → is-equiv→is-embedding f-equiv , is-equiv→is-split-surjective f-equiv)
+```
 
 # Surjectivity and connectedness
 

--- a/src/1Lab/Function/Surjection.lagda.md
+++ b/src/1Lab/Function/Surjection.lagda.md
@@ -205,10 +205,11 @@ look at functions into [[contractible]] types: if $B$ is contractible,
 then the type of surjective splittings of a function $f : A \to B$ is equivalent to $A$.
 
 ```agda
-cod-contr→surjective-splitting≃dom
-  : (f : A → B)
-  → is-contr B
-  → surjective-splitting f ≃ A
+private
+  split-surjective-is-structure
+    : (f : A → B)
+    → is-contr B
+    → surjective-splitting f ≃ A
 ```
 
 First, recall that dependent functions $(a : A) \to B(a)$ out of a contractible type are
@@ -217,24 +218,10 @@ equivalent to an element of the fibre of $f$ at the centre of contraction of $B$
 the type of paths in $B$ is also contractible, so that fibre is equivalent to $A$.
 
 ```agda
-cod-contr→surjective-splitting≃dom {A = A} f B-contr =
-  (∀ b → fibre f b)         ≃⟨ Π-contr-eqv B-contr ⟩
-  fibre f (B-contr .centre) ≃⟨ Σ-contract (λ _ → Path-is-hlevel 0 B-contr) ⟩
-  A                         ≃∎
-```
-
-In contrast, if $B$ is contractible, then $f : A \to B$ is surjective if and only
-if $A$ is merely inhabited.
-
-```agda
-cod-contr→is-surjective-iff-dom-inhab
-  : (f : A → B)
-  → is-contr B
-  → is-surjective f ≃ ∥ A ∥
-cod-contr→is-surjective-iff-dom-inhab {A = A} f B-contr =
-  (∀ b → ∥ fibre f b ∥) ≃⟨ unique-choice B-contr ⟩
-  ∥ (∀ b → fibre f b) ∥ ≃⟨ ∥-∥-ap (cod-contr→surjective-splitting≃dom f B-contr) ⟩
-  ∥ A ∥                 ≃∎
+  split-surjective-is-structure {A = A} f B-contr =
+    (∀ b → fibre f b)         ≃⟨ Π-contr-eqv B-contr ⟩
+    fibre f (B-contr .centre) ≃⟨ Σ-contract (λ _ → Path-is-hlevel 0 B-contr) ⟩
+    A                         ≃∎
 ```
 
 In light of this, we provide the following definition.

--- a/src/1Lab/Function/Surjection.lagda.md
+++ b/src/1Lab/Function/Surjection.lagda.md
@@ -181,8 +181,8 @@ definition of $f$ being surjective.
 surjective-iff-image-equiv {A = A} {B = B} {f = f} =
   Equiv.inverse $
     is-equiv fst                            ≃⟨ is-equiv≃fibre-is-contr ⟩
-    (∀ b → is-contr (fibre fst b))          ≃⟨ Π-cod≃ (λ b → is-hlevel-ap 0 (Fibre-equiv _ _)) ⟩
-    (∀ b → is-contr (∃[ a ∈ A ] (f a ≡ b))) ≃⟨ Π-cod≃ (λ b → is-prop→is-contr-iff-inhabited (hlevel 1)) ⟩
+    (∀ b → is-contr (fibre fst b))          ≃⟨ Π-ap-cod (λ b → is-hlevel-ap 0 (Fibre-equiv _ _)) ⟩
+    (∀ b → is-contr (∃[ a ∈ A ] (f a ≡ b))) ≃⟨ Π-ap-cod (λ b → is-prop→is-contr-iff-inhabited (hlevel 1)) ⟩
     (∀ b → ∃[ a ∈ A ] (f a ≡ b))            ≃⟨⟩
     is-surjective f                         ≃∎
 ```
@@ -220,7 +220,7 @@ the type of paths in $B$ is also contractible, so that fibre is equivalent to $A
 ```agda
   split-surjective-is-structure {A = A} f B-contr =
     (∀ b → fibre f b)         ≃⟨ Π-contr-eqv B-contr ⟩
-    fibre f (B-contr .centre) ≃⟨ Σ-contract (λ _ → Path-is-hlevel 0 B-contr) ⟩
+    fibre f (B-contr .centre) ≃⟨ Σ-contr-snd (λ _ → Path-is-hlevel 0 B-contr) ⟩
     A                         ≃∎
 ```
 
@@ -396,7 +396,7 @@ of contraction of $A$.
 
 ```agda
 contr-dom-surjective-iff-connected-cod {A = A} {B = B} {f = f} A-contr =
-  Π-cod≃ (λ b → ∥-∥-ap (Σ-contr-eqv A-contr ∙e sym-equiv))
+  Π-ap-cod (λ b → ∥-∥-ap (Σ-contr-fst A-contr ∙e sym-equiv))
 ```
 
 This correspondence is not a coincidence: surjective maps fit into

--- a/src/1Lab/Function/Surjection.lagda.md
+++ b/src/1Lab/Function/Surjection.lagda.md
@@ -170,20 +170,21 @@ surjective-iff-image-equiv
   → is-surjective f ≃ is-equiv {A = image f} fst
 ```
 
-First, note that asking for the [[mere]] existence of a fibre of $f$
-is equivalent to asking that the the type of mere fibres be [[contractible]],
-as the type of mere fibres is a [[proposition]]. Moreover, the type
-of mere fibres of $f$ is equivalent to the fibres of the inclusion of
-the image of $f$. This means that we have a choice of mere fibres
-of $f^*(b)$ for every $b$ exactly when the fibres of the image inclusion
-are contractible, i.e. the image inclusion is an equivalence.
+First, note that the fibre of the inclusion of the image of $f$ at $b$
+is the [[propositional truncation]] of the fibre of $f$ at $b$, by
+construction. Asking for this inclusion to be an equivalence is the same as
+asking for those fibres to be [[contractible]], which thus amounts to
+asking for the fibres of $f$ to be [[merely]] inhabited, which is the
+definition of $f$ being surjective.
 
 ```agda
 surjective-iff-image-equiv {A = A} {B = B} {f = f} =
-  (∀ b → ∃[ a ∈ A ] (f a ≡ b))            ≃˘⟨ Π-cod≃ (λ b → is-prop→is-contr-iff-inhabited (hlevel 1)) ⟩
-  (∀ b → is-contr (∃[ a ∈ A ] (f a ≡ b))) ≃˘⟨ Π-cod≃ (λ b → is-hlevel-ap 0 (Fibre-equiv _ _)) ⟩
-  (∀ b → is-contr (fibre fst b))          ≃˘⟨ is-equiv≃fibre-is-contr ⟩
-  is-equiv fst                            ≃∎
+  begin-≃⁻¹
+    is-equiv fst                            ≃⟨ is-equiv≃fibre-is-contr ⟩
+    (∀ b → is-contr (fibre fst b))          ≃⟨ Π-cod≃ (λ b → is-hlevel-ap 0 (Fibre-equiv _ _)) ⟩
+    (∀ b → is-contr (∃[ a ∈ A ] (f a ≡ b))) ≃⟨ Π-cod≃ (λ b → is-prop→is-contr-iff-inhabited (hlevel 1)) ⟩
+    (∀ b → ∃[ a ∈ A ] (f a ≡ b))            ≃⟨⟩
+    is-surjective f                         ≃∎
 ```
 
 # Split surjective functions
@@ -210,10 +211,10 @@ cod-contr→surjective-splitting≃dom
   → surjective-splitting f ≃ A
 ```
 
-First, recall that functions out of contractible types are equivalences, so
-a choice of fibres $(b : B) \to f^*(b)$ is equivalent to a single fibre
-at the centre of contraction of $B$. Moreover, the type of paths in $B$ is
-also contractible, so the type of fibres of $f : A \to B$ is equivalent to $A$.
+First, recall that dependent functions $(a : A) \to B(a)$ out of a contractible type are
+equivalent to an element of $B$ at the centre of contraction, so $(b : B) \to f^*(b)$ is
+equivalent to an element of the fibre of $f$ at the centre of contraction of $B$. Moreover,
+the type of paths in $B$ is also contractible, so that fibre is equivalent to $A$.
 
 ```agda
 cod-contr→surjective-splitting≃dom {A = A} f B-contr =
@@ -336,7 +337,7 @@ is-equiv→is-split-surjective
 ```
 
 This follows immediately from the definition of equivalences: if the
-type of fibres is contractible, then we can pluck the fibre we need
+type of fibres is contractible, then we can pluck the element we need
 out of the centre of contraction!
 
 ```agda
@@ -401,7 +402,7 @@ contr-dom-surjective-iff-connected-cod
   → is-surjective f ≃ ((x : B) → ∥ x ≡ f (A-contr .centre) ∥)
 ```
 
-To see this, note that the type of fibres of $f$ over $x$ is equivalent
+To see this, note that the fibre of $f$ over $x$ is equivalent
 to the type of paths $x = f(a_{\bullet})$, where $a_{\bullet}$ is the centre
 of contraction of $A$.
 

--- a/src/1Lab/Function/Surjection.lagda.md
+++ b/src/1Lab/Function/Surjection.lagda.md
@@ -285,15 +285,8 @@ exists-section-iff-split-surjective f =
 Like their non-split counterparts, split surjective functions are closed under composition.
 
 ```agda
-∘-surjective-splitting
-  : surjective-splitting f
-  → surjective-splitting g
-  → surjective-splitting (f ∘ g)
-
-∘-is-split-surjective
-  : is-split-surjective f
-  → is-split-surjective g
-  → is-split-surjective (f ∘ g)
+∘-surjective-splitting : ∘-closed surjective-splitting
+∘-is-split-surjective : ∘-closed is-split-surjective
 ```
 
 <details>

--- a/src/1Lab/Function/Surjection.lagda.md
+++ b/src/1Lab/Function/Surjection.lagda.md
@@ -4,7 +4,6 @@ open import 1Lab.Function.Embedding
 open import 1Lab.Reflection.HLevel
 open import 1Lab.HLevel.Closure
 open import 1Lab.Truncation
-open import 1Lab.HLevel.Closure
 open import 1Lab.Type.Sigma
 open import 1Lab.Inductive
 open import 1Lab.Type.Pi

--- a/src/1Lab/Function/Surjection.lagda.md
+++ b/src/1Lab/Function/Surjection.lagda.md
@@ -100,6 +100,19 @@ is-equiv→is-surjective : {f : A → B} → is-equiv f → is-surjective f
 is-equiv→is-surjective eqv x = inc (eqv .is-eqv x .centre)
 ```
 
+Surjections also are closed under a weaker form of [[two-out-of-three]]:
+if $f circ g$ is surjective, then $f$ must also be surjective.
+
+```agda
+is-surjective-cancelr
+  : {f : B → C} {g : A → B}
+  → is-surjective (f ∘ g)
+  → is-surjective f
+is-surjective-cancelr {g = g} fgs c = do
+  (fg*x , p) ← fgs c
+  pure (g fg*x , p)
+```
+
 <!--
 ```agda
 Equiv→Cover : A ≃ B → A ↠ B
@@ -145,6 +158,39 @@ injective-surjective→is-equiv! =
   injective-surjective→is-equiv (hlevel 2)
 ```
 -->
+
+## Surjectivity and images
+
+A map $f : A \to B$ if and only if the inclusion of the image of $f$ into $B$
+is an [[equivalence]].
+
+```agda
+surjective-iff-image-equiv
+  : ∀ {f : A → B}
+  → is-surjective f ≃ is-equiv {A = image f} fst
+```
+
+The forward direction is almost immediate: surjectivity of $f$ means
+that $B$ includes into its image, so it must be an equivalence. For the
+reverse direction, suppose that the inclusion of the image of $f$ is an
+equivalence. This lets us find some point in the image of $f$ for every $b : B$.
+Moreover, this point in the image must lie in a fibre of $b$, as the inclusion is
+an equivalence.
+
+```agda
+surjective-iff-image-equiv {f = f} = prop-ext! to from where
+
+  to : is-surjective f → is-equiv fst
+  to f-surj =
+    is-iso→is-equiv $
+      iso (λ b → b , f-surj b)
+        (λ _ → refl)
+        (λ _ → Σ-prop-path! refl)
+
+  from : is-equiv fst → is-surjective f
+  from im-eqv b = subst (λ b → ∥ fibre f b ∥) (equiv→counit im-eqv b) (snd (equiv→inverse im-eqv b))
+```
+
 # Split surjective functions
 
 :::{.definition #surjective-splitting}
@@ -322,3 +368,28 @@ is-split-surjective-cancelr fg-split =
   map surjective-splitting-cancelr fg-split
 ```
 </details>
+
+# Surjectivity and connectedness
+
+If $f : A \to B$ is a function out of a [[contractible]] type $A$,
+then $f$ is surjective if and only if $B$ is a [[pointed connected type]], where
+the basepoint of $B$ is given by $f$ applied to the centre of contraction of $A$.
+
+```agda
+contr-dom-surjective-iff-connected-cod
+  : ∀ {f : A → B}
+  → (A-contr : is-contr A)
+  → is-surjective f ≃ ((x : B) → ∥ x ≡ f (A-contr .centre) ∥)
+```
+
+To see this, note that the type of fibres of $f$ over $x$ is equivalent
+to the type of paths $x = f(a_{bullet})$, where $a_{\bullet}$ is the centre
+of contraction of $A$.
+
+```agda
+contr-dom-surjective-iff-connected-cod {A = A} {B = B} {f = f} A-contr =
+  Π-cod≃ (λ b → ∥-∥-ap (Σ-contr-eqv A-contr ∙e sym-equiv))
+```
+
+This correspondence is not a coincidence: surjective maps are a special case
+of a more general family of maps called [[connected maps]].

--- a/src/1Lab/Function/Surjection.lagda.md
+++ b/src/1Lab/Function/Surjection.lagda.md
@@ -101,7 +101,7 @@ is-equiv→is-surjective eqv x = inc (eqv .is-eqv x .centre)
 ```
 
 Surjections also are closed under a weaker form of [[two-out-of-three]]:
-if $f circ g$ is surjective, then $f$ must also be surjective.
+if $f \circ g$ is surjective, then $f$ must also be surjective.
 
 ```agda
 is-surjective-cancelr
@@ -161,8 +161,8 @@ injective-surjective→is-equiv! =
 
 ## Surjectivity and images
 
-A map $f : A \to B$ if and only if the inclusion of the image of $f$ into $B$
-is an [[equivalence]].
+A map $f : A \to B$ is surjective if and only if the inclusion of the
+image of $f$ into $B$ is an [[equivalence]].
 
 ```agda
 surjective-iff-image-equiv
@@ -176,7 +176,7 @@ as the type of mere fibres is a [[proposition]]. Moreover, the type
 of mere fibres of $f$ is equivalent to the fibres of the inclusion of
 the image of $f$. This means that we have a choice of mere fibres
 of $f^{-1}(b)$ for every $b$ exactly when the fibres of the image inclusion
-are contractible, EG: the image inclusion is an equivalence.
+are contractible, i.e. the image inclusion is an equivalence.
 
 ```agda
 surjective-iff-image-equiv {A = A} {B = B} {f = f} =
@@ -264,7 +264,7 @@ every surjective function between [[sets]] splits is [[equivalent to the axiom o
 ## Split surjective functions and sections
 
 The type of surjective splittings of a function $f : A \to B$ is equivalent
-to the type of sections of $f$, EG: functions $s : B \to A$ with $f \circ s = \id$.
+to the type of sections of $f$, i.e. functions $s : B \to A$ with $f \circ s = \id$.
 
 ```agda
 section≃surjective-splitting
@@ -319,7 +319,6 @@ Like their non-split counterparts, split surjective functions are closed under c
   in g*f*c , ap f q ∙ p
 
 ∘-is-split-surjective fs gs = ⦇ ∘-surjective-splitting fs gs ⦈
-
 ```
 </details>
 
@@ -403,7 +402,7 @@ contr-dom-surjective-iff-connected-cod
 ```
 
 To see this, note that the type of fibres of $f$ over $x$ is equivalent
-to the type of paths $x = f(a_{bullet})$, where $a_{\bullet}$ is the centre
+to the type of paths $x = f(a_{\bullet})$, where $a_{\bullet}$ is the centre
 of contraction of $A$.
 
 ```agda
@@ -411,5 +410,7 @@ contr-dom-surjective-iff-connected-cod {A = A} {B = B} {f = f} A-contr =
   Π-cod≃ (λ b → ∥-∥-ap (Σ-contr-eqv A-contr ∙e sym-equiv))
 ```
 
-This correspondence is not a coincidence: surjective maps are a special case
-of a more general family of maps called [[connected maps]].
+This correspondence is not a coincidence: surjective maps fit into
+a larger family of maps known as [[connected maps]]. In particular,
+a map is surjective exactly when it is (-1)-connected, and this lemma is
+a special case of `is-n-connected-point`{.Agda}.

--- a/src/1Lab/Function/Surjection.lagda.md
+++ b/src/1Lab/Function/Surjection.lagda.md
@@ -180,14 +180,16 @@ an equivalence.
 surjective-iff-image-equiv {f = f} = prop-ext! to from where
 
   to : is-surjective f → is-equiv fst
-  to f-surj =
-    is-iso→is-equiv $
-      iso (λ b → b , f-surj b)
-        (λ _ → refl)
-        (λ _ → Σ-prop-path! refl)
+  to f-surj = is-iso→is-equiv $ iso
+     (λ b → b , f-surj b)
+     (λ _ → refl)
+     (λ _ → Σ-prop-path! refl)
 
   from : is-equiv fst → is-surjective f
-  from im-eqv b = subst (λ b → ∥ fibre f b ∥) (equiv→counit im-eqv b) (snd (equiv→inverse im-eqv b))
+  from im-eqv b =
+    subst (λ b → ∥ fibre f b ∥)
+      (equiv→counit im-eqv b)
+      (equiv→inverse im-eqv b .snd)
 ```
 
 # Split surjective functions
@@ -235,7 +237,7 @@ cod-contr→is-surjective-iff-dom-inhab
   → is-contr B
   → is-surjective f ≃ ∥ A ∥
 cod-contr→is-surjective-iff-dom-inhab {A = A} f B-contr =
-  (∀ b → ∥ fibre f b ∥) ≃⟨ unique-choice≃ B-contr ⟩
+  (∀ b → ∥ fibre f b ∥) ≃⟨ unique-choice B-contr ⟩
   ∥ (∀ b → fibre f b) ∥ ≃⟨ ∥-∥-ap (cod-contr→surjective-splitting≃dom f B-contr) ⟩
   ∥ A ∥                 ≃∎
 ```

--- a/src/1Lab/Function/Surjection.lagda.md
+++ b/src/1Lab/Function/Surjection.lagda.md
@@ -5,6 +5,7 @@ open import 1Lab.Reflection.HLevel
 open import 1Lab.HLevel.Closure
 open import 1Lab.Truncation
 open import 1Lab.Type.Sigma
+open import 1Lab.Univalence
 open import 1Lab.Inductive
 open import 1Lab.Type.Pi
 open import 1Lab.HLevel
@@ -169,27 +170,20 @@ surjective-iff-image-equiv
   → is-surjective f ≃ is-equiv {A = image f} fst
 ```
 
-The forward direction is almost immediate: surjectivity of $f$ means
-that $B$ includes into its image, so it must be an equivalence. For the
-reverse direction, suppose that the inclusion of the image of $f$ is an
-equivalence. This lets us find some point in the image of $f$ for every $b : B$.
-Moreover, this point in the image must lie in a fibre of $b$, as the inclusion is
-an equivalence.
+First, note that asking for the [[mere]] existence of a fibre of $f$
+is equivalent to asking that the the type of mere fibres be [[contractible]],
+as the type of mere fibres is a [[proposition]]. Moreover, the type
+of mere fibres of $f$ is equivalent to the fibres of the inclusion of
+the image of $f$. This means that we have a choice of mere fibres
+of $f^{-1}(b)$ for every $b$ exactly when the fibres of the image inclusion
+are contractible, EG: the image inclusion is an equivalence.
 
 ```agda
-surjective-iff-image-equiv {f = f} = prop-ext! to from where
-
-  to : is-surjective f → is-equiv fst
-  to f-surj = is-iso→is-equiv $ iso
-     (λ b → b , f-surj b)
-     (λ _ → refl)
-     (λ _ → Σ-prop-path! refl)
-
-  from : is-equiv fst → is-surjective f
-  from im-eqv b =
-    subst (λ b → ∥ fibre f b ∥)
-      (equiv→counit im-eqv b)
-      (equiv→inverse im-eqv b .snd)
+surjective-iff-image-equiv {A = A} {B = B} {f = f} =
+  (∀ b → ∃[ a ∈ A ] (f a ≡ b))            ≃˘⟨ Π-cod≃ (λ b → is-prop→is-contr-iff-inhabited (hlevel 1)) ⟩
+  (∀ b → is-contr (∃[ a ∈ A ] (f a ≡ b))) ≃˘⟨ Π-cod≃ (λ b → is-hlevel-ap 0 (Fibre-equiv _ _)) ⟩
+  (∀ b → is-contr (fibre fst b))          ≃˘⟨ is-equiv≃fibre-is-contr ⟩
+  is-equiv fst                            ≃∎
 ```
 
 # Split surjective functions

--- a/src/1Lab/Function/Surjection.lagda.md
+++ b/src/1Lab/Function/Surjection.lagda.md
@@ -179,7 +179,7 @@ definition of $f$ being surjective.
 
 ```agda
 surjective-iff-image-equiv {A = A} {B = B} {f = f} =
-  begin-≃⁻¹
+  Equiv.inverse $
     is-equiv fst                            ≃⟨ is-equiv≃fibre-is-contr ⟩
     (∀ b → is-contr (fibre fst b))          ≃⟨ Π-cod≃ (λ b → is-hlevel-ap 0 (Fibre-equiv _ _)) ⟩
     (∀ b → is-contr (∃[ a ∈ A ] (f a ≡ b))) ≃⟨ Π-cod≃ (λ b → is-prop→is-contr-iff-inhabited (hlevel 1)) ⟩

--- a/src/1Lab/Function/Surjection.lagda.md
+++ b/src/1Lab/Function/Surjection.lagda.md
@@ -4,7 +4,10 @@ open import 1Lab.Function.Embedding
 open import 1Lab.Reflection.HLevel
 open import 1Lab.HLevel.Closure
 open import 1Lab.Truncation
+open import 1Lab.HLevel.Closure
+open import 1Lab.Type.Sigma
 open import 1Lab.Inductive
+open import 1Lab.Type.Pi
 open import 1Lab.HLevel
 open import 1Lab.Equiv
 open import 1Lab.Path
@@ -22,8 +25,10 @@ module 1Lab.Function.Surjection where
 <!--
 ```agda
 private variable
-  ℓ ℓ' : Level
+  ℓ ℓ' ℓ'' : Level
   A B C : Type ℓ
+  P Q : A → Type ℓ'
+  f g : A → B
 ```
 -->
 
@@ -140,3 +145,180 @@ injective-surjective→is-equiv! =
   injective-surjective→is-equiv (hlevel 2)
 ```
 -->
+# Split surjective functions
+
+:::{.definition #surjective-splitting}
+A **surjective splitting** of a function $f : A \to B$ consists of a designated
+element of the fibre $f^*b$ for each $b : B$.
+:::
+
+```agda
+surjective-splitting : (A → B) → Type _
+surjective-splitting f = ∀ b → fibre f b
+```
+
+Note that unlike "being surjective", a surjective splitting of $f$ is a *structure*
+on $f$, not a property. This difference becomes particularly striking when we
+look at functions into [[contractible]] types: if $B$ is contractible,
+then the type of surjective splittings of a function $f : A \to B$ is equivalent to $A$.
+
+```agda
+cod-contr→surjective-splitting≃dom
+  : (f : A → B)
+  → is-contr B
+  → surjective-splitting f ≃ A
+```
+
+First, recall that functions out of contractible types are equivalences, so
+a choice of fibres $(b : B) \to f^{-1}(b)$ is equivalent to a single fibre
+at the centre of contraction of $B$. Moreover, the type of paths in $B$ is
+also contractible, so the type of fibres of $f : A \to B$ is equivalent to $A$.
+
+```agda
+cod-contr→surjective-splitting≃dom {A = A} f B-contr =
+  (∀ b → fibre f b)         ≃⟨ Π-contr-eqv B-contr ⟩
+  fibre f (B-contr .centre) ≃⟨ Σ-contract (λ _ → Path-is-hlevel 0 B-contr) ⟩
+  A                         ≃∎
+```
+
+In contrast, if $B$ is contractible, then $f : A \to B$ is surjective if and only
+if $A$ is merely inhabited.
+
+```agda
+cod-contr→is-surjective-iff-dom-inhab
+  : (f : A → B)
+  → is-contr B
+  → is-surjective f ≃ ∥ A ∥
+cod-contr→is-surjective-iff-dom-inhab {A = A} f B-contr =
+  (∀ b → ∥ fibre f b ∥) ≃⟨ unique-choice≃ B-contr ⟩
+  ∥ (∀ b → fibre f b) ∥ ≃⟨ ∥-∥-ap (cod-contr→surjective-splitting≃dom f B-contr) ⟩
+  ∥ A ∥                 ≃∎
+```
+
+In light of this, we provide the following definition.
+
+:::{.definition #split-surjective}
+A function $f : A \to B$ is **split surjective** if there merely exists a
+surjective splitting of $f$.
+:::
+
+```agda
+is-split-surjective : (A → B) → Type _
+is-split-surjective f = ∥ surjective-splitting f ∥
+```
+
+Split surjectivity is much a much stronger property than surjectivity in constructive
+settings: the statement that every surjective function splits is
+[[equivalent to the axiom of choice|axiom-of-choice]]!
+
+## Split surjective functions and sections
+
+The type of surjective splittings of a function $f : A \to B$ is equivalent
+to the type of sections of $f$, EG: functions $s : B \to A$ with $f \circ s = \id$.
+
+```agda
+section≃surjective-splitting
+  : (f : A → B)
+  → (Σ[ s ∈ (B → A) ] is-right-inverse s f) ≃ surjective-splitting f
+```
+
+Somewhat surprisingly, this is an immediate consequence of the fact that
+sigma types distribute over pi types!
+
+```agda
+section≃surjective-splitting {A = A} {B = B} f =
+  (Σ[ s ∈ (B → A) ] ((x : B) → f (s x) ≡ x)) ≃˘⟨ Σ-Π-distrib ⟩
+  ((b : B) → Σ[ a ∈ A ] f a ≡ b)             ≃⟨⟩
+  surjective-splitting f                     ≃∎
+```
+
+This means that a function $f$ is split surjective if and only if there
+[[merely]] exists some section of $f$.
+
+```agda
+exists-section-iff-split-surjective
+  : (f : A → B)
+  → (∃[ s ∈ (B → A) ] is-right-inverse s f) ≃ is-split-surjective f
+exists-section-iff-split-surjective f =
+  ∥-∥-ap (section≃surjective-splitting f)
+```
+
+## Closure properties of split surjective functions
+
+Like their non-split counterparts, split surjective functions are closed under composition.
+
+```agda
+∘-surjective-splitting
+  : surjective-splitting f
+  → surjective-splitting g
+  → surjective-splitting (f ∘ g)
+
+∘-is-split-surjective
+  : is-split-surjective f
+  → is-split-surjective g
+  → is-split-surjective (f ∘ g)
+```
+
+<details>
+<summary> The proof is essentially identical to the non-split case.
+</summary>
+```agda
+∘-surjective-splitting {f = f} f-split g-split c =
+  let (f*c , p) = f-split c
+      (g*f*c , q) = g-split f*c
+  in g*f*c , ap f q ∙ p
+
+∘-is-split-surjective fs gs = ⦇ ∘-surjective-splitting fs gs ⦈
+
+```
+</details>
+
+Every equivalence can be equipped with a surjective splitting, and
+is thus split surjective.
+
+```agda
+is-equiv→surjective-splitting
+  : is-equiv f
+  → surjective-splitting f
+
+is-equiv→is-split-surjective
+  : is-equiv f
+  → is-split-surjective f
+```
+
+This follows immediately from the definition of equivalences: if the
+type of fibres is contractible, then we can pluck the fibre we need
+out of the centre of contraction!
+
+```agda
+is-equiv→surjective-splitting f-equiv b =
+  f-equiv .is-eqv b .centre
+
+is-equiv→is-split-surjective f-equiv =
+  pure (is-equiv→surjective-splitting f-equiv)
+```
+
+Split surjective functions also satisfy left two-out-of-three.
+
+```agda
+surjective-splitting-cancelr
+  : surjective-splitting (f ∘ g)
+  → surjective-splitting f
+
+is-split-surjective-cancelr
+  : is-split-surjective (f ∘ g)
+  → is-split-surjective f
+```
+
+<details>
+<summary>These proofs are also essentially identical to the non-split versions.
+</summary>
+```agda
+surjective-splitting-cancelr {g = g} fg-split c =
+  let (fg*c , p) = fg-split c
+  in g fg*c , p
+
+is-split-surjective-cancelr fg-split =
+  map surjective-splitting-cancelr fg-split
+```
+</details>

--- a/src/1Lab/HLevel.lagda.md
+++ b/src/1Lab/HLevel.lagda.md
@@ -730,6 +730,13 @@ SinglP-is-contr A a .paths (x , p) i = _ , λ j → fill A (∂ i) j λ where
 SinglP-is-prop : ∀ {ℓ} {A : I → Type ℓ} {a : A i0} → is-prop (SingletonP A a)
 SinglP-is-prop = is-contr→is-prop (SinglP-is-contr _ _)
 
+Single-is-contr : ∀ {x : A} → is-contr (Singleton x)
+Single-is-contr {x = x} .centre = x , refl
+Single-is-contr {x = x} .paths (y , p) i = p i , λ j → p (i ∧ j)
+
+Single-is-contr' : ∀ {x : A} → is-contr (Σ[ y ∈ A ] y ≡ x)
+Single-is-contr' {x = x} .centre = x , refl
+Single-is-contr' {x = x} .paths (y , p) i = p (~ i) , λ j → p (~ i ∨ j)
 
 is-prop→squarep
   : ∀ {B : I → I → Type ℓ} → ((i j : I) → is-prop (B i j))

--- a/src/1Lab/Truncation.lagda.md
+++ b/src/1Lab/Truncation.lagda.md
@@ -223,15 +223,22 @@ states that if $A$ is [[contractible]], then the type of functions
 [^1]: In other words, unique choice states that contractible types are [[projective|set-projective]].
 
 ```agda
-unique-choice≃
+unique-choice
   : ∀ {ℓ ℓ'} {A : Type ℓ} {B : A → Type ℓ'}
   → is-contr A
   → (∀ (x : A) → ∥ B x ∥) ≃ ∥ (∀ (x : A) → B x) ∥
-unique-choice≃ {A = A} {B = B} A-contr =
+unique-choice {A = A} {B = B} A-contr =
   ((x : A) → ∥ B x ∥)     ≃⟨ Π-contr-eqv A-contr ⟩
   ∥ B (A-contr .centre) ∥ ≃˘⟨ ∥-∥-ap (Π-contr-eqv A-contr) ⟩
   ∥ ((x : A) → B x) ∥     ≃∎
 ```
+
+<!--
+```agda
+module unique-choice {ℓ ℓ'} {A : Type ℓ} {B : A → Type ℓ'} (A-contr : is-contr A) =
+  Equiv (unique-choice {B = B} A-contr)
+```
+-->
 
 
 :::{.definition #merely alias="mere"}

--- a/src/1Lab/Truncation.lagda.md
+++ b/src/1Lab/Truncation.lagda.md
@@ -169,7 +169,6 @@ This means that propositional truncation preserves equivalences.
 ∥-∥-map₂ f (inc x) (inc y)  = inc (f x y)
 ∥-∥-map₂ f (squash x y i) z = squash (∥-∥-map₂ f x z) (∥-∥-map₂ f y z) i
 ∥-∥-map₂ f x (squash y z i) = squash (∥-∥-map₂ f x y) (∥-∥-map₂ f x z) i
-
 ```
 -->
 
@@ -218,7 +217,7 @@ is-prop≃equiv∥-∥ {P = P} =
 
 This is closely related to the principle of **unique choice**, which
 states that if $A$ is [[contractible]], then the type of functions
-`A → ∥ B x ∥` is equivalent to `∥ A → B x ∥`[^1].
+`(x : A) → ∥ B x ∥` is equivalent to `∥ (x : A) → B x ∥`[^1].
 
 [^1]: In other words, unique choice states that contractible types are [[projective|set-projective]].
 
@@ -226,7 +225,7 @@ states that if $A$ is [[contractible]], then the type of functions
 unique-choice
   : ∀ {ℓ ℓ'} {A : Type ℓ} {B : A → Type ℓ'}
   → is-contr A
-  → (∀ (x : A) → ∥ B x ∥) ≃ ∥ (∀ (x : A) → B x) ∥
+  → ((x : A) → ∥ B x ∥) ≃ ∥ ((x : A) → B x) ∥
 unique-choice {A = A} {B = B} A-contr =
   ((x : A) → ∥ B x ∥)     ≃⟨ Π-contr-eqv A-contr ⟩
   ∥ B (A-contr .centre) ∥ ≃˘⟨ ∥-∥-ap (Π-contr-eqv A-contr) ⟩

--- a/src/1Lab/Truncation.lagda.md
+++ b/src/1Lab/Truncation.lagda.md
@@ -215,31 +215,6 @@ is-prop≃equiv∥-∥ {P = P} =
                           (is-equiv-is-prop _ _ _)
 ```
 
-This is closely related to the principle of **unique choice**, which
-states that if $A$ is [[contractible]], then the type of functions
-`(x : A) → ∥ B x ∥` is equivalent to `∥ (x : A) → B x ∥`[^1].
-
-[^1]: In other words, unique choice states that contractible types are [[projective|set-projective]].
-
-```agda
-unique-choice
-  : ∀ {ℓ ℓ'} {A : Type ℓ} {B : A → Type ℓ'}
-  → is-contr A
-  → ((x : A) → ∥ B x ∥) ≃ ∥ ((x : A) → B x) ∥
-unique-choice {A = A} {B = B} A-contr =
-  ((x : A) → ∥ B x ∥)     ≃⟨ Π-contr-eqv A-contr ⟩
-  ∥ B (A-contr .centre) ∥ ≃˘⟨ ∥-∥-ap (Π-contr-eqv A-contr) ⟩
-  ∥ ((x : A) → B x) ∥     ≃∎
-```
-
-<!--
-```agda
-module unique-choice {ℓ ℓ'} {A : Type ℓ} {B : A → Type ℓ'} (A-contr : is-contr A) =
-  Equiv (unique-choice {B = B} A-contr)
-```
--->
-
-
 :::{.definition #merely alias="mere"}
 Throughout the 1Lab, we use the words "mere" and "merely" to modify a
 type to mean its propositional truncation. This terminology is adopted

--- a/src/1Lab/Truncation.lagda.md
+++ b/src/1Lab/Truncation.lagda.md
@@ -220,7 +220,7 @@ This is closely related to the principle of **unique choice**, which
 states that if $A$ is [[contractible]], then the type of functions
 `A → ∥ B x ∥` is equivalent to `∥ A → B x ∥`[^1].
 
-[^1] In other words, unique choice states that contractible types are [[projective|set-projective]].
+[^1]: In other words, unique choice states that contractible types are [[projective|set-projective]].
 
 ```agda
 unique-choice≃

--- a/src/1Lab/Truncation.lagda.md
+++ b/src/1Lab/Truncation.lagda.md
@@ -12,6 +12,7 @@ open import 1Lab.HLevel.Closure
 open import 1Lab.Path.Reasoning
 open import 1Lab.Type.Sigma
 open import 1Lab.Inductive
+open import 1Lab.Type.Pi
 open import 1Lab.HLevel
 open import 1Lab.Equiv
 open import 1Lab.Path
@@ -168,6 +169,7 @@ This means that propositional truncation preserves equivalences.
 ∥-∥-map₂ f (inc x) (inc y)  = inc (f x y)
 ∥-∥-map₂ f (squash x y i) z = squash (∥-∥-map₂ f x z) (∥-∥-map₂ f y z) i
 ∥-∥-map₂ f x (squash y z i) = squash (∥-∥-map₂ f x y) (∥-∥-map₂ f x z) i
+
 ```
 -->
 
@@ -213,6 +215,24 @@ is-prop≃equiv∥-∥ {P = P} =
     eqv-prop x y = Σ-path (λ i p → squash (x .fst p) (y .fst p) i)
                           (is-equiv-is-prop _ _ _)
 ```
+
+This is closely related to the principle of **unique choice**, which
+states that if $A$ is [[contractible]], then the type of functions
+`A → ∥ B x ∥` is equivalent to `∥ A → B x ∥`[^1].
+
+[^1] In other words, unique choice states that contractible types are [[projective|set-projective]].
+
+```agda
+unique-choice≃
+  : ∀ {ℓ ℓ'} {A : Type ℓ} {B : A → Type ℓ'}
+  → is-contr A
+  → (∀ (x : A) → ∥ B x ∥) ≃ ∥ (∀ (x : A) → B x) ∥
+unique-choice≃ {A = A} {B = B} A-contr =
+  ((x : A) → ∥ B x ∥)     ≃⟨ Π-contr-eqv A-contr ⟩
+  ∥ B (A-contr .centre) ∥ ≃˘⟨ ∥-∥-ap (Π-contr-eqv A-contr) ⟩
+  ∥ ((x : A) → B x) ∥     ≃∎
+```
+
 
 :::{.definition #merely alias="mere"}
 Throughout the 1Lab, we use the words "mere" and "merely" to modify a

--- a/src/Cat/Prelude.agda
+++ b/src/Cat/Prelude.agda
@@ -12,7 +12,7 @@ open import 1Lab.Prelude
            ; _∘⟨_ to _⊙⟨_
            ; _⟩∘_ to _⟩⊙_
            )
-  hiding (id ; map ; _↠_ ; ⟨_,_⟩)
+  hiding (id ; map ; _↠_ ; ⟨_,_⟩; ⟨⟩-unique)
   public
 
 open import Data.Set.Truncation public

--- a/src/Data/Fin/Properties.lagda.md
+++ b/src/Data/Fin/Properties.lagda.md
@@ -262,8 +262,9 @@ _between_ finite sets) [[merely]] split:
 ```agda
 finite-surjection-split
   : ∀ {ℓ} {n} {B : Type ℓ}
-  → (f : B → Fin n) → is-surjective f
-  → ∥ (∀ x → fibre f x) ∥
+  → (f : B → Fin n) 
+  → is-surjective f
+  → is-split-surjective f
 finite-surjection-split f = finite-choice _
 ```
 

--- a/src/Data/Set/Projective.lagda.md
+++ b/src/Data/Set/Projective.lagda.md
@@ -4,7 +4,6 @@ description: |
 ---
 <!--
 ```agda
-open import 1Lab.Classical
 open import 1Lab.Prelude
 
 open import Data.Dec
@@ -28,7 +27,7 @@ private variable
 
 :::{.definition #set-projective}
 A type $A$ is **set-projective** if we can commute [[propositional truncation]]
-past $A$-indexed families.
+past $A$-indexed families of [[sets]].
 :::
 
 ```agda
@@ -46,22 +45,31 @@ $A$-indexed version of the [[axiom of choice]].
 If $A$ is a set, then $A$ is set-projective if and only if every
 surjection $E \to A$ from a set $E$ splits.
 
+<!-- [TODO: Reed M, 19/05/2025]
+  This could be made into a more elegant argument via a chain of equivalences:
+  The crux is really that Fibre-equiv step!
+-->
+
 ```agda
+set-surjections-split : (A : Type ℓ) → (κ : Level) → Type _
+set-surjections-split {ℓ = ℓ} A κ =
+  ∀ (E : Type κ)
+  → is-set E
+  → (f : E → A)
+  → is-surjective f
+  → is-split-surjective f
+
 surjections-split→set-projective
-  : ∀ {ℓ ℓ'} {A : Type ℓ}
+  : ∀ {ℓ κ} {A : Type ℓ}
   → is-set A
-  → (∀ (E : Type (ℓ ⊔ ℓ')) → is-set E
-     → (f : E → A) → is-surjective f
-     → ∥ (∀ a → fibre f a) ∥)
-  → is-set-projective A (ℓ ⊔ ℓ')
+  → set-surjections-split A (ℓ ⊔ κ)
+  → is-set-projective A (ℓ ⊔ κ)
 
 sets-projective→surjections-split
-  : ∀ {ℓ ℓ'} {A : Type ℓ}
+  : ∀ {ℓ κ} {A : Type ℓ}
   → is-set A
-  → is-set-projective A (ℓ ⊔ ℓ')
-  → ∀ {E : Type ℓ'} → is-set E
-  → (f : E → A) → is-surjective f
-  → ∥ (∀ a → fibre f a) ∥
+  → is-set-projective A (ℓ ⊔ κ)
+  → set-surjections-split A (ℓ ⊔ κ)
 ```
 
 <details>
@@ -76,7 +84,7 @@ surjections-split→set-projective {A = A} A-set surj-split P P-set ∥P∥ =
     (surj-split (Σ[ x ∈ A ] (P x)) (Σ-is-hlevel 2 A-set P-set) fst λ x →
       ∥-∥-map (Equiv.from (Fibre-equiv P x)) (∥P∥ x))
 
-sets-projective→surjections-split A-set A-pro E-set f =
+sets-projective→surjections-split A-set A-pro E E-set f =
   A-pro (fibre f) (λ x → fibre-is-hlevel 2 E-set A-set f x)
 ```
 </details>

--- a/src/Homotopy/Connectedness.lagda.md
+++ b/src/Homotopy/Connectedness.lagda.md
@@ -77,7 +77,7 @@ is-n-connected-map f n = ∀ x → is-n-connected (fibre f x) n
 ```
 :::
 
-## Pointed connected types {defined="pointed-connected-type"}
+## Pointed connected types {defines="pointed-connected-type"}
 
 In the case of [[pointed types]], there is an equivalent definition of
 being connected that is sometimes easier to work with: a pointed type is

--- a/src/Homotopy/Connectedness.lagda.md
+++ b/src/Homotopy/Connectedness.lagda.md
@@ -77,7 +77,7 @@ is-n-connected-map f n = ∀ x → is-n-connected (fibre f x) n
 ```
 :::
 
-## Pointed connected types
+## Pointed connected types {defined="pointed-connected-type"}
 
 In the case of [[pointed types]], there is an equivalent definition of
 being connected that is sometimes easier to work with: a pointed type is


### PR DESCRIPTION
# Description

Pulling some of my changes out of #375 in hopes of getting back to it at some point. This PR defines split surjectivity, and also proves some misc. lemmas about surjective maps. I've done some minor cleanup in some of the base modules, and added some (hopefully useful!) equivalences.

## Checklist

Before submitting a merge request, please check the items below:

- [x] I've read [the contributing guidelines](https://github.com/plt-amy/1lab/blob/main/CONTRIBUTING.md).
- [x] The imports of new modules have been sorted with `support/sort-imports.hs` (or `nix run --experimental-features nix-command -f . sort-imports`).
- [x] All new code blocks have "agda" as their language.

If your change affects many files without adding substantial content, and
you don't want your name to appear on those pages (for example, treewide
refactorings or reformattings), start the commit message and PR title with `chore:`.
