### PR TITLE
reorganise Data.Sum.Properties

### DIFF
--- a/src/Data/Sum/Properties.lagda.md
+++ b/src/Data/Sum/Properties.lagda.md
@@ -1,15 +1,13 @@
 <!--
 ```agda
+open import 1Lab.Path.IdentitySystem
 open import 1Lab.Function.Embedding
-open import 1Lab.Reflection.HLevel
-open import 1Lab.HLevel.Universe
 open import 1Lab.HLevel.Closure
 open import 1Lab.HLevel
 open import 1Lab.Equiv
 open import 1Lab.Path
 open import 1Lab.Type
 
-open import Data.List.Base
 open import Data.Dec.Base
 open import Data.Nat.Base
 open import Data.Sum.Base
@@ -22,7 +20,7 @@ open import Meta.Invariant
 module Data.Sum.Properties where
 ```
 
-As warmup, we have that both constructors are embeddings:
+# Properties of sum types
 
 <!--
 ```agda
@@ -32,154 +30,124 @@ private variable
 ```
 -->
 
-```agda
-inl-inj : {x y : A} → inl {B = B} x ≡ inl y → x ≡ y
-inl-inj {A = A} {x = x} = ap f module inl-inj where
-  f : A ⊎ B → A
-  f (inl x) = x
-  f (inr _) = x
-
-inr-inj : {A : Type b} {x y : B} → inr {A = A} x ≡ inr y → x ≡ y
-inr-inj {B = B} {x = x} path = ap f path where
-  f : A ⊎ B → B
-  f (inl _) = x
-  f (inr x) = x
-
-inl≠inr : {A : Type a} {B : Type b} {x : A} {y : B} → ¬ inl x ≡ inr y
-inl≠inr path = subst (λ { (inl x) → ⊤ ; (inr x) → ⊥ }) path tt
-
-inr≠inl : {A : Type a} {B : Type b} {x : A} {y : B} → ¬ inr x ≡ inl y
-inr≠inl path = inl≠inr (sym path)
-```
-
-## Closure under h-levels
-
-If $A$ and $B$ are $n$-types, for $n \ge 2$, then so is their coproduct.
-The way we prove this is by characterising the entire path space of `A ⊎
-B` in terms of the path spaces for `A` and `B`, using a recursive
-definition:
+Many useful properties of [[sum types]] will fall out of characterising
+their *path spaces*. We start by defining a reflexive family of codes
+for paths in `A ⊎ B`: between elements in the same component, a code is
+simply a path in the corresponding type, while there are no codes between
+elements in different components.
 
 ```agda
-module ⊎Path where
+module ⊎Path {a b} {A : Type a} {B : Type b} where
   Code : A ⊎ B → A ⊎ B → Type (level-of A ⊔ level-of B)
-  Code {B = B} (inl x) (inl y) = Lift (level-of B) (x ≡ y)
-  Code (inl x) (inr y)         = Lift _ ⊥
-  Code (inr x) (inl y)         = Lift _ ⊥
-  Code {A = A} (inr x) (inr y) = Lift (level-of A) (x ≡ y)
+  Code (inl x) (inl y) = Lift (level-of B) (x ≡ y)
+  Code (inl x) (inr y) = Lift _ ⊥
+  Code (inr x) (inl y) = Lift _ ⊥
+  Code (inr x) (inr y) = Lift (level-of A) (x ≡ y)
+
+  Code-refl : (x : A ⊎ B) → Code x x
+  Code-refl (inl x) = lift refl
+  Code-refl (inr x) = lift refl
 ```
 
 Given a `Code`{.Agda} for a path in `A ⊎ B`, we can turn it into a
-legitimate path. Agda automatically lets us ignore the cases where
-the `Code`{.Agda} computes to `the empty type`{.Agda ident=⊥}.
+legitimate path by `ap`{.Agda}plying the corresponding constructor.
+Agda automatically lets us ignore the cases where the `Code`{.Agda}
+computes to `the empty type`{.Agda ident=⊥}.
 
 ```agda
   decode : {x y : A ⊎ B} → Code x y → x ≡ y
-  decode {x = inl x} {y = inl x₁} code = ap inl (lower code)
-  decode {x = inr x} {y = inr x₁} code = ap inr (lower code)
+  decode {x = inl x} {y = inl y} code = ap inl (lower code)
+  decode {x = inr x} {y = inr y} code = ap inr (lower code)
 ```
 
-In the inverse direction, we have a procedure for turning paths into
-codes:
+This lets us show that `Code`{.Agda} is an [[identity system]], so
+that we get an equivalence between codes and paths.
 
 ```agda
-  encode : {x y : A ⊎ B} → x ≡ y → Code x y
-  encode {x = inl x} {y = inl y} path = lift (inl-inj path)
-  encode {x = inl x} {y = inr y} path = absurd (inl≠inr path)
-  encode {x = inr x} {y = inl y} path = absurd (inr≠inl path)
-  encode {x = inr x} {y = inr y} path = lift (inr-inj path)
-```
+  ids : is-identity-system Code Code-refl
+  ids .to-path = decode
+  ids .to-path-over {inl x} {inl y} (lift p) i = lift λ j → p (i ∧ j)
+  ids .to-path-over {inr x} {inr y} (lift p) i = lift λ j → p (i ∧ j)
 
-Now we must establish that `encode`{.Agda} and `decode`{.Agda} are
-inverses. In the one direction, we can use path induction:
-
-```agda
-  decode-encode : {x y : A ⊎ B} (p : x ≡ y) → decode (encode p) ≡ p
-  decode-encode = J (λ _ p → decode (encode p) ≡ p) d-e-refl where
-    d-e-refl : {x : A ⊎ B} → decode (encode (λ i → x)) ≡ (λ i → x)
-    d-e-refl {x = inl x} = refl
-    d-e-refl {x = inr x} = refl
-```
-
-In the other direction, the proof is by case analysis, and everything
-computes wonderfully to make the right-hand sides fillable by
-`refl`{.Agda}:
-
-```agda
-  encode-decode : {x y : A ⊎ B} (p : Code x y) → encode (decode p) ≡ p
-  encode-decode {x = inl x} {y = inl y} p = refl
-  encode-decode {x = inr x} {y = inr y} p = refl
-```
-
-Thus, we have an equivalence between _codes for_ paths in `A ⊎ B` and
-_actual_ paths `A ⊎ B`. Since `Code`{.Agda} has a nice computational
-structure, we can establish its h-level by induction:
-
-```agda
   Code≃Path : {x y : A ⊎ B} → (x ≡ y) ≃ Code x y
-  Code≃Path = Iso→Equiv (encode , iso decode encode-decode decode-encode)
+  Code≃Path = identity-system-gives-path ids e⁻¹
 ```
+
+## Injectivity and disjointness of constructors
+
+A first very useful consequence is that the constructors `inl`{.Agda}
+and `inr`{.Agda} are *injective* and *disjoint*:
 
 ```agda
 open ⊎Path
 
-Code-is-hlevel : {x y : A ⊎ B} {n : Nat}
-               → is-hlevel A (2 + n)
-               → is-hlevel B (2 + n)
-               → is-hlevel (Code x y) (suc n)
-Code-is-hlevel {x = inl x} {inl y} {n} ahl bhl =
-  Lift-is-hlevel (suc n) (ahl x y)
-Code-is-hlevel {x = inr x} {inr y} {n} ahl bhl =
-  Lift-is-hlevel (suc n) (bhl x y)
+inl-inj : {x y : A} → inl {B = B} x ≡ inl y → x ≡ y
+inl-inj = lower ∘ Code≃Path .fst
+
+inr-inj : {A : Type b} {x y : B} → inr {A = A} x ≡ inr y → x ≡ y
+inr-inj = lower ∘ Code≃Path .fst
+
+inl≠inr : {A : Type a} {B : Type b} {x : A} {y : B} → ¬ inl x ≡ inr y
+inl≠inr = lower ∘ Code≃Path .fst
+
+inr≠inl : {A : Type a} {B : Type b} {x : A} {y : B} → ¬ inr x ≡ inl y
+inr≠inl = lower ∘ Code≃Path .fst
 ```
 
-In the two cases where `x` and `y` match, we can use the fact that `Lift
-preserves h-levels`{.Agda ident=Lift-is-hlevel} and the assumption that
-`A` (or `B`) have the given h-level.
+In fact they are even [[embeddings]]:
 
 ```agda
-Code-is-hlevel {x = inl x} {inr y} {n} ahl bhl =
-  Lift-is-hlevel (suc n) (is-prop→is-hlevel-suc λ x → absurd x)
-Code-is-hlevel {x = inr x} {inl y} {n} ahl bhl =
-  Lift-is-hlevel (suc n) (is-prop→is-hlevel-suc λ x → absurd x)
+inl-is-embedding : is-embedding (inl {A = A} {B})
+inl-is-embedding = cancellable→embedding (Code≃Path ∙e Lift-≃)
+
+inr-is-embedding : is-embedding (inr {A = A} {B})
+inr-is-embedding = cancellable→embedding (Code≃Path ∙e Lift-≃)
 ```
 
-In the mismatched cases, we use the fact that `propositions have any
-successor h-level`{.Agda ident=is-prop→is-hlevel-suc} to prove that `⊥` is
-also at the same h-level as `A` and `B`. Thus, we have:
+## Closure under h-levels
+
+As another consequence, if $A$ and $B$ are $n$-types for $n \ge 2$,
+then so is their coproduct.
+
+We first observe that `Code`{.Agda} is a family of $(n-1)$-types, which
+is automatic in every case using instance search:
+
+```agda
+Code-is-hlevel : {x y : A ⊎ B} {n : Nat}
+               → ⦃ H-Level A (2 + n) ⦄
+               → ⦃ H-Level B (2 + n) ⦄
+               → is-hlevel (Code x y) (suc n)
+Code-is-hlevel {x = inl x} {inl y} {n} = hlevel (suc n)
+Code-is-hlevel {x = inr x} {inr y} {n} = hlevel (suc n)
+Code-is-hlevel {x = inl x} {inr y} {n} = hlevel (suc n)
+Code-is-hlevel {x = inr x} {inl y} {n} = hlevel (suc n)
+```
+
+Thus, so are paths in `A ⊎ B`, which concludes the proof.
 
 ```agda
 ⊎-is-hlevel : (n : Nat)
-            → is-hlevel A (2 + n)
-            → is-hlevel B (2 + n)
+            → ⦃ H-Level A (2 + n) ⦄
+            → ⦃ H-Level B (2 + n) ⦄
             → is-hlevel (A ⊎ B) (2 + n)
-⊎-is-hlevel n ahl bhl x y =
-  Equiv→is-hlevel (1 + n) Code≃Path (Code-is-hlevel ahl bhl)
-
-instance
-  H-Level-⊎ : ∀ {n} ⦃ _ : 2 ≤ n ⦄ ⦃ _ : H-Level A n ⦄ ⦃ _ : H-Level B n ⦄ → H-Level (A ⊎ B) n
-  H-Level-⊎ {n = suc (suc n)} ⦃ s≤s (s≤s p) ⦄ = hlevel-instance $
-    ⊎-is-hlevel _ (hlevel (2 + n)) (hlevel (2 + n))
+⊎-is-hlevel {A = A} {B = B} n x y =
+  Equiv→is-hlevel (1 + n) Code≃Path Code-is-hlevel
 ```
 
 <!--
 ```agda
-inl-is-embedding : is-embedding (inl {A = A} {B})
-inl-is-embedding = cancellable→embedding' inl-inj λ p → decode-encode p
-
-inr-is-embedding : is-embedding (inr {A = A} {B})
-inr-is-embedding = cancellable→embedding' inr-inj λ p → decode-encode p
-
-module _ {ℓ} {A : n-Type ℓ 2} where
-  _ : is-hlevel (∣ A ∣ ⊎ ∣ A ∣) 5
-  _ = hlevel 5
+instance
+  H-Level-⊎ : ∀ {n} ⦃ _ : 2 ≤ n ⦄ ⦃ _ : H-Level A n ⦄ ⦃ _ : H-Level B n ⦄ → H-Level (A ⊎ B) n
+  H-Level-⊎ {n = suc (suc n)} ⦃ s≤s (s≤s p) ⦄ = hlevel-instance $
+    ⊎-is-hlevel _
 ```
 -->
 
-Note that, in general, being a [[proposition]] and [[contractible]]
-are not preserved under coproducts. Consider the case where `(A, a)` and
-`(B, b)` are both contractible (this generalises to propositions): Then
-their coproduct has two distinct points, `inl a` and `inr b`. However,
-the coproduct of _disjoint_ propositions is a proposition:
+Note that, in general, being a [[proposition]] and being [[contractible]]
+is not preserved under coproducts. Consider the type `⊤ ⊎ ⊤`: this
+is a coproduct of contractible types (hence propositions) that is not
+itself a proposition. However, the coproduct of _disjoint_ propositions
+is a proposition:
 
 ```agda
 disjoint-⊎-is-prop


### PR DESCRIPTION
Start by characterising paths in sum types (using an identity system) and derive injectivity and disjointness of constructors from that.