### PR TITLE
fixup: use monoid reasoning for semilattices

### DIFF
--- a/src/Order/Semilattice/Join/Reasoning.lagda.md
+++ b/src/Order/Semilattice/Join/Reasoning.lagda.md
@@ -8,7 +8,7 @@ open import Cat.Prelude
 open import Order.Semilattice.Join
 open import Order.Base
 
-import Cat.Reasoning
+import Algebra.Monoid.Reasoning
 
 import Order.Reasoning
 
@@ -56,5 +56,5 @@ Therefore, every join semilattice is a monoid.
 ∪-monoid .Monoid-on._⋆_ = _∪_
 ∪-monoid .Monoid-on.has-is-monoid = ∪-is-monoid
 
-module ∪ = Cat.Reasoning (B ∪-monoid) hiding (Ob)
+module ∪ = Algebra.Monoid.Reasoning (⌞ P ⌟ , ∪-monoid)
 ```

--- a/src/Order/Semilattice/Meet/Reasoning.lagda.md
+++ b/src/Order/Semilattice/Meet/Reasoning.lagda.md
@@ -8,7 +8,7 @@ open import Cat.Prelude
 open import Order.Semilattice.Meet
 open import Order.Base
 
-import Cat.Reasoning
+import Algebra.Monoid.Reasoning
 
 import Order.Reasoning
 
@@ -56,5 +56,5 @@ Therefore, every meet semilattice is a monoid.
 ∩-monoid .Monoid-on._⋆_ = _∩_
 ∩-monoid .Monoid-on.has-is-monoid = ∩-is-monoid
 
-module ∩ = Cat.Reasoning (B ∩-monoid) hiding (Ob)
+module ∩ = Algebra.Monoid.Reasoning (⌞ P ⌟ , ∩-monoid)
 ```


### PR DESCRIPTION
If we reuse `Cat.Reasoning` the interface for `Order.Frame.Reasoning` has >700 things in it...