### PR TITLE
web: increase margin for <pre>

### DIFF
--- a/support/web/css/code.scss
+++ b/support/web/css/code.scss
@@ -54,9 +54,9 @@ pre.Agda, div.sourceCode > pre {
   overflow-x: auto;
   overflow-y: clip;
 
-  // The margin should be 1rem (the width of the padding for paragraphs
+  // The horizontal margin should be 1rem (the width of the padding for paragraphs
   // with borders) *plus* 5px. This was measured empirically.
-  margin: 0.25rem var(--code-margin);
+  margin: 1em var(--code-margin);
 
   background-color: theme(--text-bg);
   color:            theme(--text-fg);


### PR DESCRIPTION
Makes the vertical margin for `pre` tags the same as for `.sourceCode`.

Before (1Lab.Path, hidden code off):

<img width="1600" height="763" alt="screenshot-2025-07-18-221525" src="https://github.com/user-attachments/assets/93989915-2906-4611-acd0-e9d7b8588f34" />

After:

<img width="1588" height="801" alt="screenshot-2025-07-18-221552" src="https://github.com/user-attachments/assets/2a35747c-2962-40b5-9a54-fdf5599aa244" />
