### PR TITLE
Add KaTeX worker pool

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -76,7 +76,7 @@ in
 
     LANG = "C.UTF-8";
     buildPhase = ''
-      1lab-shake all -j
+      1lab-shake all -j --git-only
     '';
 
     installPhase = ''

--- a/default.nix
+++ b/default.nix
@@ -48,7 +48,7 @@ let
     shakefile our-ghc
 
     # For building the text and maths:
-    gitMinimal nodePackages.sass
+    gitMinimal nodePackages.sass nodejs
 
     # For building diagrams:
     poppler_utils our-texlive

--- a/support/katex/katex-worker.js
+++ b/support/katex/katex-worker.js
@@ -26,7 +26,7 @@ const katexHtml = new Transform({
 	    const nbytes = Buffer.byteLength(html);
 	    const output = Buffer.allocUnsafe(nbytes + 1);
 	    output.write(html);
-	    output[html.length] = 0x00;
+	    output[nbytes] = 0x00;
             this.push(output);
             start = end + 1;
             end = chunk.indexOf(0x00, start);

--- a/support/katex/katex-worker.js
+++ b/support/katex/katex-worker.js
@@ -5,7 +5,7 @@ process.stdin.setEncoding('utf8');
 
 // An equation might be split across two chunks
 // of input. If this happens, we store the first
-// part of the equation in `partialEquation`.
+// part of the equation in `partialJob`.
 let partialJob = "";
 
 process.stdin.on('data', (chunk) => {

--- a/support/katex/katex-worker.js
+++ b/support/katex/katex-worker.js
@@ -20,13 +20,13 @@ const katexHtml = new Transform({
         while (end !== -1) {
             const job = JSON.parse(chunk.toString('utf8', start, end));
             const html = katex.renderToString(job.equation, job.options);
-	    // Allocate an extra byte for our buffer for the null terminator.
-	    // We can use `unsafeAlloc` here, as we are going to be overwritting
-	    // all of the contents ourselves.
-	    const nbytes = Buffer.byteLength(html);
-	    const output = Buffer.allocUnsafe(nbytes + 1);
-	    output.write(html);
-	    output[nbytes] = 0x00;
+            // Allocate an extra byte for our buffer for the null terminator.
+            // We can use `unsafeAlloc` here, as we are going to be overwritting
+            // all of the contents ourselves.
+            const nbytes = Buffer.byteLength(html);
+            const output = Buffer.allocUnsafe(nbytes + 1);
+            output.write(html);
+            output[nbytes] = 0x00;
             this.push(output);
             start = end + 1;
             end = chunk.indexOf(0x00, start);
@@ -35,17 +35,17 @@ const katexHtml = new Transform({
         if (start < chunk.length) {
             this.trailingChunk = chunk.subarray(start);
         } else {
-	    this.trailingChunk = Buffer.alloc(0);
-	}
+            this.trailingChunk = Buffer.alloc(0);
+        }
         done();
     },
 
     flush(done) {
-	if (this.trailingChunk.length != 0) {
-	    done("KaTeX worker closing with partially written job: " + trailingChunk.toString());
-	} else {
-	    done();
-	}
+        if (this.trailingChunk.length != 0) {
+            done("KaTeX worker closing with partially written job: " + trailingChunk.toString());
+        } else {
+            done();
+        }
     }
 });
 

--- a/support/katex/katex-worker.js
+++ b/support/katex/katex-worker.js
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+const katex = require('katex');
+
+process.stdin.setEncoding('utf8');
+
+// An equation might be split across two chunks
+// of input. If this happens, we store the first
+// part of the equation in `partialEquation`.
+let partialJob = "";
+
+process.stdin.on('data', (chunk) => {
+    // See [HACK: File Separator Control Characters] for
+    // explanation of '\x1C'.
+    const jobs = chunk.split('\x1C');
+    jobs[0] = partialJob + jobs[0];
+    partialJob = jobs.pop() || "";
+    process.stderr.write(JSON.stringify(jobs));
+    jobs.forEach((job) => {
+        job = JSON.parse(job);
+        try {
+            const html = katex.renderToString(job.equation, job.options);
+            process.stdout.write("Ok:" + html + '\x1C');
+        } catch(e) {
+	    process.stdout.write("Katex compilation failed for:\n" + job.equation + "\nError:\n" + e.message + '\^');
+        }
+    });
+});
+
+process.stdin.on('end', (chunk) => {
+    console.error("Input ended with non-terminated equation:\n", partialEquation);
+});

--- a/support/katex/katex-worker.js
+++ b/support/katex/katex-worker.js
@@ -14,18 +14,18 @@ process.stdin.on('data', (chunk) => {
     const jobs = chunk.split('\x1C');
     jobs[0] = partialJob + jobs[0];
     partialJob = jobs.pop() || "";
-    process.stderr.write(JSON.stringify(jobs));
     jobs.forEach((job) => {
+	// Instead of trying to catch errors in node and re-report them back
+	// to the haskell side, we take a more laissez-faire approach and
+	// just let the node process die.
         job = JSON.parse(job);
-        try {
-            const html = katex.renderToString(job.equation, job.options);
-            process.stdout.write("Ok:" + html + '\x1C');
-        } catch(e) {
-	    process.stdout.write("Katex compilation failed for:\n" + job.equation + "\nError:\n" + e.message + '\^');
-        }
+        const html = katex.renderToString(job.equation, job.options);
+        process.stdout.write(html + '\x1C');
     });
 });
 
-process.stdin.on('end', (chunk) => {
-    console.error("Input ended with non-terminated equation:\n", partialEquation);
+process.stdin.on('end', () => {
+    if (partialJob) {
+	console.error("Input ended with non-terminated equation:\n", partialJob);
+    }
 });

--- a/support/nix/build-shake.nix
+++ b/support/nix/build-shake.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation {
   propagatedBuildInputs = [ lua5_3 gmp ];
 
   buildPhase = ''
-  ghc -o ${main} app/${main} -threaded -with-rtsopts -A128M -rtsopts -iapp -O2 -split-sections -DNODE_BIN_PATH="\"${nodeDependencies}/bin\""
+  ghc -o ${main} app/${main} -threaded -with-rtsopts -A128M -rtsopts -iapp -O2 -split-sections -DNODE_LIB_PATH="\"${nodeDependencies}/lib/node_modules\"" -DNODE_BIN_PATH="\"${nodeDependencies}/bin\""
   '';
 
   installPhase = ''

--- a/support/shake/app/Shake/KaTeX.hs
+++ b/support/shake/app/Shake/KaTeX.hs
@@ -96,8 +96,8 @@ spawnKatexWorker :: IO KatexWorker
 spawnKatexWorker =
   Process.createProcess workerSpec >>= \case
   (Just katexWorkerIn, Just katexWorkerOut, _, katexProcessHandle) -> do
-    -- We are going to be delimiting requests with the file separator control
-    -- char (See [HACK: File Separator Control Characters]), so we can eek out a bit
+    -- We are going to be delimiting requests with null bytes
+    -- (See [NOTE: Delimiting KaTeX jobs]), so we can eek out a bit
     -- more performance by using block buffering over line buffering.
     hSetBuffering katexWorkerIn (BlockBuffering (Just 0x2000))
     hSetBuffering katexWorkerOut (BlockBuffering (Just 0x2000))

--- a/support/shake/app/Shake/KaTeX.hs
+++ b/support/shake/app/Shake/KaTeX.hs
@@ -1,4 +1,9 @@
-{-# LANGUAGE BlockArguments, GeneralizedNewtypeDeriving, TypeFamilies #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 -- | Shake rules to compile equations to HTML with KaTeX
 module Shake.KaTeX
@@ -11,17 +16,32 @@ module Shake.KaTeX
   , getPreambleFor
   ) where
 
+import Control.Applicative
 import Control.Monad
 
-import qualified Data.ByteString.Lazy as LazyBS
-import qualified Data.Text.Encoding as Text
-import qualified Data.Text.IO as Text
-import qualified Data.Text as Text
+import qualified Data.ByteString.Char8 as BS
+import qualified Data.ByteString.Lazy as LBS
+import qualified Data.Text.Encoding.Error as T
+import qualified Data.Text.Lazy.Encoding as LT
+import qualified Data.Map.Strict as Map
+import qualified Data.Text.Lazy as LT
+import qualified Data.Aeson as Aeson
+import qualified Data.Text.IO as T
+import qualified Data.Text as T
+import Data.Aeson (FromJSON(..), (.:), (.=))
 import Data.Text (Text)
 import Data.Generics
+import Data.Foldable
+
 
 import Development.Shake.Classes (Hashable, Binary, NFData)
 import Development.Shake
+
+import Control.Concurrent.Chan
+import Control.Exception
+
+import System.Process qualified as Process
+import System.IO
 
 import Shake.Utils
 import Macros
@@ -58,12 +78,79 @@ getPreambleFor = askOracle . LatexPreamble
 getParsedPreamble :: Action Preamble
 getParsedPreamble = askOracle $ ParsedPreamble ()
 
+-- * LaTeXML Worker Queues
+
+-- | The handles associated to a katex-worker process.
+data KatexWorker = KatexWorker
+  { katexWorkerIn :: Handle
+  -- ^ Stdin of the katex-worker process.
+  , katexWorkerOut :: Handle
+  -- ^ Stdout of the katex-worker process.
+  , katexWorkerErr :: Handle
+  -- ^ Stderr of the katex-worker process.
+  }
+
+-- | Spawn a single katex-worker process.
+-- If we cannot spawn the process for whatever reason, 'spawnLatexWorker' throws an exception via 'fail'.
+spawnKatexWorker :: IO KatexWorker
+spawnKatexWorker =
+  Process.createProcess workerSpec >>= \case
+  (Just katexWorkerIn, Just katexWorkerOut, Just katexWorkerErr, _) ->
+    pure (KatexWorker { .. })
+  _ -> fail "Spawning katex-worker process failed."
+  where
+    workerSpec =
+      -- FIXME: This aint the right way to do this.
+      (Process.proc "./support/katex/katex-worker.js" [])
+        { Process.cwd = Nothing
+        , Process.std_in = Process.CreatePipe
+        , Process.std_out = Process.CreatePipe
+        , Process.std_err = Process.CreatePipe
+        }
+
+-- | Create a FIFO queue of katex-worker processes.
+createKatexWorkerQueue
+  :: Int                -- ^ Number of processes to spawn.
+  -> IO (Chan KatexWorker)
+createKatexWorkerQueue numWorkers = do
+  workers <- newChan
+  for_ [0..numWorkers] $ \i -> do
+    worker <- spawnKatexWorker
+    writeChan workers worker
+  pure workers
+
+-- | Remove a worker from a worker queue for a given job type
+-- and run the provided IO action with that worker.
+-- Once completed, return the worker to the queue.
+withKatexWorker
+  :: Chan KatexWorker
+  -> (KatexWorker -> IO a)
+  -> IO a
+withKatexWorker workerQueue k =
+  bracket (readChan workerQueue) (writeChan workerQueue) k
+
+-- | Encode a 'LatexEquation' into a @katex-worker@ job.
+encodeKatexJob :: Bool -> Text -> Aeson.Value
+encodeKatexJob display tex =
+  Aeson.object
+  [ "equation" .= tex
+  , "options" .=
+    Aeson.object
+    [ "displayMode" .= display
+    , "output" .= ("html" :: Text)
+    , "trust" .= True
+    ]
+  ]
+
 -- | Shake rules required for compiling KaTeX equations.
 katexRules :: Rules ()
-katexRules = versioned 2 do
+katexRules = versioned 3 do
+  numThreads <- shakeThreads <$> getShakeOptionsRules
+  workerQueue <- liftIO $ createKatexWorkerQueue numThreads
+
   _ <- addOracle \(ParsedPreamble _) -> do
     need ["src/preamble.tex"]
-    t <- liftIO $ Text.readFile "src/preamble.tex"
+    t <- liftIO $ T.readFile "src/preamble.tex"
     case parsePreamble t of
       Just p -> pure p
       Nothing -> error "Failed to parse preamble.tex!"
@@ -71,18 +158,31 @@ katexRules = versioned 2 do
   _ <- addOracleCache \(LatexPreamble bool) -> do
     pre <- askOracle (ParsedPreamble ())
     let dark = if bool then darkSettings else mempty
-    pure (preambleToLatex pre <> Text.pack "\n" <> dark)
+    pure (preambleToLatex pre <> T.pack "\n" <> dark)
 
-  _ <- versioned 2 $ addOracleCache \(LatexEquation (display, tex)) -> do
+  _ <- versioned 3 $ addOracleCache \(LatexEquation (display, tex)) -> do
     pre <- askOracle (ParsedPreamble ())
-
-    let args = ["-T", "-F", "html"] ++ ["-d" | display]
-        stdin = LazyBS.fromStrict $ Text.encodeUtf8 $ applyPreamble pre tex
-
-    Stdout out <- nodeCommand [StdinBS stdin] "katex" args
-    pure . Text.stripEnd . Text.decodeUtf8 $ out
+    result <-
+      traced "katex" $
+      withKatexWorker workerQueue \KatexWorker{..} ->
+      handle (\(SomeException e) -> pure (T.pack $ displayException e)) $ do
+        -- [HACK: File Separator Control Characters].
+        -- Instead of trying to do some fiddly JSON streaming, we opt to
+        -- use a little known feature of ASCII to delimit our requests.
+        -- The control character 0x1C in ASCII encodes a file-separator,
+        -- which is left up to applications to interpret. We can rely on this never showing up
+        -- in our JSON, so it is safe to use this to delimit requests.
+        let job = Aeson.encode (encodeKatexJob display (applyPreamble pre tex)) <> "\FS"
+        LBS.hPutStr katexWorkerIn job
+        hFlush katexWorkerIn
+        -- We can't use 'LBS.takeWhile (0x1c /=)' here, as the output can contain utf8-encoded
+        -- text. To avoid this, we first decode to utf8.
+        LT.toStrict <$> LT.takeWhile ('\FS' /=) <$> LT.decodeUtf8With T.strictDecode <$> LBS.hGetContents katexWorkerOut
+    case T.stripPrefix "Ok:" result of
+      Just html -> pure (T.strip html)
+      Nothing -> error (T.unpack result)
 
   pure ()
 
 darkSettings :: Text
-darkSettings = Text.pack "\\newcommand{\\labdark}{yes!}"
+darkSettings = T.pack "\\newcommand{\\labdark}{yes!}"

--- a/support/shake/app/Shake/Markdown.hs
+++ b/support/shake/app/Shake/Markdown.hs
@@ -279,6 +279,8 @@ buildMarkdown modname input output = do
     Dir.createDirectoryIfMissing False "_build/search"
 
     Text.writeFile output $ renderHTML5 tags
+
+  traced "search" do
     encodeFile ("_build/search" </> modname <.> "json") search
 
   for_ (Map.toList defs) \(key, bs) -> traced "writing fragment" do

--- a/support/shake/app/Shake/Utils.hs
+++ b/support/shake/app/Shake/Utils.hs
@@ -38,13 +38,7 @@ nodeProc
   -- ^ Arguments to pass to the node script.
   -> CreateProcess
 nodeProc path opts =
-  let nodeBinPath =
-#ifdef NODE_BIN_PATH
-        NODE_BIN_PATH
-#else
-        "node_modules/.bin"
-#endif
-      nodeLibPath =
+  let nodeLibPath =
 #ifdef NODE_LIB_PATH
         NODE_LIB_PATH
 #else
@@ -52,7 +46,7 @@ nodeProc path opts =
 #endif
   in
   (Process.proc "node" (path:opts))
-  { Process.env = Just [("PATH", nodeBinPath <> ":" <> "$PATH"), ("NODE_PATH", nodeLibPath)]
+  { Process.env = Just [("NODE_PATH", nodeLibPath)]
   }
 
 -- | Read and decode JSON from a file, tracking it as a dependency.

--- a/support/shake/app/Shake/Utils.hs
+++ b/support/shake/app/Shake/Utils.hs
@@ -1,10 +1,15 @@
 {-# LANGUAGE CPP #-}
 module Shake.Utils
   ( nodeCommand
+  , nodeProc
   , readJSONFile
   ) where
 
 import Data.Aeson
+
+import System.Process (CreateProcess)
+import System.Process qualified as Process
+import System.IO
 
 import Development.Shake
 
@@ -22,6 +27,33 @@ nodeCommand opts path = command opts ( NODE_BIN_PATH ++ "/" ++ path )
 nodeCommand opts = command (opts ++ [AddPath [] ["node_modules/.bin"]])
 
 #endif
+
+-- | Construct a @CreateProcess@ for a node script.
+-- See 'nodeCommand' for more information on the resolution
+-- of node-related paths.
+nodeProc
+  :: FilePath
+  -- ^ Path to the node script.
+  -> [String]
+  -- ^ Arguments to pass to the node script.
+  -> CreateProcess
+nodeProc path opts =
+  let nodeBinPath =
+#ifdef NODE_BIN_PATH
+        NODE_BIN_PATH
+#else
+        "node_modules/.bin"
+#endif
+      nodeLibPath =
+#ifdef NODE_LIB_PATH
+        NODE_LIB_PATH
+#else
+        "node_modules/"
+#endif
+  in
+  (Process.proc "node" (path:opts))
+  { Process.env = Just [("PATH", nodeBinPath <> ":" <> "$PATH"), ("NODE_PATH", nodeLibPath)]
+  }
 
 -- | Read and decode JSON from a file, tracking it as a dependency.
 readJSONFile :: FromJSON b => FilePath -> Action b


### PR DESCRIPTION
# Description

Closes #115. On my machine, this turn an 11 minute `1lab-shake all -j --skip-agda` clean build into a much snappier 3 minutes.