### PR TITLE
Homotopy.Join as Logical Disjunction

### DIFF
--- a/src/Homotopy/Join.lagda.md
+++ b/src/Homotopy/Join.lagda.md
@@ -143,6 +143,31 @@ join-commutative .snd = is-iso→is-equiv record where
   linv = Pushout-elim (λ _ → refl) (λ _ → refl) λ c i j → glue c i
 ```
 
+Finally, if either of the joined types is contractible, so is the join.
+```agda
+join-is-contr-l : is-contr X → is-contr (X ∗ Y)
+join-is-contr-l h .centre = inl (centre h)
+join-is-contr-l h .paths (inl x) = ap inl (paths h x)
+join-is-contr-l h .paths (inr y) = join (centre h) y
+join-is-contr-l h .paths (join x y i) j = hcomp (∂ i ∨ ∂ j) λ where
+  k (k = i0) → join x y (i ∧ j)
+  k (i = i0) → inl (paths h x (~ k ∨ j))
+  k (i = i1) → join (paths h x (~ k)) y j
+  k (j = i0) → inl (paths h x (~ k))
+  k (j = i1) → join x y i
+
+join-is-contr-r : is-contr Y → is-contr (X ∗ Y)
+join-is-contr-r h .centre = inr (centre h)
+join-is-contr-r h .paths (inl x) = sym (join x (centre h))
+join-is-contr-r h .paths (inr y) = ap inr (paths h y)
+join-is-contr-r h .paths (join x y i) j = hcomp (∂ i ∨ ∂ j) λ where
+  k (k = i0) → join x y (i ∨ ~ j)
+  k (i = i0) → join x (paths h y (~ k)) (~ j)
+  k (i = i1) → inr (paths h y (~ k ∨ j))
+  k (j = i0) → inr (paths h y (~ k))
+  k (j = i1) → join x y i
+```
+
 <!--
 ```agda
 join-map : (A → B) → (X → Y) → A ∗ X → B ∗ Y
@@ -189,4 +214,27 @@ lives in the meridians.
     (λ a → join false a)
     λ { (true , a) → transpose (flip₁ (∙-filler _ _))
       ; (false , a) i j → join false a (i ∧ j) }
+```
+
+## Joins of propositions {defines="disjunction logical-or"}
+
+When applied to propositions, the join construction
+acts as logical disjunction. If `X` and `Y` are propositions,
+then `X ∗ Y` is also a proposition, which holds iff
+either `X` or `Y` does.
+
+```agda
+join-elim-prop : {P : X ∗ Y → Type ℓ} (pprop : ∀ x → is-prop (P x))
+  → (f : ∀ x → P (inl x)) (g : ∀ y → P (inr y))
+  → ∀ x → P x
+join-elim-prop h f g =
+  Pushout-elim f g λ c → is-prop→pathp (λ i → h (glue c i)) _ _
+
+join-is-prop : is-prop X → is-prop Y → is-prop (X ∗ Y)
+join-is-prop {X = X} {Y = Y} hx hy = λ x y → go x x y where
+  go : X ∗ Y → is-prop (X ∗ Y)
+  go = join-elim-prop
+    (λ _ → is-prop-is-prop)
+    (λ x → is-contr→is-prop (join-is-contr-l (is-prop∙→is-contr hx x)))
+    (λ y → is-contr→is-prop (join-is-contr-r (is-prop∙→is-contr hy y)))
 ```

--- a/src/Homotopy/Join.lagda.md
+++ b/src/Homotopy/Join.lagda.md
@@ -144,6 +144,7 @@ join-commutative .snd = is-iso→is-equiv record where
 ```
 
 Finally, if either of the joined types is contractible, so is the join.
+
 ```agda
 join-is-contr-l : is-contr X → is-contr (X ∗ Y)
 join-is-contr-l h .centre = inl (centre h)


### PR DESCRIPTION
Suppose `X` is a type, and we want to produce an element of `X` under the assumption "`P` or `Q`". Intuitively, we should have to provide an element under the assumption `P`, provide an element under the assumption `Q`, and show that the elements agree when both assumptions hold.

This sounds exactly like the elimination principle for `_∗_` from `Homotopy.Join`! And indeed, `P ∗ Q` is a proposition that correctly represents the logical disjunction of `P` and `Q`. I provide the groundwork required to use it this way.

This could be useful, for example, as a potential resolution to issue #474. But beyond that, I'd argue that `P ∗ Q` is a good replacement for `∥ P ⊎ Q ∥` pretty much anywhere. It's equivalent, but it lets you eliminate into arbitrary types rather than just propositions.

---

In the process of implementing this, I also prove that a join with a contractible type is always contractible. This fact should be useful on its own.