### PR TITLE
chore:fix minor inconsistency

### DIFF
--- a/src/Data/Fin/Base.lagda.md
+++ b/src/Data/Fin/Base.lagda.md
@@ -335,7 +335,7 @@ _[_≔_]
   : ∀ {ℓ} {A : Type ℓ} {n}
   → (Fin n → A) → Fin (suc n) → A
   → Fin (suc n) → A
-_[_≔_] {n = n} p i a j with fin-view i | fin-view j
+_[_≔_] {n = n} ρ i a j with fin-view i | fin-view j
 _[_≔_] {n = n} ρ fzero a fzero             | zero  | zero  = a
 _[_≔_] {n = n} ρ fzero a .(fsuc j)         | zero  | suc j = ρ j
 _[_≔_] {n = suc n} ρ .(fsuc i) a .fzero    | suc i | zero  = ρ fzero


### PR DESCRIPTION
# Description

One function definition was using ρ (rho) and p inconsistently as variable names (it was referred to as p in one case of the pattern match, and ρ in the rest, so I fixed it by replacing the first p with a ρ)

## Checklist

Before submitting a merge request, please check the items below:

- [x] I've read [the contributing guidelines](https://github.com/plt-amy/1lab/blob/main/CONTRIBUTING.md).
- [x] The imports of new modules have been sorted with `support/sort-imports.hs` (or `nix run --experimental-features nix-command -f . sort-imports`).
- [x] All new code blocks have "agda" as their language.

If your change affects many files without adding substantial content, and
you don't want your name to appear on those pages (for example, treewide
refactorings or reformattings), start the commit message and PR title with `chore:`.
