### PR TITLE
Add a case bash tactic

### DIFF
--- a/src/1Lab/Type/Pi/Currying.lagda.md
+++ b/src/1Lab/Type/Pi/Currying.lagda.md
@@ -1,0 +1,142 @@
+---
+description: |
+  Currying pi types.
+---
+<!--
+```agda
+open import 1Lab.Type.Sigma
+open import 1Lab.Type.Pi
+open import 1Lab.Equiv
+open import 1Lab.Type
+```
+-->
+```agda
+module 1Lab.Type.Pi.Currying where
+```
+
+# Currying and uncurrying automation
+
+This module contains proof automation for passing between curried and
+uncurried Π types.
+
+## Currying
+
+The core of our currying automation is the following typeclass, which
+decomposes a type $A$ into a Π type.
+
+```agda
+record Curried {ℓ} (A : Type ℓ) (ℓd ℓf : Level) : Type (ℓ ⊔ lsuc ℓd ⊔ lsuc ℓf) where
+  no-eta-equality
+  field
+    Dom : Type ℓd
+    Cod : Dom → Type ℓf
+    eqv : ((d : Dom) → Cod d) ≃ A
+```
+
+The only interesting instances of `Curried` check to see if $A$
+is an iterated Π type, and shuffle over elements of the codomain into
+a Σ in the domain.
+
+```agda
+instance
+  Curried-Π
+    : ∀ {ℓ ℓ' ℓ'' ℓd ℓf} {A : Type ℓ} {B : A → Type ℓ'} {C : (a : A) → B a → Type ℓ''}
+    → ⦃ _ : ∀ {a} → Curried ((b : B a) → C a b) ℓd ℓf ⦄
+    → Curried ((a : A) (b : B a) → C a b) (ℓd ⊔ ℓ) ℓf
+  Curried-Π {A = A} ⦃ c ⦄ .Curried.Dom = Σ[ a ∈ A ] (Curried.Dom (c {a}))
+  Curried-Π {A = A} ⦃ c ⦄ .Curried.Cod (a , d) = Curried.Cod c d
+  Curried-Π {A = A} ⦃ c ⦄ .Curried.eqv = curry≃ ∙e Π-ap-cod λ a → Curried.eqv c
+
+  Curried-Π'
+    : ∀ {ℓ ℓ' ℓ'' ℓd ℓf} {A : Type ℓ} {B : A → Type ℓ'} {C : (a : A) → B a → Type ℓ''}
+    → ⦃ _ : ∀ {a} → Curried ((b : B a) → C a b) ℓd ℓf ⦄
+    → Curried ({a : A} (b : B a) → C a b) (ℓd ⊔ ℓ) ℓf
+  Curried-Π' {A = A} ⦃ c ⦄ .Curried.Dom = Σ[ a ∈ A ] (Curried.Dom (c {a}))
+  Curried-Π' {A = A} ⦃ c ⦄ .Curried.Cod (a , d) = Curried.Cod c d
+  Curried-Π' {A = A} ⦃ c ⦄ .Curried.eqv = curry≃ ∙e Π-impl≃ ∙e Π'-ap-cod λ a → Curried.eqv c
+```
+
+Finally, we have an `INCOHERENT` base case that will match only when
+we have run out of iterated Π types.
+
+```agda
+  Curried-default
+    : ∀ {ℓ ℓ'} {A : Type ℓ} {B : A → Type ℓ'}
+    → Curried ((a : A) → B a) ℓ ℓ'
+  Curried-default {A = A} {B = B} .Curried.Dom = A
+  Curried-default {A = A} {B = B} .Curried.Cod = B
+  Curried-default {A = A} {B = B} .Curried.eqv = id≃
+  {-# INCOHERENT Curried-default #-}
+```
+
+Now that we've got our instances in place, we can use instance arguments
+to compute the fully curried version of a type.
+
+```agda
+Curry : ∀ {ℓ ℓd ℓf} → (A : Type ℓ) → ⦃ C : Curried A ℓd ℓf ⦄ → Type (ℓd ⊔ ℓf)
+Curry A ⦃ C ⦄ = (x : Curried.Dom C) → Curried.Cod C x
+{-# NOINLINE Curry #-}
+```
+
+We also expose the equivlance between the original type and it's
+curried form.
+
+```agda
+curry!
+  : ∀ {ℓ ℓd ℓf}
+  → {A : Type ℓ}
+  → ⦃ C : Curried A ℓd ℓf ⦄
+  → A ≃ Curry A
+curry! ⦃ C ⦄ = Curried.eqv C e⁻¹
+{-# NOINLINE curry! #-}
+```
+
+## Uncurrying
+
+The uncurrying typeclass is identical to the currying typeclass in
+all but name.
+
+```agda
+record Uncurried {ℓ} (A : Type ℓ) (ℓd ℓf : Level) : Type (ℓ ⊔ lsuc ℓd ⊔ lsuc ℓf) where
+  no-eta-equality
+  field
+    Dom : Type ℓd
+    Cod : Dom → Type ℓf
+    eqv : ((d : Dom) → Cod d) ≃ A
+```
+
+However, the instances for `Uncurried` go in the opposite direction.
+
+```agda
+instance
+  Uncurried-Π
+    : ∀ {ℓ ℓ' ℓ'' ℓd ℓf} {A : Type ℓ} {B : A → Type ℓ'} {C : Σ A B → Type ℓ''}
+    → ⦃ _ : ∀ {a} → Uncurried ((b : B a) → C (a , b)) ℓd ℓf ⦄
+    → Uncurried ((ab : Σ A B) → C ab) ℓ (ℓd ⊔ ℓf)
+  Uncurried-Π {A = A} ⦃ c ⦄ .Uncurried.Dom = A
+  Uncurried-Π {A = A} ⦃ c ⦄ .Uncurried.Cod a = (d : Uncurried.Dom (c {a})) → Uncurried.Cod (c {a}) d
+  Uncurried-Π {A = A} ⦃ c ⦄ .Uncurried.eqv = Π-ap-cod (λ a → Uncurried.eqv c) ∙e curry≃ e⁻¹
+
+  Uncurried-default
+    : ∀ {ℓ ℓ'} {A : Type ℓ} {B : A → Type ℓ'}
+    → Uncurried ((a : A) → B a) ℓ ℓ'
+  Uncurried-default {A = A} {B = B} .Uncurried.Dom = A
+  Uncurried-default {A = A} {B = B} .Uncurried.Cod = B
+  Uncurried-default {A = A} {B = B} .Uncurried.eqv = id≃
+```
+
+We expose a similar API for uncurrying.
+
+```agda
+Uncurry : ∀ {ℓ ℓd ℓf} → (A : Type ℓ) → ⦃ C : Uncurried A ℓd ℓf ⦄ → Type (ℓd ⊔ ℓf)
+Uncurry A ⦃ C ⦄ = (x : Uncurried.Dom C) → Uncurried.Cod C x
+{-# NOINLINE Uncurry #-}
+
+uncurry!
+  : ∀ {ℓ ℓd ℓf}
+  → {A : Type ℓ}
+  → ⦃ C : Uncurried A ℓd ℓf ⦄
+  → A ≃ Uncurry A
+uncurry! ⦃ C ⦄ = Uncurried.eqv C e⁻¹
+{-# NOINLINE uncurry! #-}
+```

--- a/src/Data/Fin/CaseBash.lagda.md
+++ b/src/Data/Fin/CaseBash.lagda.md
@@ -1,0 +1,81 @@
+---
+description: |
+  Case bashing automation.
+---
+<!--
+```agda
+open import 1Lab.Type.Pi.Currying
+open import 1Lab.Prelude
+
+open import Data.List.Quantifiers
+open import Data.List.Membership
+open import Data.Fin.Finite
+open import Data.Bool.Base
+open import Data.List.Base
+open import Data.Dec.Base
+```
+-->
+```agda
+module Data.Fin.CaseBash where
+```
+
+# The case bash tactic
+
+In the 1Lab, we try to strive for the most elegant proofs possible.
+Unfortunately, sometimes the most elegant proof really is a giant
+proof-by-cases. These proofs are enlightening to read and tedious to
+write, and are a prime candidate for proof automation.
+
+Enter `case-bash!`{.Agda}. This tactic walks down a goal like
+$(x : A) \to (y : B x) \to \cdots$, and repeatedly case splits
+on each [[listable|listing]] type in the domain, and which point it
+gathers all of the resulting goals into a dependent list.
+
+Somewhat surprisingly, this can be implemented entirely using instance
+arguments! We first use the `Curried`{.Agda} typeclass to gather
+all of the arguments into a big Σ type. We then use instance resolution
+to try and find a `Listing`{.Agda} of that Σ-type, which
+will attempt to resolve `Listing`{.Agda} instances for all of the
+components. We then require proofs of the curried codomain for every
+single element in the listing of the curried codomain.
+
+```agda
+case-bash!
+  : ∀ {ℓ ℓd ℓf} {Goal : Type ℓ}
+  → ⦃ C : Curried Goal ℓd ℓf ⦄
+  → ⦃ ds : Listing (Curried.Dom C) ⦄
+  → All (Curried.Cod C) (Listing.univ ds)
+  → Goal
+```
+
+The type of the function is honestly more complicated then it's
+implementation, which just curries and then looks up proofs in a list.
+
+```agda
+case-bash! ⦃ C ⦄ ⦃ ds ⦄ proofs =
+  Equiv.to (Curried.eqv C) (λ ix → all-∈ proofs (Listing.find ds ix))
+```
+
+## Examples
+
+Now that we have our tactic, let's see some examples. The following
+bit of code proves commutativity of `and`{.Agda} via `case-bash!`.
+
+```agda
+private
+  and-comm-via-case-bash : ∀ (x y : Bool) → and x y ≡ and y x
+  and-comm-via-case-bash = case-bash! (refl ∷ refl ∷ refl ∷ refl ∷ [])
+```
+
+We can avoid writing a giant list of `refl`{.Agda} by using even more proof
+automation. The `decide!`{.Agda} tactic lets us use `Dec`{.Agda} instances
+to prove goals, and `All`{.Agda} has a `Dec`{.Agda} instance that tries
+to decide some predicate for every element of the list. This means that
+we can combine `case-bash!`{.Agda} and `decide!`{.Agda} to discharge the
+entire list of goals in one go, provided that every goal is decidable.
+
+```agda
+private
+  and-assoc-via-case-bash : ∀ (x y z : Bool) → and x (and y z) ≡ and (and x y) z
+  and-assoc-via-case-bash = case-bash! decide!
+```


### PR DESCRIPTION
# Description

This PR adds an instance-based `case-bash!` tactic, which lets us reduce goals like `(x : Bool) -> (y : Nat) -> ...` to 
an `All` of each of the pointwise goals. When combined with other proof automation like `decide!`, this lets us automate proofs that are big case bashes followed by all `refl`.
