### PR TITLE
prose: fix family type in the dependent sum section

### DIFF
--- a/src/1Lab/intro.lagda.md
+++ b/src/1Lab/intro.lagda.md
@@ -1084,7 +1084,7 @@ former, $\sum$! Indeed, the short discussion there also made some
 mention of the introduction rule, but let's reiterate with more clarity
 here.
 
-If we have some index type $A : \ty_\ell$, and a family of types $B \to
+If we have some index type $A : \ty_\ell$, and a family of types $B : A \to
 \ty_{\ell'}$, then we can form the **dependent sum type** $\sum_{(x
 : A)} B$. When the index is clear from context, we let ourselves omit
 the variable, and write $\sum B$. Since $\sum B$ is a type, it lives in


### PR DESCRIPTION
# Description

The family should have the type `A -> Type_l'`, while its *name* is `B`.

## Checklist

Before submitting a merge request, please check the items below:

- [x] I've read [the contributing guidelines](https://github.com/plt-amy/1lab/blob/main/CONTRIBUTING.md).
- [x] The imports of new modules have been sorted with `support/sort-imports.hs` (or `nix run --experimental-features nix-command -f . sort-imports`).
- [x] All new code blocks have "agda" as their language.

If your change affects many files without adding substantial content, and
you don't want your name to appear on those pages (for example, treewide
refactorings or reformattings), start the commit message and PR title with `chore:`.
