### PR TITLE
chore: bump Agda

### DIFF
--- a/src/Data/Fin/Base.lagda.md
+++ b/src/Data/Fin/Base.lagda.md
@@ -53,7 +53,9 @@ Instead, we would like the `subst`{.Agda} operation on `Fin`{.Agda} to
 definitionally commute with the constructors, and (if possible) to
 definitionally preserve the underlying numeric value. Defining
 `Fin`{.Agda} as an indexed type with an irrelevant proof field achieves
-exactly this:
+exactly this. Moreover, if we're substituting over a loop, even at a
+neutral number, transport at `Fin`{.Agda} is definitionally the identity
+function.
 
 ```agda
 private
@@ -64,6 +66,9 @@ private
     }
 
   _ : ∀ {m n} {p : m ≡ n} {x : Fin m} → subst Fin p x ≡ cast p x
+  _ = refl
+
+  _ : ∀ {m} {p : m ≡ m} {x : Fin m} → subst Fin p x ≡ x
   _ = refl
 ```
 

--- a/support/nix/dep/Agda/github.json
+++ b/support/nix/dep/Agda/github.json
@@ -3,6 +3,6 @@
   "repo": "agda",
   "branch": "master",
   "private": false,
-  "rev": "822e0aee235ba787b7ac50cc7ab19fca20be5924",
-  "sha256": "1b93dbfz224dwx34va9hafrykgnah06cznagg1dmp9xvpac1sw8b"
+  "rev": "e717572aa1dcc976b3a4b5b977fcfaf5a60fe3e2",
+  "sha256": "0y7bspb6gdpxzqg9qcsbidmpq3n8wwz54w5zvqz6mwbyl2sqm8k5"
 }

--- a/support/nix/haskell-packages.nix
+++ b/support/nix/haskell-packages.nix
@@ -16,6 +16,12 @@ in
     # somehow depends on mime-types
     labHaskellPackages = super.haskell.packages.ghc946.override (old: {
       overrides = self: super: {
+        infinite-list = super.callHackageDirect {
+          pkg    = "infinite-list";
+          ver    = "0.1.2";
+          sha256 = "sha256-OUNCBVKCHFPjtJK/Lm4PG6ldKvqSySA0TwnaY9estzo=";
+        } {};
+
         Agda = noJunk (super.callCabal2nixWithOptions "Agda" (thunkSource ./dep/Agda) "-f optimise-heavily -f debug" {});
       };
     });


### PR DESCRIPTION
Includes the fixes to @ncfavier's highlighting issue and @4e554c4c's `record where` issue and profiling/benchmarking options so we can be sad about the performance of parametrised modules and not much else