### PR TITLE
Lifting Refactor

### DIFF
--- a/src/1Lab/Truncation.lagda.md
+++ b/src/1Lab/Truncation.lagda.md
@@ -222,6 +222,13 @@ from the HoTT book. For example, a type $X$ is said _merely equivalent_
 to $Y$ if the type $\| X \equiv Y \|$ is inhabited.
 :::
 
+<!--
+```agda
+is-prop∥∥→is-contr : ∀ {ℓ} {P : Type ℓ} → is-prop P → ∥ P ∥ → is-contr P
+is-prop∥∥→is-contr pprop mp = is-prop∙→is-contr pprop (∥-∥-out pprop mp)
+```
+-->
+
 ## Maps into sets
 
 The elimination principle for $\| A \|$ says that we can only use the

--- a/src/Borceux.lagda.md
+++ b/src/Borceux.lagda.md
@@ -10,6 +10,7 @@ open import Algebra.Group.Cat.Base
 open import Algebra.Group.Free hiding (_◆_)
 open import Algebra.Group.Ab
 
+open import Cat.Morphism.Factorisation.Orthogonal
 open import Cat.Diagram.Coequaliser.RegularEpi
 open import Cat.Functor.Adjoint.Epireflective
 open import Cat.Functor.Adjoint.Representable
@@ -954,9 +955,7 @@ _ = Localisation
 
 <!--
 ```agda
-_ = m⊥m
-_ = m⊥o
-_ = o⊥m
+_ = Orthogonal
 _ = object-orthogonal-!-orthogonal
 _ = in-subcategory→orthogonal-to-inverted
 _ = orthogonal-to-ηs→in-subcategory
@@ -966,8 +965,8 @@ _ = in-subcategory→orthogonal-to-ηs
 
 * Definition 5.4.1: `m⊥m`{.Agda}
 * Definition 5.4.2:
-  1. `m⊥o`{.Agda}
-  2. `o⊥m`{.Agda}
+  1. `Orthogonal`{.Agda}
+  2. `Orthogonal`{.Agda}
 * Proposition 5.4.3: `object-orthogonal-!-orthogonal`{.Agda}
 * Proposition 5.4.4:
   * 1.
@@ -978,7 +977,7 @@ _ = in-subcategory→orthogonal-to-ηs
 
 <!--
 ```agda
-_ = is-factorisation-system
+_ = is-ofs
 _ = factorisation-essentially-unique
 _ = E-is-⊥M
 _ = in-intersection≃is-iso
@@ -1116,5 +1115,3 @@ _ = const-nato
 * Exercise 8.4.6:
   * (⇒) `dependent-product→lcc`{.Agda}
   * (⇐) `lcc→dependent-product`{.Agda}
-
-[[marked graph homomorphism]]

--- a/src/Borceux.lagda.md
+++ b/src/Borceux.lagda.md
@@ -980,7 +980,7 @@ _ = in-subcategory→orthogonal-to-ηs
 ```agda
 _ = is-ofs
 _ = factorisation-essentially-unique
-_ = E-is-⊥M
+_ = L-is-⊥R
 _ = in-intersection≃is-iso
 ```
 -->

--- a/src/Borceux.lagda.md
+++ b/src/Borceux.lagda.md
@@ -90,6 +90,7 @@ open import Cat.Instances.Slice
 open import Cat.Functor.Closed
 open import Cat.Instances.Free
 open import Cat.Instances.Sets
+open import Cat.Morphism.Lifts
 open import Cat.Diagram.Monad
 open import Cat.Functor.Final
 open import Cat.Functor.Joint

--- a/src/Borceux.lagda.md
+++ b/src/Borceux.lagda.md
@@ -788,7 +788,7 @@ _ = Karoubi-is-completion
 ```agda
 _ = is-regular-epi
 _ = is-strong-epi
-_ = strong-epi-∘
+_ = ∘-is-strong-epic
 _ = strong-epi-cancelr
 _ = strong-epi+mono→invertible
 _ = is-regular-epi→is-strong-epi
@@ -801,7 +801,7 @@ _ = is-extremal-epi→is-strong-epi
 * Definition 4.3.1: `is-regular-epi`{.Agda}
 * Definition 4.3.5: `is-strong-epi`{.Agda}
 * Proposition 4.3.6:
-  * 1. `strong-epi-∘`{.Agda}
+  * 1. `∘-is-strong-epic`{.Agda}
   * 2. `strong-epi-cancelr`{.Agda}
   * 3. `strong-epi-mono→invertible`{.Agda}
   * 4. `is-regular-epi→is-strong-epi`{.Agda}

--- a/src/Cat/Bi/Instances/Relations.lagda.md
+++ b/src/Cat/Bi/Instances/Relations.lagda.md
@@ -201,10 +201,10 @@ into a subobject.]
   open Relation t renaming (src to t₁ ; tgt to t₂) hiding (rel)
 
   i : ∀ {x y} {f : Hom x y} → Hom im[ f ] y
-  i = factor _ .forget
+  i = factor _ .right
 
   q : ∀ {x y} {f : Hom x y} → Hom x im[ f ]
-  q = factor _ .mediate
+  q = factor _ .left
 
   ξ₁ = [rs]t.inter .p₁
   ξ₂ = [rs]t.inter .p₂
@@ -374,7 +374,7 @@ Since $q$ is a strong epi, $\alpha$ is, too.
     α-is-pb = pasting-outer→left-is-pullback ([rs]t.inter .has-is-pb) rem₁ ([rs]t.inter .p₂∘universal)
 
   α-cover : is-strong-epi C α
-  α-cover = stable _ _ (□-out! (factor rs.it .mediate∈E)) α-is-pb
+  α-cover = stable _ _ (factor rs.it .left∈L) α-is-pb
 ```
 
 The purpose of all this calculation is the following: Postcomposing with
@@ -433,7 +433,7 @@ want to look at the formalisation.
       (r[st].inter .p₁∘universal)
 
   β-cover : is-strong-epi C β
-  β-cover = stable _ _ (□-out! (factor st.it .mediate∈E)) β-is-pb
+  β-cover = stable _ _ (factor st.it .left∈L) β-is-pb
 
   r[st]≅i : Im r[st].it Sub.≅ Im j
   r[st]≅i = subst (λ e → Im r[st].it Sub.≅ Im e)
@@ -474,7 +474,7 @@ but keep in mind that they are not commented.
 ```agda
 ∘-rel-monotone {r = r} {r'} {s} {s'} α β =
   Im-universal (∘-rel.it r s) _
-    {e = factor _ .mediate ∘ ∘-rel.inter r' s' .universal
+    {e = factor _ .left ∘ ∘-rel.inter r' s' .universal
       {p₁' = β .map ∘ ∘-rel.inter _ _ .p₁}
       {p₂' = α .map ∘ ∘-rel.inter _ _ .p₂}
       ( pullr (pulll (sym (β .com) ∙ idl _))
@@ -497,7 +497,7 @@ but keep in mind that they are not commented.
     (assoc _ _ _)
 
   f≤fid : f ≤ₘ ∘-rel f id-rel
-  f≤fid .map = factor _ .mediate ∘
+  f≤fid .map = factor _ .left ∘
     ∘-rel.inter f id-rel .universal {p₁' = Relation.src f} {p₂' = id}
       (eliml π₂∘⟨⟩ ∙ intror refl)
   f≤fid .com = idl _ ∙ sym (pulll (sym (factor _ .factors)) ∙ ⟨⟩∘ _ ∙ sym (⟨⟩-unique
@@ -511,7 +511,7 @@ but keep in mind that they are not commented.
     (assoc _ _ _ ∙ ∘-rel.inter id-rel f .square ∙ eliml π₁∘⟨⟩ ∙ introl π₂∘⟨⟩)
 
   f≤idf : f ≤ₘ ∘-rel id-rel f
-  f≤idf .map = factor _ .mediate ∘
+  f≤idf .map = factor _ .left ∘
     ∘-rel.inter id-rel f .universal {p₁' = id} {p₂' = Relation.tgt f}
       (idr _ ∙ sym (eliml π₁∘⟨⟩))
   f≤idf .com = idl _ ∙ sym (pulll (sym (factor _ .factors)) ∙ ⟨⟩∘ _ ∙ sym (⟨⟩-unique

--- a/src/Cat/Diagram/Coequaliser/RegularEpi.lagda.md
+++ b/src/Cat/Diagram/Coequaliser/RegularEpi.lagda.md
@@ -143,7 +143,7 @@ module _ {o ℓ oj ℓj}
   {C : Precategory o ℓ} {J : Precategory oj ℓj}
   {F : Functor J C}
   (∐Ob : has-coproducts-indexed-by C ⌞ J ⌟)
-  (∐Hom : has-coproducts-indexed-by C (Arrows J))
+  (∐Hom : has-coproducts-indexed-by C (Arrow J))
   (∐F : Colimit F)
   where
 ```

--- a/src/Cat/Diagram/Colimit/Base.lagda.md
+++ b/src/Cat/Diagram/Colimit/Base.lagda.md
@@ -578,10 +578,10 @@ module _ {o ℓ} {C : Precategory o ℓ} where
   colimit-as-coequaliser-of-coproduct
     : ∀ {oj ℓj} {J : Precategory oj ℓj}
     → has-coproducts-indexed-by C ⌞ J ⌟
-    → has-coproducts-indexed-by C (Arrows J)
+    → has-coproducts-indexed-by C (Arrow J)
     → has-coequalisers C
     → (F : Functor J C) → Colimit F
-  colimit-as-coequaliser-of-coproduct {oj} {ℓj} {J} has-Ob-cop has-Arrows-cop has-coeq F =
+  colimit-as-coequaliser-of-coproduct {oj} {ℓj} {J} has-Ob-cop has-Arrow-cop has-coeq F =
     to-colimit (to-is-colimit colim) where
 ```
 
@@ -616,15 +616,15 @@ and the second morphism to be the injection into the codomain component precompo
 
 ~~~{.quiver}
 \[\begin{tikzcd}
-	{\displaystyle \coprod_{(f : a \to b) : \text{Arrows}(\mathcal J)} F(a)} & {\displaystyle \coprod_{o : \text{Ob}(\mathcal J)} F(o)}
+	{\displaystyle \coprod_{(f : a \to b) : \text{Arrow}(\mathcal J)} F(a)} & {\displaystyle \coprod_{o : \text{Ob}(\mathcal J)} F(o)}
 	\arrow["{\iota_a}", shift left, from=1-1, to=1-2]
 	\arrow["{\iota_b \circ F(f)}"', shift right, from=1-1, to=1-2]
 \end{tikzcd}\]
 ~~~
 
 ```agda
-    Dom : Indexed-coproduct C {Idx = Arrows J} λ (a , b , f) → F₀ a
-    Dom = has-Arrows-cop _
+    Dom : Indexed-coproduct C {Idx = Arrow J} λ (a , b , f) → F₀ a
+    Dom = has-Arrow-cop _
 
     s t : C.Hom (Dom .ΣF) (Obs .ΣF)
     s = Dom .match λ (a , b , f) → Obs .ι b C.∘ F₁ f

--- a/src/Cat/Diagram/Limit/Base.lagda.md
+++ b/src/Cat/Diagram/Limit/Base.lagda.md
@@ -716,10 +716,10 @@ module _ {o ℓ} {C : Precategory o ℓ} where
   limit-as-equaliser-of-product
     : ∀ {oj ℓj} {J : Precategory oj ℓj}
     → has-products-indexed-by C ⌞ J ⌟
-    → has-products-indexed-by C (Arrows J)
+    → has-products-indexed-by C (Arrow J)
     → has-equalisers C
     → (F : Functor J C) → Limit F
-  limit-as-equaliser-of-product {oj} {ℓj} {J} has-Ob-prod has-Arrows-prod has-eq F =
+  limit-as-equaliser-of-product {oj} {ℓj} {J} has-Ob-prod has-Arrow-prod has-eq F =
     to-limit (to-is-limit lim) where
 ```
 
@@ -753,15 +753,15 @@ and the second morphism to be the projection of the domain postcomposed with $f$
 
 ~~~{.quiver}
 \[\begin{tikzcd}
-	{\displaystyle \prod_{o : \text{Ob}(\mathcal J)} F(o)} & {\displaystyle \prod_{(f : a \to b) : \text{Arrows}(\mathcal J)} F(b)}
+	{\displaystyle \prod_{o : \text{Ob}(\mathcal J)} F(o)} & {\displaystyle \prod_{(f : a \to b) : \text{Arrow}(\mathcal J)} F(b)}
 	\arrow["{\pi_b}", shift left, from=1-1, to=1-2]
 	\arrow["{F(f) \circ \pi_a}"', shift right, from=1-1, to=1-2]
 \end{tikzcd}\]
 ~~~
 
 ```agda
-    Cod : Indexed-product C {Idx = Arrows J} λ (a , b , f) → F₀ b
-    Cod = has-Arrows-prod _
+    Cod : Indexed-product C {Idx = Arrow J} λ (a , b , f) → F₀ b
+    Cod = has-Arrow-prod _
 
     s t : C.Hom (Obs .ΠF) (Cod .ΠF)
     s = Cod .tuple λ (a , b , f) → F₁ f C.∘ Obs .π a

--- a/src/Cat/Diagram/Limit/Finite.lagda.md
+++ b/src/Cat/Diagram/Limit/Finite.lagda.md
@@ -103,7 +103,7 @@ products).
   Finitely-complete→is-finitely-complete cat Flim finite =
     limit-as-equaliser-of-product
       (Cartesian→finite-products (Flim .terminal) (Flim .products) cat (finite .has-finite-Ob))
-      (Cartesian→finite-products (Flim .terminal) (Flim .products) cat (finite .has-finite-Arrows))
+      (Cartesian→finite-products (Flim .terminal) (Flim .products) cat (finite .has-finite-Arrow))
       (Flim .equalisers)
 
   is-finitely-complete→Finitely-complete

--- a/src/Cat/Diagram/Projective/Strong.lagda.md
+++ b/src/Cat/Diagram/Projective/Strong.lagda.md
@@ -7,6 +7,8 @@ description: |
 open import Cat.Diagram.Coproduct.Copower
 open import Cat.Diagram.Coproduct.Indexed
 open import Cat.Functor.Morphism
+open import Cat.Morphism.Class
+open import Cat.Morphism.Lifts
 open import Cat.Diagram.Zero
 open import Cat.Functor.Hom
 open import Cat.Prelude
@@ -61,10 +63,7 @@ a $s : P \to X$ such that $e \circ s = p$, as in the following diagram:
 
 ```agda
 is-strong-projective : (P : Ob) → Type _
-is-strong-projective P =
-  ∀ {X Y} (p : Hom P Y) (e : Hom X Y)
-  → is-strong-epi e
-  → ∃[ s ∈ Hom P X ] (e ∘ s ≡ p)
+is-strong-projective P = Lifts C P StrongEpis
 ```
 
 ::: warning
@@ -78,8 +77,8 @@ projective→strong-projective
   : ∀ {P}
   → is-projective P
   → is-strong-projective P
-projective→strong-projective pro p e e-strong =
-  pro p (record { mor = e ; epic = e-strong .fst })
+projective→strong-projective pro e e-strong p =
+  pro e (e-strong .fst) p
 ```
 
 ## A functorial definition
@@ -105,7 +104,7 @@ strong-projective→preserves-strong-epis
 ones for projective objects, so we omit the details.
 </summary>
 ```agda
-preserves-strong-epis→strong-projective {P = P} hom-epi {X = X} {Y = Y} p e e-strong =
+preserves-strong-epis→strong-projective {P = P} hom-epi {X} {Y} e e-strong p =
   epi→surjective (el! (Hom P X)) (el! (Hom P Y))
     (e ∘_)
     (λ {c} → hom-epi e-strong .fst {c = c})
@@ -113,7 +112,7 @@ preserves-strong-epis→strong-projective {P = P} hom-epi {X = X} {Y = Y} p e e-
 
 strong-projective→preserves-strong-epis {P = P} pro {X} {Y} {f = f} f-strong =
     surjective→strong-epi (el! (Hom P X)) (el! (Hom P Y)) (f ∘_) $ λ p →
-    pro p f f-strong
+    pro f f-strong p
 ```
 </details>
 
@@ -144,15 +143,15 @@ retract→strong-projective
 ones for projective objects.
 </summary>
 ```agda
-indexed-coproduct-strong-projective {P = P} {ι = ι} Idx-pro P-pro coprod {X = X} {Y = Y} p e e-strong = do
+indexed-coproduct-strong-projective {P = P} {ι = ι} Idx-pro P-pro coprod {X} {Y} e e-strong p = do
   s ← Idx-pro
         (λ i → Σ[ sᵢ ∈ Hom (P i) X ] (e ∘ sᵢ ≡ p ∘ ι i)) (λ i → hlevel 2)
-        (λ i → P-pro i (p ∘ ι i) e e-strong)
+        (λ i → P-pro i e e-strong (p ∘ ι i))
   pure (match (λ i → s i .fst) , unique₂ (λ i → pullr commute ∙ s i .snd))
   where open is-indexed-coproduct coprod
 
-retract→strong-projective P-pro s r p e e-strong = do
-  (t , t-factor) ← P-pro (p ∘ r .retract) e e-strong
+retract→strong-projective P-pro s r e e-strong p = do
+  (t , t-factor) ← P-pro e e-strong (p ∘ r .retract)
   pure (t ∘ s , pulll t-factor ∙ cancelr (r .is-retract))
 ```
 </details>

--- a/src/Cat/Displayed/Comprehension/Coproduct/Strong.lagda.md
+++ b/src/Cat/Displayed/Comprehension/Coproduct/Strong.lagda.md
@@ -71,7 +71,7 @@ module _
   strong-comprehension-coproducts : Type _
   strong-comprehension-coproducts =
     ∀ {Γ Δ} (x : E.Ob[ Γ ]) (a : D.Ob[ Γ Q.⨾ x ]) (b : D.Ob[ Δ ])
-    → m⊥m B (Q.πᶜ P.⨾ˢ ⟨ x , a ⟩) (P.πᶜ {x = b})
+    → Orthogonal B (Q.πᶜ P.⨾ˢ ⟨ x , a ⟩) (P.πᶜ {x = b})
 ```
 
 <!--
@@ -106,7 +106,7 @@ module _
   to-strong-comprehension-coproducts
     : make-strong-comprehension-coproducts
     → strong-comprehension-coproducts
-  to-strong-comprehension-coproducts mk x a b {u = u} {v = v} p =
+  to-strong-comprehension-coproducts mk x a b u v p =
     contr (∐-strong-elim _ _ p , ∐-strong-β p , ∐-strong-sub p) λ w →
        Σ-prop-path! $
        sym (∐-strong-η p (w .fst) (w .snd .fst) (w .snd .snd))
@@ -161,7 +161,7 @@ which are extremely rare.
       → σ ∘ (Q.πᶜ P.⨾ˢ ⟨ x , a ⟩) ≡ P.πᶜ ∘ ν
       → Hom (Γ P.⨾ ∐ x a) (Δ P.⨾ b)
     ∐-strong-elim {x = x} {a = a} {b = b} σ ν p =
-      strong x a b p .centre .fst
+      strong x a b _ _ p .centre .fst
 ```
 
 The upper-left triangle of the diagram gives us our $\beta$ law;
@@ -176,7 +176,7 @@ gives us the original substitution.
       → {σ : Hom (Γ P.⨾ ∐ x a) Δ} {ν : Hom (Γ Q.⨾ x P.⨾ a) (Δ P.⨾ b)}
       → (p : σ ∘ (Q.πᶜ P.⨾ˢ ⟨ x , a ⟩) ≡ P.πᶜ ∘ ν)
       → ∐-strong-elim σ ν p ∘ (Q.πᶜ P.⨾ˢ ⟨ x , a ⟩) ≡ ν
-    ∐-strong-β p = strong _ _ _ p .centre .snd .fst
+    ∐-strong-β p = strong _ _ _ _ _ p .centre .snd .fst
 ```
 
 The lower-right triangle describes how substitution interacts with
@@ -189,7 +189,7 @@ we recover the substitution from $\Gamma, \coprod X A \to \Delta$.
       → {σ : Hom (Γ P.⨾ ∐ x a) Δ} {ν : Hom (Γ Q.⨾ x P.⨾ a) (Δ P.⨾ b)}
       → (p : σ ∘ (Q.πᶜ P.⨾ˢ ⟨ x , a ⟩) ≡ P.πᶜ ∘ ν)
       → P.πᶜ ∘ ∐-strong-elim σ ν p ≡ σ
-    ∐-strong-sub p = strong _ _ _ p .centre .snd .snd
+    ∐-strong-sub p = strong _ _ _ _ _ p .centre .snd .snd
 ```
 
 Finally, uniqueness gives us an $\eta$; any other substitution that
@@ -206,7 +206,7 @@ eliminator.
       → P.πᶜ ∘ other ≡ σ
       → other ≡ ∐-strong-elim σ ν p
     ∐-strong-η p other β sub =
-      ap fst (sym $ strong _ _ _ p .paths (other , β , sub))
+      ap fst (sym $ strong _ _ _ _ _ p .paths (other , β , sub))
 ```
 
 Now, for some useful lemmas. If we eliminate by simply packaging up

--- a/src/Cat/Displayed/Comprehension/Coproduct/Strong.lagda.md
+++ b/src/Cat/Displayed/Comprehension/Coproduct/Strong.lagda.md
@@ -5,6 +5,7 @@ open import Cat.Displayed.Comprehension
 open import Cat.Displayed.Cartesian
 open import Cat.Morphism.Orthogonal
 open import Cat.Displayed.Base
+open import Cat.Morphism.Lifts
 open import Cat.Prelude
 
 import Cat.Reasoning

--- a/src/Cat/Displayed/Instances/Subobjects.lagda.md
+++ b/src/Cat/Displayed/Instances/Subobjects.lagda.md
@@ -302,13 +302,16 @@ module Sub {y} = Cr (Sub y)
 _≤ₘ_ : ∀ {y} (a b : Subobject y) → Type _
 _≤ₘ_ = ≤-over id
 
-≤ₘ→mono : ∀ {y} {a b : Subobject y} → a ≤ₘ b → a .dom ↪ b .dom
-≤ₘ→mono x .mor = x .map
-≤ₘ→mono {a = a} x .monic g h α = a .monic g h $
-  a .map ∘ g      ≡⟨ ap (_∘ g) (introl refl ∙ x .com) ∙ pullr refl ⟩
-  _ ∘ x .map ∘ g  ≡⟨ ap₂ _∘_ refl α ⟩
-  _ ∘ x .map ∘ h  ≡⟨ pulll (sym (x .com) ∙ idl _) ⟩
+≤ₘ→monic : ∀ {y} {a b : Subobject y} → (f : a ≤ₘ b) → is-monic (f .map)
+≤ₘ→monic {a = a} f g h α = a .monic g h $
+  a .map ∘ g      ≡⟨ ap (_∘ g) (introl refl ∙ f .com) ∙ pullr refl ⟩
+  _ ∘ f .map ∘ g  ≡⟨ ap₂ _∘_ refl α ⟩
+  _ ∘ f .map ∘ h  ≡⟨ pulll (sym (f .com) ∙ idl _) ⟩
   a .map ∘ h      ∎
+
+≤ₘ→mono : ∀ {y} {a b : Subobject y} → a ≤ₘ b → a .dom ↪ b .dom
+≤ₘ→mono f .mor = f .map
+≤ₘ→mono {a = a} f .monic = ≤ₘ→monic f
 
 cutₛ : ∀ {x y} {f : Hom x y} → is-monic f → Subobject y
 cutₛ x .dom   = _

--- a/src/Cat/Finite.lagda.md
+++ b/src/Cat/Finite.lagda.md
@@ -24,7 +24,7 @@ record is-finite-precategory {o ℓ} (D : Precategory o ℓ) : Type (o ⊔ ℓ) 
   constructor finite-cat
   field
     ⦃ has-finite-Ob ⦄ : Finite (Ob D)
-    ⦃ has-finite-Arrows ⦄ : Finite (Arrows D)
+    ⦃ has-finite-Arrow ⦄ : Finite (Arrow D)
 
 open is-finite-precategory
 ```

--- a/src/Cat/Functor/Adjoint/Conservative.lagda.md
+++ b/src/Cat/Functor/Adjoint/Conservative.lagda.md
@@ -126,7 +126,7 @@ strong epis.
       f-strong-epi =
         D.strong-epi-cancelr f (ε x) $
         D.subst-is-strong-epi (counit.is-natural x y f) $
-        D.strong-epi-∘ (ε y) (L.₁ (R.₁ f))
+        D.∘-is-strong-epic
           ε-strong-epi
           (D.invertible→strong-epi (L.F-map-invertible Rf-inv))
 ```

--- a/src/Cat/Functor/Adjoint/Epireflective.lagda.md
+++ b/src/Cat/Functor/Adjoint/Epireflective.lagda.md
@@ -138,7 +138,7 @@ is reflective!
       unit-strong-mono =
         C.strong-mono-cancell (R.₁ (L.₁ f)) (η x) $
         C.subst-is-strong-mono (unit.is-natural _ _ _) $
-        C.strong-mono-∘ (η (R.₀ a)) f
+        C.∘-is-strong-monic
           (C.invertible→strong-mono (is-reflective→unit-right-is-iso L⊣R reflective))
           f-strong-mono
 ```
@@ -361,7 +361,7 @@ diagram chase; we will spare the innocent reader the details.
       RL[e]-strong-epi =
         C.strong-epi-cancelr _ _ $
         C.subst-is-strong-epi (unit.is-natural _ _ _) $
-        C.strong-epi-∘ _ _
+        C.∘-is-strong-epic
           (C.invertible→strong-epi unit-im-invertible)
           e-strong-epi
 
@@ -386,7 +386,7 @@ diagram chase; we will spare the innocent reader the details.
       unit-strong-epi : C.is-strong-epi (η x)
       unit-strong-epi =
         C.subst-is-strong-epi (sym factors) $
-        C.strong-epi-∘ _ _
+        C.∘-is-strong-epic
           (C.invertible→strong-epi m-invertible)
           e-strong-epi
 ```

--- a/src/Cat/Functor/Adjoint/Epireflective.lagda.md
+++ b/src/Cat/Functor/Adjoint/Epireflective.lagda.md
@@ -156,7 +156,7 @@ that the unit is always epic.
   factor+strong-mono-unit-invertible→epireflective
     : is-reflective L⊣R
     → (∀ {x a} {f : C.Hom x (R.₀ a)} → C.is-strong-mono f → C.is-invertible (η x))
-    → (∀ {x y} → (f : C.Hom x y) → Factorisation C Epis C.StrongMonos f)
+    → (∀ {x y} → (f : C.Hom x y) → Factorisation C C.Epis C.StrongMonos f)
     → ∀ {x} → C.is-epic (η x)
 ```
 
@@ -303,7 +303,7 @@ when $L \dashv R$ is a strong epireflective category.
   factor+mono-unit-invertible→strong-epireflective
     : is-reflective L⊣R
     → (∀ {x a} {f : C.Hom x (R.₀ a)} → C.is-monic f → C.is-invertible (η x))
-    → (∀ {x y} → (f : C.Hom x y) → Factorisation C C.StrongEpis Monos f)
+    → (∀ {x y} → (f : C.Hom x y) → Factorisation C C.StrongEpis C.Monos f)
     → ∀ {x} → C.is-strong-epi (η x)
 
 ```

--- a/src/Cat/Functor/Adjoint/Epireflective.lagda.md
+++ b/src/Cat/Functor/Adjoint/Epireflective.lagda.md
@@ -10,6 +10,7 @@ open import Cat.Morphism.Factorisation
 open import Cat.Functor.Properties
 open import Cat.Functor.Adjoint
 open import Cat.Functor.Compose
+open import Cat.Morphism.Class
 open import Cat.Prelude
 
 import Cat.Morphism.Strong.Mono
@@ -89,19 +90,6 @@ module _
     module L = Cat.Functor.Reasoning L
     module R = Cat.Functor.Reasoning R
   open _⊣_ L⊣R
-
-  private
-    Epi : ∀ {a b} → C.Hom a b → Ω
-    Epi x = elΩ (C.is-epic x)
-
-    Mono : ∀ {a b} → C.Hom a b → Ω
-    Mono x = elΩ (C.is-monic x)
-
-    StrongEpi : ∀ {a b} → C.Hom a b → Ω
-    StrongEpi f = elΩ (C.is-strong-epi f)
-
-    StrongMono : ∀ {a b} → C.Hom a b → Ω
-    StrongMono f = elΩ (C.is-strong-mono f)
 ```
 -->
 
@@ -168,7 +156,7 @@ that the unit is always epic.
   factor+strong-mono-unit-invertible→epireflective
     : is-reflective L⊣R
     → (∀ {x a} {f : C.Hom x (R.₀ a)} → C.is-strong-mono f → C.is-invertible (η x))
-    → (∀ {x y} → (f : C.Hom x y) → Factorisation C Epi StrongMono f)
+    → (∀ {x y} → (f : C.Hom x y) → Factorisation C Epis C.StrongMonos f)
     → ∀ {x} → C.is-epic (η x)
 ```
 
@@ -199,11 +187,11 @@ diagram:
     unit-epic
     where
       open Factorisation (factor (η x)) renaming
-          ( mediating to im
-          ; forget to m
-          ; mediate to e
-          ; forget∈M to m-strong-mono
-          ; mediate∈E to e-epi
+          ( mid to im
+          ; right to m
+          ; left to e
+          ; right∈R to m-strong-mono
+          ; left∈L to e-epi
           )
 ```
 
@@ -213,7 +201,7 @@ be invertible, as $m : \cC(I, R(L(X)))$ is a strong mono.
 ```agda
       unit-im-invertible : C.is-invertible (η im)
       unit-im-invertible =
-        unit-inv (□-out! m-strong-mono)
+        unit-inv (m-strong-mono)
 ```
 
 Next, observe that $R(L(m)) \circ R(L(e))$ must also be invertible:
@@ -252,7 +240,7 @@ right-cancellation of epis to deduce that $R(L(e))$ must be epic.
         C.subst-is-epic (unit.is-natural _ _ _) $
         C.∘-is-epic
           (C.invertible→epic unit-im-invertible)
-          (□-out! e-epi)
+          e-epi
 ```
 
 We can put the previous two observations together to show that
@@ -296,7 +284,7 @@ so it must also be an epi.
         C.subst-is-epic (sym factors) $
         C.∘-is-epic
           (C.invertible→epic m-invertible)
-          (□-out! e-epi)
+          e-epi
 ```
 
 ## Strong epireflective subcategories and monos
@@ -315,7 +303,7 @@ when $L \dashv R$ is a strong epireflective category.
   factor+mono-unit-invertible→strong-epireflective
     : is-reflective L⊣R
     → (∀ {x a} {f : C.Hom x (R.₀ a)} → C.is-monic f → C.is-invertible (η x))
-    → (∀ {x y} → (f : C.Hom x y) → Factorisation C StrongEpi Mono f)
+    → (∀ {x y} → (f : C.Hom x y) → Factorisation C C.StrongEpis Monos f)
     → ∀ {x} → C.is-strong-epi (η x)
 
 ```
@@ -345,16 +333,16 @@ diagram chase; we will spare the innocent reader the details.
     unit-strong-epi
     where
       open Factorisation (factor (η x)) renaming
-          ( mediating to im
-          ; forget to m
-          ; mediate to e
-          ; forget∈M to m-mono
-          ; mediate∈E to e-strong-epi
+          ( mid to im
+          ; right to m
+          ; left to e
+          ; right∈R to m-mono
+          ; left∈L to e-strong-epi
           )
 
       unit-im-invertible : C.is-invertible (η im)
       unit-im-invertible =
-        unit-inv (□-out! m-mono)
+        unit-inv m-mono
 
       RL[m]∘RL[e]-invertible
         : C.is-invertible (R.₁ (L.₁ m) C.∘ R.₁ (L.₁ e))
@@ -375,7 +363,7 @@ diagram chase; we will spare the innocent reader the details.
         C.subst-is-strong-epi (unit.is-natural _ _ _) $
         C.strong-epi-∘ _ _
           (C.invertible→strong-epi unit-im-invertible)
-          (□-out! e-strong-epi)
+          e-strong-epi
 
       RL[e]-invertible : C.is-invertible (R.₁ (L.₁ e))
       RL[e]-invertible =
@@ -400,6 +388,6 @@ diagram chase; we will spare the innocent reader the details.
         C.subst-is-strong-epi (sym factors) $
         C.strong-epi-∘ _ _
           (C.invertible→strong-epi m-invertible)
-          (□-out! e-strong-epi)
+          e-strong-epi
 ```
 </details>

--- a/src/Cat/Functor/Amnestic.lagda.md
+++ b/src/Cat/Functor/Amnestic.lagda.md
@@ -49,7 +49,7 @@ An isomorphism $f : a \cong b$ **is an identity** if it is an identity
 in the total space of `Hom`{.Agda}, i.e. if there is an object $c : \cC$
 s.t. $(c, c, \id) = (a, b, f)$ in the type $\Sigma_a \Sigma_b (a \to b)$.
 Every isomorphism in a [[univalent category]] is an identity, since we can
-take $c = a$, and the identification in `Arrows`{.Agda} follows from
+take $c = a$, and the identification in `Arrow`{.Agda} follows from
 univalence.
 
 <!--
@@ -107,9 +107,9 @@ now in $\cD$. But because $\cD$ is a univalent category, $Fi$ is
 an identity, and by $F$'s amnesia, so is $i$.
 
 ```agda
-      p : Σ[ c ∈ C ] Path (Arrows C) (c , c , C.id) (A , B , isom .C.to)
+      p : Σ[ c ∈ C ] Path (Arrow C) (c , c , C.id) (A , B , isom .C.to)
       p = equiv→inverse (forget (isom .C.to) (C.iso→invertible isom)) $ F.₀ A ,
-        Arrows-path D refl (d-cat .to-path isom')
+        Arrow-path D refl (d-cat .to-path isom')
           (Univalent.Hom-pathp-reflr-iso d-cat (D.idr _))
 ```
 

--- a/src/Cat/Instances/Shape/Interval.lagda.md
+++ b/src/Cat/Instances/Shape/Interval.lagda.md
@@ -14,7 +14,6 @@ open import Order.Cat
 import Cat.Reasoning as Cat
 
 import Order.Reasoning as Poset
-
 ```
 -->
 

--- a/src/Cat/Instances/Shape/Interval.lagda.md
+++ b/src/Cat/Instances/Shape/Interval.lagda.md
@@ -114,24 +114,24 @@ private variable
 -->
 
 ```agda
-Arrows : Precategory o ℓ → Type (o ⊔ ℓ)
-Arrows C = Σ[ A ∈ C ] Σ[ B ∈ C ] (C.Hom A B)
+Arrow : Precategory o ℓ → Type (o ⊔ ℓ)
+Arrow C = Σ[ A ∈ C ] Σ[ B ∈ C ] (C.Hom A B)
   where module C = Precategory C
 ```
 
 <!--
 ```agda
 module _ (C : Precategory o ℓ) where
-  Hom→Arrow : {a b : Ob C} → Hom C a b → Arrows C
+  Hom→Arrow : {a b : Ob C} → Hom C a b → Arrow C
   Hom→Arrow f = _ , _ , f
 
-  Arrows-path
-    : {a b : Arrows C}
+  Arrow-path
+    : {a b : Arrow C}
     → (p : a .fst ≡ b .fst)
     → (q : a .snd .fst ≡ b .snd .fst)
     → PathP (λ i → Hom C (p i) (q i)) (a .snd .snd) (b .snd .snd)
     → a ≡ b
-  Arrows-path p q r i = p i , q i , r i
+  Arrow-path p q r i = p i , q i , r i
 ```
 -->
 
@@ -143,7 +143,7 @@ arrows $\Arr{\cC}$, as defined above, and the space of functors $[
 module _ {C : Precategory o ℓ} where
   import Cat.Reasoning C as C
 
-  arrow→functor : Arrows C → Functor 0≤1 C
+  arrow→functor : Arrow C → Functor 0≤1 C
   arrow→functor (A , B , f) = fun where
     fun : Functor _ _
     fun .F₀ false = A
@@ -170,7 +170,7 @@ the non-trivial arrow $0 \le 1$ maps to, and the domain/codomain can be
 inferred by Agda.
 
 ```agda
-  functor→arrow : Functor 0≤1 C → Arrows C
+  functor→arrow : Functor 0≤1 C → Arrow C
   functor→arrow F = _ , _ , F .F₁ {false} {true} _
 ```
 

--- a/src/Cat/Morphism.lagda.md
+++ b/src/Cat/Morphism.lagda.md
@@ -2,6 +2,7 @@
 ```agda
 open import 1Lab.Prelude hiding (_∘_ ; id ; _↪_ ; _↠_)
 
+open import Cat.Morphism.Class
 open import Cat.Solver
 open import Cat.Base
 ```
@@ -50,6 +51,14 @@ open _↪_ public
 
 <!--
 ```agda
+Monos : Arrows C (o ⊔ h)
+Monos .arrows = is-monic
+Monos .is-tr = hlevel 1
+```
+-->
+
+<!--
+```agda
 Factors : ∀ {A B C} (f : Hom A C) (g : Hom B C) → Type _
 Factors f g = Σ[ h ∈ Hom _ _ ] (f ≡ g ∘ h)
 ```
@@ -76,6 +85,14 @@ record _↠_ (a b : Ob) : Type (o ⊔ h) where
 
 open _↠_ public
 ```
+
+<!--
+```agda
+Epis : Arrows C (o ⊔ h)
+Epis .arrows = is-epic
+Epis .is-tr = hlevel 1
+```
+-->
 
 The identity morphism is monic and epic.
 
@@ -531,6 +548,14 @@ is-invertible-is-prop {a = a} {b = b} {f = f} g h = p where
   p i .is-invertible.inverses =
     is-prop→pathp (λ i → Inverses-are-prop {g = g≡h i}) g.inverses h.inverses i
 ```
+
+<!--
+```agda
+Isos : Arrows C h
+Isos .arrows = is-invertible
+Isos .is-tr = is-invertible-is-prop
+```
+-->
 
 We note that the identity morphism is always iso, and that isos compose:
 

--- a/src/Cat/Morphism/Class.lagda.md
+++ b/src/Cat/Morphism/Class.lagda.md
@@ -26,15 +26,15 @@ arguments, so passing around functions like `∀ {x y} → Hom x y → Ω`
 as first-class objects can often lead to unsolved metavariable errors.
 
 To work around this, we define a class of morphisms in a category $\cC$
-as a single-field record type. This avoids the implicit instantiating
-issue from before, at the cost of a bit of code bloat.
+as a record type. This avoids the implicit instantiation issue from before,
+at the cost of a bit of code bloat.
 
 ```agda
 record Arrows {o ℓ} (C : Precategory o ℓ) (κ : Level) : Type (o ⊔ ℓ ⊔ lsuc κ) where
   no-eta-equality
   field
     arrows : ∀ {x y} → Precategory.Hom C x y → Type κ
-    is-tr : ∀  {x y} {f : Precategory.Hom C x y} → is-prop (arrows f)
+    is-tr  : ∀ {x y} {f : Precategory.Hom C x y} → is-prop (arrows f)
 
 open Arrows public
 ```

--- a/src/Cat/Morphism/Class.lagda.md
+++ b/src/Cat/Morphism/Class.lagda.md
@@ -7,10 +7,7 @@ description: |
 open import 1Lab.Reflection
 open import 1Lab.Prelude hiding (_∘_ ; id ; _↪_ ; _↠_)
 
-open import Cat.Morphism.Instances
 open import Cat.Base
-
-import Cat.Morphism
 ```
 -->
 ```agda
@@ -60,7 +57,7 @@ instance
 {-# DISPLAY Arrows.arrows S f = f ∈ S #-}
 
 module _ {o ℓ} {C : Precategory o ℓ} where
-  open Cat.Morphism C
+  open Precategory C
 
   instance
     Membership-Arrows : ∀ {κ} {x y} → Membership (Hom x y) (Arrows C κ) κ
@@ -99,21 +96,6 @@ module _ {o ℓ} {C : Precategory o ℓ} where
 ```
 -->
 
-We also take the time define classes of morphisms for monos, epis, and isos.
-
-```agda
-  Monos : Arrows C (o ⊔ ℓ)
-  Monos .arrows = is-monic
-  Monos .is-tr = hlevel 1
-
-  Epis : Arrows C (o ⊔ ℓ)
-  Epis .arrows = is-epic
-  Epis .is-tr = hlevel 1
-
-  Isos : Arrows C ℓ
-  Isos .arrows = is-invertible
-  Isos .is-tr = hlevel 1
-```
 
 We can take intersections of morphism classes.
 

--- a/src/Cat/Morphism/Class.lagda.md
+++ b/src/Cat/Morphism/Class.lagda.md
@@ -1,0 +1,116 @@
+---
+description: |
+  Classes of morphisms.
+---
+<!--
+```agda
+open import 1Lab.Reflection
+open import 1Lab.Prelude hiding (_∘_ ; id ; _↪_ ; _↠_)
+
+open import Cat.Morphism.Instances
+open import Cat.Base
+
+import Cat.Morphism
+```
+-->
+```agda
+module Cat.Morphism.Class where
+```
+
+
+# Classes of morphisms
+
+When defining [[factorisation systems|orthogonal-factorisation-system]] and
+lifting properties, we need to consider collections of morphisms in a category
+$\cC$. Such collections can be naively encoded in Agda as a function
+`∀ {x y} → Hom x y → Ω`, but this representation is somewhat suboptimal.
+Agda is quite aggressive about automatically instantiating implicit
+arguments, so passing around functions like `∀ {x y} → Hom x y → Ω`
+as first-class objects can often lead to unsolved metavariable errors.
+
+To work around this, we define a class of morphisms in a category $\cC$
+as a single-field record type. This avoids the implicit instantiating
+issue from before, at the cost of a bit of code bloat.
+
+```agda
+record Arrows {o ℓ} (C : Precategory o ℓ) (κ : Level) : Type (o ⊔ ℓ ⊔ lsuc κ) where
+  no-eta-equality
+  field
+    arrows : ∀ {x y} → Precategory.Hom C x y → Type κ
+    is-tr : ∀  {x y} {f : Precategory.Hom C x y} → is-prop (arrows f)
+
+open Arrows public
+```
+
+<!--
+```agda
+{-# INLINE Arrows.constructor #-}
+
+instance
+  open hlevel-projection
+
+  Arrows-hlevel-proj : hlevel-projection (quote Arrows.arrows)
+  Arrows-hlevel-proj .has-level = quote Arrows.is-tr
+  Arrows-hlevel-proj .get-level _ = pure (lit (nat 1))
+  Arrows-hlevel-proj .get-argument (_ ∷ _ ∷ _ ∷ _ ∷ arg _ h ∷ _) = pure h
+  {-# CATCHALL #-}
+  Arrows-hlevel-proj .get-argument _ = typeError []
+
+
+{-# DISPLAY Arrows.arrows S f = f ∈ S #-}
+
+module _ {o ℓ} {C : Precategory o ℓ} where
+  open Cat.Morphism C
+
+  instance
+    Membership-Arrows : ∀ {κ} {x y} → Membership (Hom x y) (Arrows C κ) κ
+    Membership-Arrows = record { _∈_ = λ f S → Arrows.arrows S f }
+
+    Inclusion-Arrows : ∀ {κ} → Inclusion (Arrows C κ) (o ⊔ ℓ ⊔ κ)
+    Inclusion-Arrows = record { _⊆_ = λ S T → ∀ {x y} → (f : Hom x y) → f ∈ S → f ∈ T }
+
+    Funlike-Arrows : ∀ {κ} {x y} → Funlike (Arrows C κ) (Hom x y) λ _ → Prop κ
+    Funlike-Arrows = record { _·_ = λ S f → el (S .arrows f) (S .is-tr) }
+
+  private
+    unquoteDecl arrows-iso = declare-record-iso arrows-iso (quote Arrows)
+
+  Arrows≃ : ∀ {κ} → Arrows C κ ≃ (∀ {x y} → Hom x y → Prop κ)
+  Arrows≃ .fst S f = el! (f ∈ S)
+  Arrows≃ .snd = is-iso→is-equiv λ where
+    .is-iso.from S → record { arrows = λ f → f ∈ S ; is-tr = hlevel 1 }
+    .is-iso.rinv S → ext (λ x → n-path refl)
+    .is-iso.linv S → Iso.injective arrows-iso (refl ,ₚ prop!)
+
+  instance
+    Extensional-Arrows
+      : ∀ {κ ℓr} ⦃ _ : Extensional (∀ {x y} → Hom x y → Type κ) ℓr ⦄
+      → Extensional (Arrows C κ) ℓr
+    Extensional-Arrows {κ = κ} ⦃ e ⦄ = embedding→extensional (arrows , emb) e where abstract
+      emb : is-embedding (Arrows.arrows {C = C} {κ = κ})
+      emb = ∘-is-embedding {f = λ f g → g ∈ f} {g = Arrows≃ .fst}
+        (cancellable→embedding
+          ( (λ h → ext λ f → n-path λ i → h i f)
+          , is-iso→is-equiv (iso (λ x i g → ⌞ x i g ⌟)
+              (λ p i j f → n-Type-square {p = refl} {n-path (λ i → ⌞ p i f ⌟)} {λ i → p i f} {refl} refl i j)
+              λ h → refl)
+          ))
+        (is-equiv→is-embedding (Arrows≃ .snd))
+```
+-->
+
+Finally, we define classes of morphisms for monos, epis, and isos.
+
+```agda
+  Monos : Arrows C (o ⊔ ℓ)
+  Monos .arrows = is-monic
+  Monos .is-tr = hlevel 1
+
+  Epis : Arrows C (o ⊔ ℓ)
+  Epis .arrows = is-epic
+  Epis .is-tr = hlevel 1
+
+  Isos : Arrows C ℓ
+  Isos .arrows = is-invertible
+  Isos .is-tr = hlevel 1
+```

--- a/src/Cat/Morphism/Class.lagda.md
+++ b/src/Cat/Morphism/Class.lagda.md
@@ -99,7 +99,7 @@ module _ {o ℓ} {C : Precategory o ℓ} where
 ```
 -->
 
-Finally, we define classes of morphisms for monos, epis, and isos.
+We also take the time define classes of morphisms for monos, epis, and isos.
 
 ```agda
   Monos : Arrows C (o ⊔ ℓ)
@@ -113,4 +113,12 @@ Finally, we define classes of morphisms for monos, epis, and isos.
   Isos : Arrows C ℓ
   Isos .arrows = is-invertible
   Isos .is-tr = hlevel 1
+```
+
+We can take intersections of morphism classes.
+
+```agda
+  _∩ₐ_ : ∀ {κ κ'} → Arrows C κ → Arrows C κ' → Arrows C (κ ⊔ κ')
+  (S ∩ₐ T) .arrows f = f ∈ S × f ∈ T
+  (S ∩ₐ T) .is-tr = hlevel 1
 ```

--- a/src/Cat/Morphism/Factorisation.lagda.md
+++ b/src/Cat/Morphism/Factorisation.lagda.md
@@ -72,8 +72,8 @@ monic.
     → (f-fac : Factorisation C L R f)
     → C.is-monic f
     → C.is-monic (f-fac .left)
-  factor-monic→left-monic {f = f} f-fac f-monic =
-    C.monic-cancell $ C.subst-is-monic (f-fac .factors) f-monic
+  factor-monic→left-monic {f = f} f-fac f-monic = C.monic-cancell $
+    C.subst-is-monic (f-fac .factors) f-monic
 ```
 
 If $f$ is [[epic]] and factors as $f = r \circ l$, then $r$ must also be
@@ -85,6 +85,6 @@ epic.
     → (f-fac : Factorisation C L R f)
     → C.is-epic f
     → C.is-epic (f-fac .right)
-  factor-epic→right-epic {f = f} f-fac f-epic =
-    C.epic-cancelr $ C.subst-is-epic (f-fac .factors) f-epic
+  factor-epic→right-epic {f = f} f-fac f-epic = C.epic-cancelr $
+    C.subst-is-epic (f-fac .factors) f-epic
 ```

--- a/src/Cat/Morphism/Factorisation.lagda.md
+++ b/src/Cat/Morphism/Factorisation.lagda.md
@@ -1,305 +1,47 @@
+---
+description: |
+  Factorisations of morphisms.
+---
 <!--
 ```agda
-open import Cat.Morphism.Orthogonal
+open import Cat.Morphism.Class
 open import Cat.Prelude
-
-open import Data.Power
 
 import Cat.Reasoning
 ```
 -->
-
 ```agda
 module Cat.Morphism.Factorisation where
 ```
 
-# Orthogonal factorisation systems {defines="orthogonal-factorisation-system"}
-
-Suppose you have some category $\cC$ and you, inspired by the wisdom
-of King Solomon, want to chop every morphism in half. A **factorisation
-system** $(E, M)$ on $\cC$ will provide a tool for doing so, in a
-particularly coherent way. Here, $E$ and $M$ are predicates on the space
-of morphisms of $C$. First, we package the data of an $(E,
-M)$-factorisation of a morphism $f : a \to b$.
+# Factorisations
 
 <!--
 ```agda
-module _ {o ℓ} (C : Precategory o ℓ)
-         (E : ∀ {a b} → C .Precategory.Hom a b → Ω)
-         (M : ∀ {a b} → C .Precategory.Hom a b → Ω) where
+module _
+  {o ℓ ℓl ℓr}
+  (C : Precategory o ℓ)
+  (L : Arrows C ℓl)
+  (R : Arrows C ℓr)
+  where
   private module C = Cat.Reasoning C
 ```
 -->
 
-Note that while the archetype for a factorisation system is the (epi,
-mono)-factorisation system on the category of sets^[Or, more generally,
-in every topos.], so that it's very hard _not_ to refer to these things
-as images, it is _not_ the case, in general, nothing is required about
-the interaction of epis and monos with the classes $E$ and $M$.
-Generically, we call the $E$-morphism in the factorisation
-`mediate`{.Agda}, and the $M$-morphism `forget`{.Agda}.
+:::{.definition #factorisation}
+Let $L, R \subseteq C$ be two classes of morphisms of $\cC$.
+An $(L,R)$ **factorisation** of a morphism $f : \cC(X,Y)$ consists
+of an object $Im : \cC$ and a pair of morphisms $l : \cC(X,M), r : \cC(M,Y)$
+such that $l \in L$, $r \in R$, and $f = r \circ l$.
+:::
 
 ```agda
-  record Factorisation {a b} (f : C.Hom a b) : Type (o ⊔ ℓ) where
+  record Factorisation {a b} (f : C.Hom a b) : Type (o ⊔ ℓ ⊔ ℓl ⊔ ℓr) where
     field
-      mediating : C.Ob
-      mediate   : C.Hom a mediating
-      forget    : C.Hom mediating b
-      mediate∈E : mediate ∈ E
-      forget∈M  : forget ∈ M
-      factors   : f ≡ forget C.∘ mediate
-```
-
-In addition to mandating that every map $f : a \to b$ factors as a map
-$f : a \xto{e} r(f) \xto{m}$ where $e \in E$ and $m \in M$, the classes
-must satisfy the following properties:
-
-- Every isomorphism is in both $E$ and in $M$.^[We'll see, in a bit, that
-the converse is true, too.]
-
-- Both classes are stable under composition: if $f \in E$ and $g \in E$,
-then $(g \circ f) \in E$ and the same for $M$
-
-```agda
-  record is-factorisation-system : Type (o ⊔ ℓ) where
-    field
-      factor : ∀ {a b} (f : C.Hom a b) → Factorisation f
-
-      is-iso→in-E : ∀ {a b} (f : C.Hom a b) → C.is-invertible f → f ∈ E
-      E-is-stable
-        : ∀ {a b c} (g : C.Hom b c) (f : C.Hom a b) → f ∈ E → g ∈ E
-        → (g C.∘ f) ∈ E
-
-      is-iso→in-M : ∀ {a b} (f : C.Hom a b) → C.is-invertible f → f ∈ M
-      M-is-stable
-        : ∀ {a b c} (g : C.Hom b c) (f : C.Hom a b) → f ∈ M → g ∈ M
-        → (g C.∘ f) ∈ M
-```
-
-Most importantly, the class $E$ is exactly the class of morphisms
-left-orthogonal to $M$: A map satisfies $f \in E$ if, and only if, for
-every $g \in M$, we have $f \ortho g$. Conversely, a map has $g \in M$
-if, and only if, we have $f \ortho g$ for every $f \in E$.
-
-```agda
-      E⊥M : ∀ {a b c d} (f : C.Hom a b) (g : C.Hom c d) → f ∈ E → g ∈ M
-          → m⊥m C f g
-```
-
-<!--
-```agda
-module
-  _ {o ℓ} (C : Precategory o ℓ) (E M : ∀ {a b} → ℙ (C .Precategory.Hom a b))
-    (fs : is-factorisation-system C E M)
-    where
-
-  private module C = Cat.Reasoning C
-  open is-factorisation-system fs
-  open Factorisation
-```
--->
-
-The first thing we observe is that factorisations for a morphism are
-unique. Working in precategorical generality, we weaken this to
-essential uniqueness: Given two factorisations of $f$ we exhibit an
-isomorphism between their replacements $r(f)$, $r'(f)$ which commutes
-with both the `mediate`{.Agda} morphism and the `forget`{.Agda}
-morphism. We reproduce the proof from [@Borceux:vol1, §5.5].
-
-```agda
-  factorisation-essentially-unique
-    : ∀ {a b} (f : C.Hom a b) (fa1 fa2 : Factorisation C E M f)
-    → Σ[ f ∈ fa1 .mediating C.≅ fa2 .mediating ]
-        ( (f .C.to C.∘ fa1 .mediate ≡ fa2 .mediate)
-        × (fa1 .forget C.∘ f .C.from ≡ fa2 .forget))
-  factorisation-essentially-unique f fa1 fa2 =
-    C.make-iso (upq .fst) (vp'q' .fst) vu=id uv=id , upq .snd .fst , vp'q' .snd .snd
-    where
-```
-
-Suppose that $f = m \circ e$ and $f = m' \circ e'$ are both
-$(E,M)$-factorisations of $f$. We use the fact that $e \ortho m'$ and
-$e' \ortho m$ to get maps $u, v$ satisfying $um = m'$, $m'u = m$, $ve =
-e'$, and $e'v = e$.
-
-```agda
-      module fa1 = Factorisation fa1
-      module fa2 = Factorisation fa2
-
-      upq = E⊥M fa1.mediate fa2.forget fa1.mediate∈E fa2.forget∈M
-        (sym fa1.factors ∙ fa2.factors) .centre
-
-      vp'q' = E⊥M fa2.mediate fa1.forget fa2.mediate∈E fa1.forget∈M
-        (sym fa2.factors ∙ fa1.factors) .centre
-```
-
-To show that $u$ and $v$ are inverses, fit first $e$ and $m$ into a
-lifting diagram like the one below. Since $e \ortho m$, we have that the
-space of diagonals $r(f) \to r(f)$ is contractible, hence a proposition,
-and since both $vu$ and the identity are in that diagonal, $uv =
-\id$.
-
-~~~{.quiver}
-\[\begin{tikzcd}
-  a && {r(f)} \\
-  \\
-  {r(f)} && b
-  \arrow["e", from=1-1, to=1-3]
-  \arrow["m"', from=3-1, to=3-3]
-  \arrow["e"', from=1-1, to=3-1]
-  \arrow["m", from=1-3, to=3-3]
-	\arrow["{\mathrm{id}}"', shift right=1, from=1-3, to=3-1]
-	\arrow["vu", shift left=1, from=1-3, to=3-1]
-\end{tikzcd}\]
-~~~
-
-```agda
-      vu=id : upq .fst C.∘ vp'q' .fst ≡ C.id
-      vu=id = ap fst $ is-contr→is-prop
-        (E⊥M fa2.mediate fa2.forget fa2.mediate∈E fa2.forget∈M refl)
-        ( upq .fst C.∘ vp'q' .fst
-        , C.pullr (vp'q' .snd .fst) ∙ upq .snd .fst
-        , C.pulll (upq .snd .snd) ∙ vp'q' .snd .snd
-        ) (C.id , C.idl _ , C.idr _)
-```
-
-A dual argument works by making a lifting square with $e'$ and $m'$ as
-its faces. We omit it for brevity.  By the characterisation of path
-spaces in categories, this implies that factorisations of a fixed
-morphism are a proposition.
-
-<!--
-```agda
-      uv=id : vp'q' .fst C.∘ upq .fst ≡ C.id
-      uv=id = ap fst $ is-contr→is-prop
-        (E⊥M fa1.mediate fa1.forget fa1.mediate∈E fa1.forget∈M refl)
-        ( vp'q' .fst C.∘ upq .fst
-        , C.pullr (upq .snd .fst) ∙ vp'q' .snd .fst
-        , C.pulll (vp'q' .snd .snd) ∙ upq .snd .snd
-        ) (C.id , C.idl _ , C.idr _)
-```
--->
-
-```agda
-  factorisation-unique
-    : ∀ {a b} (f : C.Hom a b) → is-category C → is-prop (Factorisation C E M f)
-  factorisation-unique f c-cat x y = go where
-    isop1p2 = factorisation-essentially-unique f x y
-
-    p = Univalent.Hom-pathp-reflr-iso c-cat {q = isop1p2 .fst} (isop1p2 .snd .fst)
-    q = Univalent.Hom-pathp-refll-iso c-cat {p = isop1p2 .fst} (isop1p2 .snd .snd)
-
-    go : x ≡ y
-    go i .mediating = c-cat .to-path (isop1p2 .fst) i
-    go i .mediate = p i
-    go i .forget = q i
-```
-
-<!--
-```agda
-    go i .mediate∈E = is-prop→pathp (λ i → E (p i) .is-tr) (x .mediate∈E) (y .mediate∈E) i
-    go i .forget∈M = is-prop→pathp (λ i → M (q i) .is-tr) (x .forget∈M) (y .forget∈M) i
-    go i .factors =
-      is-prop→pathp (λ i → C.Hom-set _ _ f (q i C.∘ p i)) (x .factors) (y .factors) i
-```
--->
-
-As a passing observation, note that the intersection $E \cap M$ is
-precisely the class of isomorphisms of $f$. Every isomorphism is in both
-classes, by the definition, and if a morphism is in both classes, it is
-orthogonal to itself, hence an isomorphism.
-
-```agda
-  in-intersection→is-iso
-    : ∀ {a b} (f : C.Hom a b) → f ∈ E → f ∈ M → C.is-invertible f
-  in-intersection→is-iso f f∈E f∈M = self-orthogonal→invertible C f $ E⊥M f f f∈E f∈M
-
-  in-intersection≃is-iso
-    : ∀ {a b} (f : C.Hom a b) → C.is-invertible f ≃ ((f ∈ E) × (f ∈ M))
-  in-intersection≃is-iso f = prop-ext!
-    (λ fi → is-iso→in-E f fi , is-iso→in-M f fi)
-    λ { (a , b) → in-intersection→is-iso f a b }
-```
-
-The final observation is that the class $E$ is precisely $^\bot M$, the
-class of morphisms left-orthogonal to those in $M$. One direction is by
-definition, and the other is rather technical. Let's focus on the
-technical one.
-
-```agda
-  E-is-⊥M
-    : ∀ {a b} (f : C.Hom a b)
-    → (f ∈ E) ≃ (∀ {c d} (m : C.Hom c d) → m ∈ M → m⊥m C f m)
-  E-is-⊥M f =
-    prop-ext (E f .is-tr) (hlevel 1) (λ m f∈E m∈M → to f∈E m m∈M) from
-    where
-      to : ∀ {c d} (m : C.Hom c d) → f ∈ E → m ∈ M → m⊥m C f m
-      to m f∈E m∈M {u} {v} square = E⊥M f m f∈E m∈M square
-
-      from : (∀ {c d} (m : C.Hom c d) → m ∈ M → m⊥m C f m) → f ∈ E
-      from ortho = subst (_∈ E) (sym fa.factors) $ E-is-stable _ _ fa.mediate∈E m∈E
-        where
-```
-
-Suppose that $f$ is left-orthogonal to every $m \in M$, and write out
-the $(E,M)$-factorisation $f = m \circ e$. By a syntactic limitation in
-Agda, we start with the conclusion: We'll show that $m$ is in $E$, and
-since $E$ is closed under composition, so is $f$.  Since $f$ is
-orthogonal to $m$, we can fit it into a lifting diagram
-
-~~~{.quiver}
-\[\begin{tikzcd}
-  A && B \\
-  \\
-  {r(f)} && {B\text{,}}
-  \arrow["f", from=1-1, to=1-3]
-  \arrow["g", dashed, from=1-3, to=3-1]
-  \arrow["e"', from=1-1, to=3-1]
-  \arrow[from=1-3, to=3-3]
-  \arrow["m", from=3-1, to=3-3]
-\end{tikzcd}\]
-~~~
-
-and make note of the diagonal filler $g : B \to r(f)$, and that it
-satisfies $gf=e$ and $mg = \id$.
-
-```agda
-        fa = factor f
-        module fa = Factorisation fa
-        gpq = ortho fa.forget fa.forget∈M {v = C.id} (C.idl _ ∙ fa.factors)
-```
-
-We'll show $gm = \id$ by fitting it into a lifting diagram. But
-since $e \ortho m$, the factorisation is unique, and $gm = \id$, as
-needed.
-
-~~~{.quiver}
-\[\begin{tikzcd}
-  A && {r(f)} \\
-  \\
-  {r(f)} && B
-  \arrow["e", from=1-1, to=1-3]
-  \arrow["m", from=1-3, to=3-3]
-  \arrow["m"', from=3-1, to=3-3]
-  \arrow["e"', from=1-1, to=3-1]
-  \arrow["gm"', shift right=1, from=1-3, to=3-1]
-  \arrow["id", shift left=1, from=1-3, to=3-1]
-\end{tikzcd}\]
-~~~
-
-```agda
-        gm=id : gpq .centre .fst C.∘ fa.forget ≡ C.id
-        gm=id = ap fst $ is-contr→is-prop
-          (E⊥M fa.mediate fa.forget fa.mediate∈E fa.forget∈M refl)
-          ( _ , C.pullr (sym fa.factors) ∙ gpq .centre .snd .fst
-          , C.cancell (gpq .centre .snd .snd)) (C.id , C.idl _ , C.idr _)
-```
-
-Think back to the conclusion we wanted to reach: $m$ is in $E$, so since
-$f = m \circ e$ and $E$ is stable, so is $f$!
-
-```agda
-        m∈E : fa.forget ∈ E
-        m∈E = is-iso→in-E fa.forget $
-          C.make-invertible (gpq .centre .fst) (gpq .centre .snd .snd) gm=id
+      mid     : C.Ob
+      left    : C.Hom a mid
+      right   : C.Hom mid b
+      left∈L  : left ∈ L
+      right∈R : right ∈ R
+      factors : f ≡ right C.∘ left
 ```

--- a/src/Cat/Morphism/Factorisation.lagda.md
+++ b/src/Cat/Morphism/Factorisation.lagda.md
@@ -45,3 +45,45 @@ such that $l \in L$, $r \in R$, and $f = r \circ l$.
       right∈R : right ∈ R
       factors : f ≡ right C.∘ left
 ```
+
+<!--
+```agda
+module _
+  {o ℓ ℓl ℓr}
+  {C : Precategory o ℓ}
+  {L : Arrows C ℓl}
+  {R : Arrows C ℓr}
+  where
+  private module C = Cat.Reasoning C
+  open Factorisation
+```
+-->
+
+
+## Properties of factorisations
+
+If $f$ is [[monic]] and factors as $f = r \circ l$, then $l$ must also be
+monic.
+
+```agda
+  factor-monic→left-monic
+    : ∀ {x y} {f : C.Hom x y}
+    → (f-fac : Factorisation C L R f)
+    → C.is-monic f
+    → C.is-monic (f-fac .left)
+  factor-monic→left-monic {f = f} f-fac f-monic =
+    C.monic-cancell $ C.subst-is-monic (f-fac .factors) f-monic
+```
+
+If $f$ is [[epic]] and factors as $f = r \circ l$, then $r$ must also be
+epic.
+
+```agda
+  factor-epic→right-epic
+    : ∀ {x y} {f : C.Hom x y}
+    → (f-fac : Factorisation C L R f)
+    → C.is-epic f
+    → C.is-epic (f-fac .right)
+  factor-epic→right-epic {f = f} f-fac f-epic =
+    C.epic-cancelr $ C.subst-is-epic (f-fac .factors) f-epic
+```

--- a/src/Cat/Morphism/Factorisation.lagda.md
+++ b/src/Cat/Morphism/Factorisation.lagda.md
@@ -2,6 +2,7 @@
 description: |
   Factorisations of morphisms.
 ---
+
 <!--
 ```agda
 open import Cat.Morphism.Class
@@ -10,6 +11,7 @@ open import Cat.Prelude
 import Cat.Reasoning
 ```
 -->
+
 ```agda
 module Cat.Morphism.Factorisation where
 ```
@@ -58,7 +60,6 @@ module _
   open Factorisation
 ```
 -->
-
 
 ## Properties of factorisations
 

--- a/src/Cat/Morphism/Factorisation.lagda.md
+++ b/src/Cat/Morphism/Factorisation.lagda.md
@@ -33,7 +33,7 @@ module _
 :::{.definition #factorisation}
 Let $L, R \subseteq C$ be two classes of morphisms of $\cC$.
 An $(L,R)$ **factorisation** of a morphism $f : \cC(X,Y)$ consists
-of an object $Im : \cC$ and a pair of morphisms $l : \cC(X,M), r : \cC(M,Y)$
+of an object $m(f) : \cC$ and a pair of morphisms $l : \cC(X,M), r : \cC(M,Y)$
 such that $l \in L$, $r \in R$, and $f = r \circ l$.
 :::
 

--- a/src/Cat/Morphism/Factorisation.lagda.md
+++ b/src/Cat/Morphism/Factorisation.lagda.md
@@ -33,7 +33,7 @@ module _
 :::{.definition #factorisation}
 Let $L, R \subseteq C$ be two classes of morphisms of $\cC$.
 An $(L,R)$ **factorisation** of a morphism $f : \cC(X,Y)$ consists
-of an object $m(f) : \cC$ and a pair of morphisms $l : \cC(X,M), r : \cC(M,Y)$
+of an object $m(f) : \cC$ and a pair of morphisms $l : \cC(X,m(f)), r : \cC(m(f),Y)$
 such that $l \in L$, $r \in R$, and $f = r \circ l$.
 :::
 

--- a/src/Cat/Morphism/Factorisation/Orthogonal.lagda.md
+++ b/src/Cat/Morphism/Factorisation/Orthogonal.lagda.md
@@ -187,14 +187,14 @@ morphism are a proposition.
     q = Univalent.Hom-pathp-refll-iso c-cat {p = isop1p2 .fst} (isop1p2 .snd .snd)
 
     go : x ≡ y
-    go i .mid = c-cat .to-path (isop1p2 .fst) i
-    go i .left = p i
+    go i .mid   = c-cat .to-path (isop1p2 .fst) i
+    go i .left  = p i
     go i .right = q i
 ```
 
 <!--
 ```agda
-    go i .left∈L = is-prop→pathp (λ i → is-tr (L · (p i))) (x .left∈L) (y .left∈L) i
+    go i .left∈L  = is-prop→pathp (λ i → is-tr (L · (p i))) (x .left∈L) (y .left∈L) i
     go i .right∈R = is-prop→pathp (λ i → is-tr (R · (q i))) (x .right∈R) (y .right∈R) i
     go i .factors =
       is-prop→pathp (λ i → C.Hom-set _ _ f (q i C.∘ p i)) (x .factors) (y .factors) i
@@ -227,15 +227,13 @@ technical one.
   L-is-⊥R
     : ∀ {a b} (f : C.Hom a b)
     → (f ∈ L) ≃ (∀ {c d} (m : C.Hom c d) → m ∈ R → Orthogonal C f m)
-  L-is-⊥R f =
-    prop-ext! (λ m f∈L m∈R → to f∈L m m∈R) from
-    where
-      to : ∀ {c d} (m : C.Hom c d) → f ∈ L → m ∈ R → Orthogonal C f m
-      to m f∈L m∈R u v square = L⊥R f f∈L m m∈R u v square
+  L-is-⊥R f = prop-ext! (λ m f∈L m∈R → to f∈L m m∈R) from where
+    to : ∀ {c d} (m : C.Hom c d) → f ∈ L → m ∈ R → Orthogonal C f m
+    to m f∈L m∈R u v square = L⊥R f f∈L m m∈R u v square
 
-      from : (∀ {c d} (m : C.Hom c d) → m ∈ R → Orthogonal C f m) → f ∈ L
-      from ortho = subst (_∈ L) (sym (fa .factors)) $ L-is-stable _ _ m∈L (fa .left∈L)
-        where
+    from : (∀ {c d} (m : C.Hom c d) → m ∈ R → Orthogonal C f m) → f ∈ L
+    from ortho = subst (_∈ L) (sym (fa .factors)) $ L-is-stable _ _ m∈L (fa .left∈L)
+      where
 ```
 
 Suppose that $f$ is left-orthogonal to every $r \in R$, and write out
@@ -261,8 +259,8 @@ and make note of the diagonal filler $g : B \to r(f)$, and that it
 satisfies $gf=e$ and $mg = \id$.
 
 ```agda
-        fa = factor f
-        gpq = ortho (fa .right) (fa .right∈R) (fa .left) C.id (C.idl _ ∙ (fa .factors))
+      fa = factor f
+      gpq = ortho (fa .right) (fa .right∈R) (fa .left) C.id (C.idl _ ∙ (fa .factors))
 ```
 
 We'll show $gr = \id$ by fitting it into a lifting diagram. But
@@ -284,18 +282,18 @@ needed.
 ~~~
 
 ```agda
-        gm=id : gpq .centre .fst C.∘ (fa .right) ≡ C.id
-        gm=id = ap fst $ is-contr→is-prop
-          (L⊥R _ (fa .left∈L) _ (fa .right∈R) _ _ refl)
-          ( _ , C.pullr (sym (fa .factors)) ∙ gpq .centre .snd .fst
-          , C.cancell (gpq .centre .snd .snd)) (C.id , C.idl _ , C.idr _)
+      gm=id : gpq .centre .fst C.∘ (fa .right) ≡ C.id
+      gm=id = ap fst $ is-contr→is-prop
+        (L⊥R _ (fa .left∈L) _ (fa .right∈R) _ _ refl)
+        ( _ , C.pullr (sym (fa .factors)) ∙ gpq .centre .snd .fst
+        , C.cancell (gpq .centre .snd .snd)) (C.id , C.idl _ , C.idr _)
 ```
 
 Think back to the conclusion we wanted to reach: $r$ is in $L$, so since
 $f = r \circ l$ and $R$ is stable, so is $f$!
 
 ```agda
-        m∈L : fa .right ∈ L
-        m∈L = is-iso→in-L (fa .right) $
-          C.make-invertible (gpq .centre .fst) (gpq .centre .snd .snd) gm=id
+      m∈L : fa .right ∈ L
+      m∈L = is-iso→in-L (fa .right) $
+        C.make-invertible (gpq .centre .fst) (gpq .centre .snd .snd) gm=id
 ```

--- a/src/Cat/Morphism/Factorisation/Orthogonal.lagda.md
+++ b/src/Cat/Morphism/Factorisation/Orthogonal.lagda.md
@@ -1,0 +1,313 @@
+<!--
+```agda
+open import Cat.Morphism.Factorisation
+open import Cat.Morphism.Orthogonal
+open import Cat.Morphism.Class
+open import Cat.Prelude
+
+import Cat.Reasoning
+```
+-->
+
+```agda
+module Cat.Morphism.Factorisation.Orthogonal where
+```
+
+# Orthogonal factorisation systems {defines="orthogonal-factorisation-system"}
+
+Suppose you have some category $\cC$ and you, inspired by the wisdom
+of King Solomon, want to chop every morphism in half. A **factorisation
+system** $(E, M)$ on $\cC$ will provide a tool for doing so, in a
+particularly coherent way. Here, $E$ and $M$ are predicates on the space
+of morphisms of $C$. First, we package the data of an $(E,
+M)$-factorisation of a morphism $f : a \to b$.
+
+<!--
+```agda
+module _
+  {o ℓ ℓe ℓm}
+  (C : Precategory o ℓ)
+  (E : Arrows C ℓe)
+  (M : Arrows C ℓm) where
+  private module C = Cat.Reasoning C
+```
+-->
+
+Note that while the archetype for a factorisation system is the (epi,
+mono)-factorisation system on the category of sets^[Or, more generally,
+in every topos.], so that it's very hard _not_ to refer to these things
+as images, it is _not_ the case, in general, nothing is required about
+the interaction of epis and monos with the classes $E$ and $M$.
+Generically, we call the $E$-morphism in the factorisation
+`mediate`{.Agda}, and the $M$-morphism `forget`{.Agda}.
+
+```agda
+  open Factorisation
+    renaming
+      ( mid to mediating
+      ; left to mediate
+      ; right to forget
+      ; left∈L to mediate∈E
+      ; right∈R to forget∈M
+      )
+```
+
+In addition to mandating that every map $f : a \to b$ factors as a map
+$f : a \xto{e} r(f) \xto{m}$ where $e \in E$ and $m \in M$, the classes
+must satisfy the following properties:
+
+- Every isomorphism is in both $E$ and in $M$.^[We'll see, in a bit, that
+the converse is true, too.]
+
+- Both classes are stable under composition: if $f \in E$ and $g \in E$,
+then $(g \circ f) \in E$ and the same for $M$
+
+```agda
+  record is-ofs : Type (o ⊔ ℓ ⊔ ℓe ⊔ ℓm) where
+    field
+      factor : ∀ {a b} (f : C.Hom a b) → Factorisation C E M f
+
+      is-iso→in-E : ∀ {a b} (f : C.Hom a b) → C.is-invertible f → f ∈ E
+      E-is-stable
+        : ∀ {a b c} (g : C.Hom b c) (f : C.Hom a b) → f ∈ E → g ∈ E
+        → (g C.∘ f) ∈ E
+
+      is-iso→in-M : ∀ {a b} (f : C.Hom a b) → C.is-invertible f → f ∈ M
+      M-is-stable
+        : ∀ {a b c} (g : C.Hom b c) (f : C.Hom a b) → f ∈ M → g ∈ M
+        → (g C.∘ f) ∈ M
+```
+
+Most importantly, the class $E$ is exactly the class of morphisms
+left-orthogonal to $M$: A map satisfies $f \in E$ if, and only if, for
+every $g \in M$, we have $f \ortho g$. Conversely, a map has $g \in M$
+if, and only if, we have $f \ortho g$ for every $f \in E$.
+
+```agda
+      E⊥M : Orthogonal C E M
+```
+
+<!--
+```agda
+module _
+  {o ℓ ℓe ℓm}
+  (C : Precategory o ℓ)
+  (E : Arrows C ℓe)
+  (M : Arrows C ℓm)
+  (fs : is-ofs C E M)
+  where
+
+  private module C = Cat.Reasoning C
+  open is-ofs fs
+  open Factorisation
+    renaming
+      ( mid to mediating
+      ; left to mediate
+      ; right to forget
+      ; left∈L to mediate∈E
+      ; right∈R to forget∈M
+      )
+```
+-->
+
+The first thing we observe is that factorisations for a morphism are
+unique. Working in precategorical generality, we weaken this to
+essential uniqueness: Given two factorisations of $f$ we exhibit an
+isomorphism between their replacements $r(f)$, $r'(f)$ which commutes
+with both the `mediate`{.Agda} morphism and the `forget`{.Agda}
+morphism. We reproduce the proof from [@Borceux:vol1, §5.5].
+
+```agda
+  factorisation-essentially-unique
+    : ∀ {a b} (f : C.Hom a b) (fa1 fa2 : Factorisation C E M f)
+    → Σ[ f ∈ fa1 .mediating C.≅ fa2 .mediating ]
+        ( (f .C.to C.∘ fa1 .mediate ≡ fa2 .mediate)
+        × (fa1 .forget C.∘ f .C.from ≡ fa2 .forget))
+  factorisation-essentially-unique f fa1 fa2 =
+    C.make-iso (upq .fst) (vp'q' .fst) vu=id uv=id , upq .snd .fst , vp'q' .snd .snd
+    where
+```
+
+Suppose that $f = m \circ e$ and $f = m' \circ e'$ are both
+$(E,M)$-factorisations of $f$. We use the fact that $e \ortho m'$ and
+$e' \ortho m$ to get maps $u, v$ satisfying $um = m'$, $m'u = m$, $ve =
+e'$, and $e'v = e$.
+
+```agda
+      upq =
+        E⊥M _ (fa1 .mediate∈E) _ (fa2 .forget∈M) _ _
+          (sym (fa1 .factors) ∙ fa2 .factors) .centre
+
+      vp'q' = E⊥M _ (fa2 .mediate∈E) _ (fa1 .forget∈M) _ _
+        (sym (fa2 .factors) ∙ fa1 .factors) .centre
+```
+
+To show that $u$ and $v$ are inverses, fit first $e$ and $m$ into a
+lifting diagram like the one below. Since $e \ortho m$, we have that the
+space of diagonals $r(f) \to r(f)$ is contractible, hence a proposition,
+and since both $vu$ and the identity are in that diagonal, $uv =
+\id$.
+
+~~~{.quiver}
+\[\begin{tikzcd}
+  a && {r(f)} \\
+  \\
+  {r(f)} && b
+  \arrow["e", from=1-1, to=1-3]
+  \arrow["m"', from=3-1, to=3-3]
+  \arrow["e"', from=1-1, to=3-1]
+  \arrow["m", from=1-3, to=3-3]
+	\arrow["{\mathrm{id}}"', shift right=1, from=1-3, to=3-1]
+	\arrow["vu", shift left=1, from=1-3, to=3-1]
+\end{tikzcd}\]
+~~~
+
+```agda
+      vu=id : upq .fst C.∘ vp'q' .fst ≡ C.id
+      vu=id = ap fst $ is-contr→is-prop
+        (E⊥M _ (fa2 .mediate∈E) _ (fa2 .forget∈M) _ _ refl)
+        ( upq .fst C.∘ vp'q' .fst
+        , C.pullr (vp'q' .snd .fst) ∙ upq .snd .fst
+        , C.pulll (upq .snd .snd) ∙ vp'q' .snd .snd
+        ) (C.id , C.idl _ , C.idr _)
+```
+
+A dual argument works by making a lifting square with $e'$ and $m'$ as
+its faces. We omit it for brevity.  By the characterisation of path
+spaces in categories, this implies that factorisations of a fixed
+morphism are a proposition.
+
+<!--
+```agda
+      uv=id : vp'q' .fst C.∘ upq .fst ≡ C.id
+      uv=id = ap fst $ is-contr→is-prop
+        (E⊥M _ (fa1 .mediate∈E) _ (fa1 .forget∈M) _ _ refl)
+        ( vp'q' .fst C.∘ upq .fst
+        , C.pullr (upq .snd .fst) ∙ vp'q' .snd .fst
+        , C.pulll (vp'q' .snd .snd) ∙ upq .snd .snd
+        ) (C.id , C.idl _ , C.idr _)
+```
+-->
+
+```agda
+  factorisation-unique
+    : ∀ {a b} (f : C.Hom a b) → is-category C → is-prop (Factorisation C E M f)
+  factorisation-unique f c-cat x y = go where
+    isop1p2 = factorisation-essentially-unique f x y
+
+    p = Univalent.Hom-pathp-reflr-iso c-cat {q = isop1p2 .fst} (isop1p2 .snd .fst)
+    q = Univalent.Hom-pathp-refll-iso c-cat {p = isop1p2 .fst} (isop1p2 .snd .snd)
+
+    go : x ≡ y
+    go i .mediating = c-cat .to-path (isop1p2 .fst) i
+    go i .mediate = p i
+    go i .forget = q i
+```
+
+<!--
+```agda
+    go i .mediate∈E = is-prop→pathp (λ i → is-tr (E · (p i))) (x .mediate∈E) (y .mediate∈E) i
+    go i .forget∈M = is-prop→pathp (λ i → is-tr (M · (q i))) (x .forget∈M) (y .forget∈M) i
+    go i .factors =
+      is-prop→pathp (λ i → C.Hom-set _ _ f (q i C.∘ p i)) (x .factors) (y .factors) i
+```
+-->
+
+As a passing observation, note that the intersection $E \cap M$ is
+precisely the class of isomorphisms of $f$. Every isomorphism is in both
+classes, by the definition, and if a morphism is in both classes, it is
+orthogonal to itself, hence an isomorphism.
+
+```agda
+  in-intersection→is-iso
+    : ∀ {a b} (f : C.Hom a b) → f ∈ E → f ∈ M → C.is-invertible f
+  in-intersection→is-iso f f∈E f∈M = self-orthogonal→invertible C f $ E⊥M f f∈E f f∈M
+
+  in-intersection≃is-iso
+    : ∀ {a b} (f : C.Hom a b) → C.is-invertible f ≃ ((f ∈ E) × (f ∈ M))
+  in-intersection≃is-iso f = prop-ext!
+    (λ fi → is-iso→in-E f fi , is-iso→in-M f fi)
+    λ { (a , b) → in-intersection→is-iso f a b }
+```
+
+The final observation is that the class $E$ is precisely $^\bot M$, the
+class of morphisms left-orthogonal to those in $M$. One direction is by
+definition, and the other is rather technical. Let's focus on the
+technical one.
+
+```agda
+  E-is-⊥M
+    : ∀ {a b} (f : C.Hom a b)
+    → (f ∈ E) ≃ (∀ {c d} (m : C.Hom c d) → m ∈ M → Orthogonal C f m)
+  E-is-⊥M f =
+    prop-ext! (λ m f∈E m∈M → to f∈E m m∈M) from
+    where
+      to : ∀ {c d} (m : C.Hom c d) → f ∈ E → m ∈ M → Orthogonal C f m
+      to m f∈E m∈M u v square = E⊥M f f∈E m m∈M u v square
+
+      from : (∀ {c d} (m : C.Hom c d) → m ∈ M → Orthogonal C f m) → f ∈ E
+      from ortho = subst (_∈ E) (sym (fa .factors)) $ E-is-stable _ _ (fa .mediate∈E) m∈E
+        where
+```
+
+Suppose that $f$ is left-orthogonal to every $m \in M$, and write out
+the $(E,M)$-factorisation $f = m \circ e$. By a syntactic limitation in
+Agda, we start with the conclusion: We'll show that $m$ is in $E$, and
+since $E$ is closed under composition, so is $f$.  Since $f$ is
+orthogonal to $m$, we can fit it into a lifting diagram
+
+~~~{.quiver}
+\[\begin{tikzcd}
+  A && B \\
+  \\
+  {r(f)} && {B\text{,}}
+  \arrow["f", from=1-1, to=1-3]
+  \arrow["g", dashed, from=1-3, to=3-1]
+  \arrow["e"', from=1-1, to=3-1]
+  \arrow[from=1-3, to=3-3]
+  \arrow["m", from=3-1, to=3-3]
+\end{tikzcd}\]
+~~~
+
+and make note of the diagonal filler $g : B \to r(f)$, and that it
+satisfies $gf=e$ and $mg = \id$.
+
+```agda
+        fa = factor f
+        gpq = ortho (fa .forget) (fa .forget∈M) (fa .mediate) C.id (C.idl _ ∙ (fa .factors))
+```
+
+We'll show $gm = \id$ by fitting it into a lifting diagram. But
+since $e \ortho m$, the factorisation is unique, and $gm = \id$, as
+needed.
+
+~~~{.quiver}
+\[\begin{tikzcd}
+  A && {r(f)} \\
+  \\
+  {r(f)} && B
+  \arrow["e", from=1-1, to=1-3]
+  \arrow["m", from=1-3, to=3-3]
+  \arrow["m"', from=3-1, to=3-3]
+  \arrow["e"', from=1-1, to=3-1]
+  \arrow["gm"', shift right=1, from=1-3, to=3-1]
+  \arrow["id", shift left=1, from=1-3, to=3-1]
+\end{tikzcd}\]
+~~~
+
+```agda
+        gm=id : gpq .centre .fst C.∘ (fa .forget) ≡ C.id
+        gm=id = ap fst $ is-contr→is-prop
+          (E⊥M _ (fa .mediate∈E) _ (fa .forget∈M) _ _ refl)
+          ( _ , C.pullr (sym (fa .factors)) ∙ gpq .centre .snd .fst
+          , C.cancell (gpq .centre .snd .snd)) (C.id , C.idl _ , C.idr _)
+```
+
+Think back to the conclusion we wanted to reach: $m$ is in $E$, so since
+$f = m \circ e$ and $E$ is stable, so is $f$!
+
+```agda
+        m∈E : fa .forget ∈ E
+        m∈E = is-iso→in-E (fa .forget) $
+          C.make-invertible (gpq .centre .fst) (gpq .centre .snd .snd) gm=id
+```

--- a/src/Cat/Morphism/Factorisation/Orthogonal.lagda.md
+++ b/src/Cat/Morphism/Factorisation/Orthogonal.lagda.md
@@ -17,7 +17,7 @@ module Cat.Morphism.Factorisation.Orthogonal where
 # Orthogonal factorisation systems {defines="orthogonal-factorisation-system"}
 
 Suppose you have some category $\cC$ and you, inspired by the wisdom
-of King Solomon, want to chop every morphism in half. A **factorisation
+of King Solomon, want to chop every morphism in half. An **orthogonal factorisation
 system** $(E, M)$ on $\cC$ will provide a tool for doing so, in a
 particularly coherent way. Here, $E$ and $M$ are predicates on the space
 of morphisms of $C$. First, we package the data of an $(E,
@@ -34,13 +34,11 @@ module _
 ```
 -->
 
-Note that while the archetype for a factorisation system is the (epi,
+Though the archetype for an orthogonal factorisation system is the (epi,
 mono)-factorisation system on the category of sets^[Or, more generally,
-in every topos.], so that it's very hard _not_ to refer to these things
-as images, it is _not_ the case, in general, nothing is required about
-the interaction of epis and monos with the classes $E$ and $M$.
-Generically, we call the $E$-morphism in the factorisation
-`mediate`{.Agda}, and the $M$-morphism `forget`{.Agda}.
+in every topos.], in the general setting there is no relation between
+epis/monos and the classes $E$ and $M$. Generically, we call the $E$-morphism
+in the factorisation `mediate`{.Agda}, and the $M$-morphism `forget`{.Agda}.
 
 ```agda
   open Factorisation

--- a/src/Cat/Morphism/Factorisation/Orthogonal.lagda.md
+++ b/src/Cat/Morphism/Factorisation/Orthogonal.lagda.md
@@ -3,6 +3,7 @@
 open import Cat.Morphism.Factorisation
 open import Cat.Morphism.Orthogonal
 open import Cat.Morphism.Class
+open import Cat.Morphism.Lifts
 open import Cat.Prelude
 
 import Cat.Reasoning

--- a/src/Cat/Morphism/Factorisation/Orthogonal.lagda.md
+++ b/src/Cat/Morphism/Factorisation/Orthogonal.lagda.md
@@ -42,7 +42,7 @@ of a morphism $f : a \to b$.
 ```
 
 In addition to mandating that every map $f : a \to b$ factors as a map
-$f : a \xto{l} r(f) \xto{r} b$ where $l \in L$ and $r \in R$, the classes
+$f : a \xto{l} m(f) \xto{r} b$ where $l \in L$ and $r \in R$, the classes
 must satisfy the following properties:
 
 - Every isomorphism is in both $L$ and in $R$^[We'll see, in a bit, that
@@ -64,7 +64,7 @@ then $(g \circ f) \in L$, and likewise for $R$.
 ```
 
 Most importantly, the class $L$ is [[orthogonal|orthogonality]] to $R$, i.e:
-for every $l \in L$ and $r \in R$, we have $l \ortho r$[^ortho].
+for every $l \in L$ and $r \in R$, we have $l \ortho r$.[^ortho]
 
 [^ortho]: As we shall shortly see, $L$ is actually *exactly* the class of
 morphisms that is left orthogonal to $R$ and vice-versa for $R$.
@@ -76,7 +76,7 @@ morphisms that is left orthogonal to $R$ and vice-versa for $R$.
 The canonical example of an orthogonal factorisation system is the
 ([[surjective|surjection-between-sets]], [[injective|embedding]])
 factorisation system on the [[category of sets]], which uniquely factors
-a function $f : A \to B$ through the image of $f$[^regular].
+a function $f : A \to B$ through the image of $f$.[^regular]
 
 [^regular]: This factorisation system is a special case of the
 ([[strong epimorphism]], [[monomorphism]]) orthogonal factorisation
@@ -101,7 +101,7 @@ module _
 The first thing we observe is that factorisations for a morphism are
 unique. Working in precategorical generality, we weaken this to
 essential uniqueness: Given two factorisations of $f$ we exhibit an
-isomorphism between their replacements $r(f)$, $r'(f)$ which commutes
+isomorphism between their replacements $m(f)$, $m'(f)$ which commutes
 with both the `left`{.Agda} morphism and the `right`{.Agda}
 morphism. We reproduce the proof from [@Borceux:vol1, §5.5].
 
@@ -116,10 +116,10 @@ morphism. We reproduce the proof from [@Borceux:vol1, §5.5].
     where
 ```
 
-Suppose that $f = m \circ e$ and $f = m' \circ e'$ are both
-$(L,R)$-factorisations of $f$. We use the fact that $e \ortho m'$ and
-$e' \ortho m$ to get maps $u, v$ satisfying $um = m'$, $m'u = m$, $ve =
-e'$, and $e'v = e$.
+Suppose that $f = r \circ l$ and $f = r' \circ l'$ are both
+$(L,R)$-factorisations of $f$. We use the fact that $l \ortho r'$ and
+$l' \ortho r$ to get maps $u, v$ satisfying $ur = r'$, $r'u = r$, $vl =
+l'$, and $l'v = l$.
 
 ```agda
       upq =
@@ -130,24 +130,24 @@ e'$, and $e'v = e$.
         (sym (fa2 .factors) ∙ fa1 .factors) .centre
 ```
 
-To show that $u$ and $v$ are inverses, fit first $e$ and $m$ into a
-lifting diagram like the one below. Since $e \ortho m$, we have that the
-space of diagonals $r(f) \to r(f)$ is contractible, hence a proposition,
+To show that $u$ and $v$ are inverses, fit first $l$ and $r$ into a
+lifting diagram like the one below. Since $l \ortho r$, we have that the
+space of diagonals $m(f) \to m(f)$ is contractible, hence a proposition,
 and since both $vu$ and the identity are in that diagonal, $uv =
 \id$.
 
 ~~~{.quiver}
-\[\begin{tikzcd}
-  a && {r(f)} \\
+\begin{tikzcd}
+  a && {m(f)} \\
   \\
-  {r(f)} && b
-  \arrow["e", from=1-1, to=1-3]
-  \arrow["m"', from=3-1, to=3-3]
-  \arrow["e"', from=1-1, to=3-1]
-  \arrow["m", from=1-3, to=3-3]
-	\arrow["{\mathrm{id}}"', shift right=1, from=1-3, to=3-1]
-	\arrow["vu", shift left=1, from=1-3, to=3-1]
-\end{tikzcd}\]
+  {m(f)} && b
+  \arrow["l", from=1-1, to=1-3]
+  \arrow["l"', from=1-1, to=3-1]
+  \arrow["r", from=1-3, to=3-3]
+  \arrow["\id", shift left=2, from=3-1, to=1-3]
+  \arrow["vu"', shift right=2, from=3-1, to=1-3]
+  \arrow["r"', from=3-1, to=3-3]
+\end{tikzcd}
 ~~~
 
 ```agda
@@ -160,7 +160,7 @@ and since both $vu$ and the identity are in that diagonal, $uv =
         ) (C.id , C.idl _ , C.idr _)
 ```
 
-A dual argument works by making a lifting square with $e'$ and $m'$ as
+A dual argument works by making a lifting square with $l'$ and $r'$ as
 its faces. We omit it for brevity.  By the characterisation of path
 spaces in categories, this implies that factorisations of a fixed
 morphism are a proposition.
@@ -238,22 +238,22 @@ technical one.
         where
 ```
 
-Suppose that $f$ is left-orthogonal to every $m \in R$, and write out
-the $(L,R)$-factorisation $f = m \circ e$. By a syntactic limitation in
-Agda, we start with the conclusion: We'll show that $m$ is in $E$, and
+Suppose that $f$ is left-orthogonal to every $r \in R$, and write out
+the $(L,R)$-factorisation $f = r \circ l$. By a syntactic limitation in
+Agda, we start with the conclusion: We'll show that $r$ is in $L$, and
 since $L$ is closed under composition, so is $f$.  Since $f$ is
-orthogonal to $m$, we can fit it into a lifting diagram
+orthogonal to $r$, we can fit it into a lifting diagram
 
 ~~~{.quiver}
 \[\begin{tikzcd}
-  A && B \\
+  a && {m(f)} \\
   \\
-  {r(f)} && {B\text{,}}
-  \arrow["f", from=1-1, to=1-3]
-  \arrow["g", dashed, from=1-3, to=3-1]
-  \arrow["e"', from=1-1, to=3-1]
-  \arrow[from=1-3, to=3-3]
-  \arrow["m", from=3-1, to=3-3]
+  b && b
+  \arrow["l", from=1-1, to=1-3]
+  \arrow["f"', from=1-1, to=3-1]
+  \arrow["r", from=1-3, to=3-3]
+  \arrow["g", dashed, from=3-1, to=1-3]
+  \arrow["\id"', from=3-1, to=3-3]
 \end{tikzcd}\]
 ~~~
 
@@ -265,22 +265,22 @@ satisfies $gf=e$ and $mg = \id$.
         gpq = ortho (fa .right) (fa .right∈R) (fa .left) C.id (C.idl _ ∙ (fa .factors))
 ```
 
-We'll show $gm = \id$ by fitting it into a lifting diagram. But
-since $e \ortho m$, the factorisation is unique, and $gm = \id$, as
+We'll show $gr = \id$ by fitting it into a lifting diagram. But
+since $l \ortho r$, the factorisation is unique, and $gr = \id$, as
 needed.
 
 ~~~{.quiver}
 \[\begin{tikzcd}
-  A && {r(f)} \\
+  a && {m(f)} \\
   \\
-  {r(f)} && B
-  \arrow["e", from=1-1, to=1-3]
-  \arrow["m", from=1-3, to=3-3]
-  \arrow["m"', from=3-1, to=3-3]
-  \arrow["e"', from=1-1, to=3-1]
-  \arrow["gm"', shift right=1, from=1-3, to=3-1]
-  \arrow["id", shift left=1, from=1-3, to=3-1]
-\end{tikzcd}\]
+  {m(f)} && b
+  \arrow["l", from=1-1, to=1-3]
+  \arrow["l"', from=1-1, to=3-1]
+  \arrow["r", from=1-3, to=3-3]
+  \arrow["gr", shift left=2, from=3-1, to=1-3]
+  \arrow["\id"', shift right=2, from=3-1, to=1-3]
+  \arrow["r"', from=3-1, to=3-3]
+\end{tikzcd} \]
 ~~~
 
 ```agda
@@ -291,8 +291,8 @@ needed.
           , C.cancell (gpq .centre .snd .snd)) (C.id , C.idl _ , C.idr _)
 ```
 
-Think back to the conclusion we wanted to reach: $m$ is in $E$, so since
-$f = m \circ e$ and $L$ is stable, so is $f$!
+Think back to the conclusion we wanted to reach: $r$ is in $L$, so since
+$f = r \circ l$ and $R$ is stable, so is $f$!
 
 ```agda
         m∈L : fa .right ∈ L

--- a/src/Cat/Morphism/Factorisation/Orthogonal.lagda.md
+++ b/src/Cat/Morphism/Factorisation/Orthogonal.lagda.md
@@ -16,96 +16,85 @@ module Cat.Morphism.Factorisation.Orthogonal where
 
 # Orthogonal factorisation systems {defines="orthogonal-factorisation-system"}
 
-Suppose you have some category $\cC$ and you, inspired by the wisdom
-of King Solomon, want to chop every morphism in half. An **orthogonal factorisation
-system** $(E, M)$ on $\cC$ will provide a tool for doing so, in a
-particularly coherent way. Here, $E$ and $M$ are predicates on the space
-of morphisms of $C$. First, we package the data of an $(E,
-M)$-factorisation of a morphism $f : a \to b$.
-
 <!--
 ```agda
 module _
-  {o ℓ ℓe ℓm}
+  {o ℓ ℓl ℓr}
   (C : Precategory o ℓ)
-  (E : Arrows C ℓe)
-  (M : Arrows C ℓm) where
+  (L : Arrows C ℓl)
+  (R : Arrows C ℓr) where
   private module C = Cat.Reasoning C
+  open Factorisation
 ```
 -->
 
-Though the archetype for an orthogonal factorisation system is the (epi,
-mono)-factorisation system on the category of sets^[Or, more generally,
-in every topos.], in the general setting there is no relation between
-epis/monos and the classes $E$ and $M$. Generically, we call the $E$-morphism
-in the factorisation `mediate`{.Agda}, and the $M$-morphism `forget`{.Agda}.
+Suppose you have some category $\cC$ and you, inspired by the wisdom
+of King Solomon, want to chop every morphism in half. An **orthogonal factorisation
+system** $(L, R)$ on $\cC$ will provide a tool for doing so, in a
+particularly coherent way. Here, $L$ and $R$ are predicates on the space
+of morphisms of $C$. First, we package the data of an [[$(L, R)$-factorisation|factorisation]]
+of a morphism $f : a \to b$.
 
 ```agda
-  open Factorisation
-    renaming
-      ( mid to mediating
-      ; left to mediate
-      ; right to forget
-      ; left∈L to mediate∈E
-      ; right∈R to forget∈M
-      )
+  record is-ofs : Type (o ⊔ ℓ ⊔ ℓl ⊔ ℓr) where
+    field
+      factor : ∀ {a b} (f : C.Hom a b) → Factorisation C L R f
 ```
 
 In addition to mandating that every map $f : a \to b$ factors as a map
-$f : a \xto{e} r(f) \xto{m}$ where $e \in E$ and $m \in M$, the classes
+$f : a \xto{l} r(f) \xto{r} b$ where $l \in L$ and $r \in R$, the classes
 must satisfy the following properties:
 
-- Every isomorphism is in both $E$ and in $M$.^[We'll see, in a bit, that
-the converse is true, too.]
+- Every isomorphism is in both $L$ and in $R$^[We'll see, in a bit, that
+the converse is true, too.].
 
-- Both classes are stable under composition: if $f \in E$ and $g \in E$,
-then $(g \circ f) \in E$ and the same for $M$
-
-```agda
-  record is-ofs : Type (o ⊔ ℓ ⊔ ℓe ⊔ ℓm) where
-    field
-      factor : ∀ {a b} (f : C.Hom a b) → Factorisation C E M f
-
-      is-iso→in-E : ∀ {a b} (f : C.Hom a b) → C.is-invertible f → f ∈ E
-      E-is-stable
-        : ∀ {a b c} (g : C.Hom b c) (f : C.Hom a b) → f ∈ E → g ∈ E
-        → (g C.∘ f) ∈ E
-
-      is-iso→in-M : ∀ {a b} (f : C.Hom a b) → C.is-invertible f → f ∈ M
-      M-is-stable
-        : ∀ {a b c} (g : C.Hom b c) (f : C.Hom a b) → f ∈ M → g ∈ M
-        → (g C.∘ f) ∈ M
-```
-
-Most importantly, the class $E$ is exactly the class of morphisms
-left-orthogonal to $M$: A map satisfies $f \in E$ if, and only if, for
-every $g \in M$, we have $f \ortho g$. Conversely, a map has $g \in M$
-if, and only if, we have $f \ortho g$ for every $f \in E$.
+- Both classes are stable under composition: if $f \in L$ and $g \in L$,
+then $(g \circ f) \in L$, and likewise for $R$.
 
 ```agda
-      E⊥M : Orthogonal C E M
+      is-iso→in-L : ∀ {a b} (f : C.Hom a b) → C.is-invertible f → f ∈ L
+      L-is-stable
+        : ∀ {a b c} (f : C.Hom b c) (g : C.Hom a b) → f ∈ L → g ∈ L
+        → (f C.∘ g) ∈ L
+
+      is-iso→in-R : ∀ {a b} (f : C.Hom a b) → C.is-invertible f → f ∈ R
+      R-is-stable
+        : ∀ {a b c} (f : C.Hom b c) (g : C.Hom a b) → f ∈ R → g ∈ R
+        → (f C.∘ g) ∈ R
 ```
+
+Most importantly, the class $L$ is [[orthogonal|orthogonality]] to $R$, i.e:
+for every $l \in L$ and $r \in R$, we have $l \ortho r$[^ortho].
+
+[^ortho]: As we shall shortly see, $L$ is actually *exactly* the class of
+morphisms that is left orthogonal to $R$ and vice-versa for $R$.
+
+```agda
+      L⊥R : Orthogonal C L R
+```
+
+The canonical example of an orthogonal factorisation system is the
+([[surjective|surjection-between-sets]], [[injective|embedding]])
+factorisation system on the [[category of sets]], which uniquely factors
+a function $f : A \to B$ through the image of $f$[^regular].
+
+[^regular]: This factorisation system is a special case of the
+([[strong epimorphism]], [[monomorphism]]) orthogonal factorisation
+system on a [[regular category]].
 
 <!--
 ```agda
 module _
-  {o ℓ ℓe ℓm}
+  {o ℓ ℓl ℓr}
   (C : Precategory o ℓ)
-  (E : Arrows C ℓe)
-  (M : Arrows C ℓm)
-  (fs : is-ofs C E M)
+  (L : Arrows C ℓl)
+  (R : Arrows C ℓr)
+  (fs : is-ofs C L R)
   where
 
   private module C = Cat.Reasoning C
   open is-ofs fs
   open Factorisation
-    renaming
-      ( mid to mediating
-      ; left to mediate
-      ; right to forget
-      ; left∈L to mediate∈E
-      ; right∈R to forget∈M
-      )
 ```
 -->
 
@@ -113,31 +102,31 @@ The first thing we observe is that factorisations for a morphism are
 unique. Working in precategorical generality, we weaken this to
 essential uniqueness: Given two factorisations of $f$ we exhibit an
 isomorphism between their replacements $r(f)$, $r'(f)$ which commutes
-with both the `mediate`{.Agda} morphism and the `forget`{.Agda}
+with both the `left`{.Agda} morphism and the `right`{.Agda}
 morphism. We reproduce the proof from [@Borceux:vol1, §5.5].
 
 ```agda
   factorisation-essentially-unique
-    : ∀ {a b} (f : C.Hom a b) (fa1 fa2 : Factorisation C E M f)
-    → Σ[ f ∈ fa1 .mediating C.≅ fa2 .mediating ]
-        ( (f .C.to C.∘ fa1 .mediate ≡ fa2 .mediate)
-        × (fa1 .forget C.∘ f .C.from ≡ fa2 .forget))
+    : ∀ {a b} (f : C.Hom a b) (fa1 fa2 : Factorisation C L R f)
+    → Σ[ f ∈ fa1 .mid C.≅ fa2 .mid ]
+        ( (f .C.to C.∘ fa1 .left ≡ fa2 .left)
+        × (fa1 .right C.∘ f .C.from ≡ fa2 .right))
   factorisation-essentially-unique f fa1 fa2 =
     C.make-iso (upq .fst) (vp'q' .fst) vu=id uv=id , upq .snd .fst , vp'q' .snd .snd
     where
 ```
 
 Suppose that $f = m \circ e$ and $f = m' \circ e'$ are both
-$(E,M)$-factorisations of $f$. We use the fact that $e \ortho m'$ and
+$(L,R)$-factorisations of $f$. We use the fact that $e \ortho m'$ and
 $e' \ortho m$ to get maps $u, v$ satisfying $um = m'$, $m'u = m$, $ve =
 e'$, and $e'v = e$.
 
 ```agda
       upq =
-        E⊥M _ (fa1 .mediate∈E) _ (fa2 .forget∈M) _ _
+        L⊥R _ (fa1 .left∈L) _ (fa2 .right∈R) _ _
           (sym (fa1 .factors) ∙ fa2 .factors) .centre
 
-      vp'q' = E⊥M _ (fa2 .mediate∈E) _ (fa1 .forget∈M) _ _
+      vp'q' = L⊥R _ (fa2 .left∈L) _ (fa1 .right∈R) _ _
         (sym (fa2 .factors) ∙ fa1 .factors) .centre
 ```
 
@@ -164,7 +153,7 @@ and since both $vu$ and the identity are in that diagonal, $uv =
 ```agda
       vu=id : upq .fst C.∘ vp'q' .fst ≡ C.id
       vu=id = ap fst $ is-contr→is-prop
-        (E⊥M _ (fa2 .mediate∈E) _ (fa2 .forget∈M) _ _ refl)
+        (L⊥R _ (fa2 .left∈L) _ (fa2 .right∈R) _ _ refl)
         ( upq .fst C.∘ vp'q' .fst
         , C.pullr (vp'q' .snd .fst) ∙ upq .snd .fst
         , C.pulll (upq .snd .snd) ∙ vp'q' .snd .snd
@@ -180,7 +169,7 @@ morphism are a proposition.
 ```agda
       uv=id : vp'q' .fst C.∘ upq .fst ≡ C.id
       uv=id = ap fst $ is-contr→is-prop
-        (E⊥M _ (fa1 .mediate∈E) _ (fa1 .forget∈M) _ _ refl)
+        (L⊥R _ (fa1 .left∈L) _ (fa1 .right∈R) _ _ refl)
         ( vp'q' .fst C.∘ upq .fst
         , C.pullr (upq .snd .fst) ∙ vp'q' .snd .fst
         , C.pulll (vp'q' .snd .snd) ∙ upq .snd .snd
@@ -190,7 +179,7 @@ morphism are a proposition.
 
 ```agda
   factorisation-unique
-    : ∀ {a b} (f : C.Hom a b) → is-category C → is-prop (Factorisation C E M f)
+    : ∀ {a b} (f : C.Hom a b) → is-category C → is-prop (Factorisation C L R f)
   factorisation-unique f c-cat x y = go where
     isop1p2 = factorisation-essentially-unique f x y
 
@@ -198,61 +187,61 @@ morphism are a proposition.
     q = Univalent.Hom-pathp-refll-iso c-cat {p = isop1p2 .fst} (isop1p2 .snd .snd)
 
     go : x ≡ y
-    go i .mediating = c-cat .to-path (isop1p2 .fst) i
-    go i .mediate = p i
-    go i .forget = q i
+    go i .mid = c-cat .to-path (isop1p2 .fst) i
+    go i .left = p i
+    go i .right = q i
 ```
 
 <!--
 ```agda
-    go i .mediate∈E = is-prop→pathp (λ i → is-tr (E · (p i))) (x .mediate∈E) (y .mediate∈E) i
-    go i .forget∈M = is-prop→pathp (λ i → is-tr (M · (q i))) (x .forget∈M) (y .forget∈M) i
+    go i .left∈L = is-prop→pathp (λ i → is-tr (L · (p i))) (x .left∈L) (y .left∈L) i
+    go i .right∈R = is-prop→pathp (λ i → is-tr (R · (q i))) (x .right∈R) (y .right∈R) i
     go i .factors =
       is-prop→pathp (λ i → C.Hom-set _ _ f (q i C.∘ p i)) (x .factors) (y .factors) i
 ```
 -->
 
-As a passing observation, note that the intersection $E \cap M$ is
+As a passing observation, note that the intersection $L \cap R$ is
 precisely the class of isomorphisms of $f$. Every isomorphism is in both
 classes, by the definition, and if a morphism is in both classes, it is
 orthogonal to itself, hence an isomorphism.
 
 ```agda
   in-intersection→is-iso
-    : ∀ {a b} (f : C.Hom a b) → f ∈ E → f ∈ M → C.is-invertible f
-  in-intersection→is-iso f f∈E f∈M = self-orthogonal→invertible C f $ E⊥M f f∈E f f∈M
+    : ∀ {a b} (f : C.Hom a b) → f ∈ L → f ∈ R → C.is-invertible f
+  in-intersection→is-iso f f∈L f∈R = self-orthogonal→invertible C f $ L⊥R f f∈L f f∈R
 
   in-intersection≃is-iso
-    : ∀ {a b} (f : C.Hom a b) → C.is-invertible f ≃ ((f ∈ E) × (f ∈ M))
+    : ∀ {a b} (f : C.Hom a b) → C.is-invertible f ≃ (f ∈ L × f ∈ R)
   in-intersection≃is-iso f = prop-ext!
-    (λ fi → is-iso→in-E f fi , is-iso→in-M f fi)
+    (λ fi → is-iso→in-L f fi , is-iso→in-R f fi)
     λ { (a , b) → in-intersection→is-iso f a b }
 ```
 
-The final observation is that the class $E$ is precisely $^\bot M$, the
-class of morphisms left-orthogonal to those in $M$. One direction is by
+The final observation is that the class $L$ is precisely $^\bot R$, the
+class of morphisms left-orthogonal to those in $R$. One direction is by
 definition, and the other is rather technical. Let's focus on the
 technical one.
 
 ```agda
-  E-is-⊥M
+  L-is-⊥R
     : ∀ {a b} (f : C.Hom a b)
-    → (f ∈ E) ≃ (∀ {c d} (m : C.Hom c d) → m ∈ M → Orthogonal C f m)
-  E-is-⊥M f =
-    prop-ext! (λ m f∈E m∈M → to f∈E m m∈M) from
+    → (f ∈ L) ≃ (∀ {c d} (m : C.Hom c d) → m ∈ R → Orthogonal C f m)
+  L-is-⊥R f =
+    prop-ext! (λ m f∈L m∈R → to f∈L m m∈R) from
     where
-      to : ∀ {c d} (m : C.Hom c d) → f ∈ E → m ∈ M → Orthogonal C f m
-      to m f∈E m∈M u v square = E⊥M f f∈E m m∈M u v square
+      to : ∀ {c d} (m : C.Hom c d) → f ∈ L → m ∈ R → Orthogonal C f m
+      to m f∈L m∈R u v square = L⊥R f f∈L m m∈R u v square
 
-      from : (∀ {c d} (m : C.Hom c d) → m ∈ M → Orthogonal C f m) → f ∈ E
-      from ortho = subst (_∈ E) (sym (fa .factors)) $ E-is-stable _ _ (fa .mediate∈E) m∈E
+      from : (∀ {c d} (m : C.Hom c d) → m ∈ R → Orthogonal C f m) → f ∈ L
+      from ortho = subst (_∈ L) (sym (fa .factors)) $ L-is-stable _ _ m∈L (fa .left∈L)
         where
 ```
 
-Suppose that $f$ is left-orthogonal to every $m \in M$, and write out
-the $(E,M)$-factorisation $f = m \circ e$. By a syntactic limitation in
+Suppose that $f$ is left-orthogonal to every $m \in R$, and write out
+the $(L,R)$-factorisation $f = m \circ e$. By a syntactic limitation in
 Agda, we start with the conclusion: We'll show that $m$ is in $E$, and
-since $E$ is closed under composition, so is $f$.  Since $f$ is
+since $L$ is closed under composition, so is $f$.  Since $f$ is
 orthogonal to $m$, we can fit it into a lifting diagram
 
 ~~~{.quiver}
@@ -273,7 +262,7 @@ satisfies $gf=e$ and $mg = \id$.
 
 ```agda
         fa = factor f
-        gpq = ortho (fa .forget) (fa .forget∈M) (fa .mediate) C.id (C.idl _ ∙ (fa .factors))
+        gpq = ortho (fa .right) (fa .right∈R) (fa .left) C.id (C.idl _ ∙ (fa .factors))
 ```
 
 We'll show $gm = \id$ by fitting it into a lifting diagram. But
@@ -295,18 +284,18 @@ needed.
 ~~~
 
 ```agda
-        gm=id : gpq .centre .fst C.∘ (fa .forget) ≡ C.id
+        gm=id : gpq .centre .fst C.∘ (fa .right) ≡ C.id
         gm=id = ap fst $ is-contr→is-prop
-          (E⊥M _ (fa .mediate∈E) _ (fa .forget∈M) _ _ refl)
+          (L⊥R _ (fa .left∈L) _ (fa .right∈R) _ _ refl)
           ( _ , C.pullr (sym (fa .factors)) ∙ gpq .centre .snd .fst
           , C.cancell (gpq .centre .snd .snd)) (C.id , C.idl _ , C.idr _)
 ```
 
 Think back to the conclusion we wanted to reach: $m$ is in $E$, so since
-$f = m \circ e$ and $E$ is stable, so is $f$!
+$f = m \circ e$ and $L$ is stable, so is $f$!
 
 ```agda
-        m∈E : fa .forget ∈ E
-        m∈E = is-iso→in-E (fa .forget) $
+        m∈L : fa .right ∈ L
+        m∈L = is-iso→in-L (fa .right) $
           C.make-invertible (gpq .centre .fst) (gpq .centre .snd .snd) gm=id
 ```

--- a/src/Cat/Morphism/Lifts.lagda.md
+++ b/src/Cat/Morphism/Lifts.lagda.md
@@ -77,8 +77,8 @@ there [[merely]] exists a lifting $w$.
 
 We can also talk about objects with left or right lifting properties.
 An object $P : \cC$ left lefts against a morphism $f$ if for every
-cospan $P \xto{u} X \xfrom{f} Y$, there merely exists a map $w : \cC(P, X)$
-with $f \circ w = u$.
+cospan $P \xto{u} X \xot{f} Y$, there merely exists a map $w : \cC(P,
+X)$ with $f \circ w = u$.
 
 ~~~{.quiver}
 \begin{tikzcd}
@@ -91,8 +91,8 @@ with $f \circ w = u$.
 \end{tikzcd}
 ~~~
 
-Similarly, an object $A$ right lifts against a morphism $f$ if for
-every span $Y \xfrom{f} X \xto{u} A$, there merely exists a map $w : \cC(Y, A)$
+Similarly, an object $A$ right lifts against a morphism $f$ if for every
+span $Y \xot{f} X \xto{u} A$, there merely exists a map $w : \cC(Y, A)$
 with $w \circ f = u$.
 
 \begin{tikzcd}

--- a/src/Cat/Morphism/Lifts.lagda.md
+++ b/src/Cat/Morphism/Lifts.lagda.md
@@ -2,6 +2,7 @@
 description: |
   Lifting properties.
 ---
+
 <!--
 ```agda
 open import Cat.Instances.Shape.Interval
@@ -11,6 +12,7 @@ open import Cat.Prelude
 import Cat.Reasoning
 ```
 -->
+
 ```agda
 module Cat.Morphism.Lifts where
 ```
@@ -27,7 +29,6 @@ private module Impl {o ℓ} {C : Precategory o ℓ} where
       f g h u v : Hom a b
 ```
 -->
-
 
 :::{.definition #lifting}
 Let $f, g, u, v$ be a square of morphisms fitting into a commutative

--- a/src/Cat/Morphism/Lifts.lagda.md
+++ b/src/Cat/Morphism/Lifts.lagda.md
@@ -171,10 +171,7 @@ aforementioned lifting properties.
     {-# INCOHERENT Lifts-against-arrows-right #-}
 
 open Impl hiding (Lifts; Orthogonal; Lifting) public
-private open module Reimpl {o ℓ} (C : Precategory o ℓ) = Impl {C = C} using (Lifts; Orthogonal; Lifting) public
-{-# DISPLAY Impl.Lifts {C = C} L R = Lifts C L R #-}
-{-# DISPLAY Impl.Orthogonal {C = C} L R = Orthogonal C L R #-}
-{-# DISPLAY Impl.Lifting {C = C} f g h k = Lifting C f g h k #-}
+module _ {o ℓ} (C : Precategory o ℓ) where open Impl {C = C} using (Lifts ; Orthogonal ; Lifting) public
 
 module _ {o ℓ} (C : Precategory o ℓ) where
   open Cat.Reasoning C
@@ -229,8 +226,7 @@ some short calculations show that both triangles commute.
 ```agda
   invertible-left-lifts f f-inv u v vf=gu =
     pure (u ∘ f.inv , cancelr f.invr , pulll (sym vf=gu) ∙ cancelr f.invl)
-    where
-      module f = is-invertible f-inv
+    where module f = is-invertible f-inv
 ```
 
 <details>
@@ -240,8 +236,7 @@ some short calculations show that both triangles commute.
 ```agda
   invertible-right-lifts g g-inv u v vf=gu =
     pure (g.inv ∘ v , pullr vf=gu ∙ cancell g.invr , cancell g.invl)
-    where
-      module g = is-invertible g-inv
+    where module g = is-invertible g-inv
 ```
 </details>
 
@@ -371,8 +366,8 @@ type of lifts of such a square is a proposition.
 ```agda
   left-epic→lift-is-prop
     : is-epic f → v ∘ f ≡ g ∘ u → is-prop (Lifting C f g u v)
-  left-epic→lift-is-prop f-epi vf=gu (l , lf=u , _) (k , kf=u , _) =
-    Σ-prop-path! (f-epi l k (lf=u ∙ sym kf=u))
+  left-epic→lift-is-prop f-epi vf=gu (l , lf=u , _) (k , kf=u , _) = Σ-prop-path! $
+    f-epi l k (lf=u ∙ sym kf=u)
 ```
 
 Dually, if $g$ is a [[monomorphism]], then we the type of lifts is also

--- a/src/Cat/Morphism/Lifts.lagda.md
+++ b/src/Cat/Morphism/Lifts.lagda.md
@@ -39,10 +39,10 @@ square like so:
   A && X \\
   \\
   B && {Y\text{.}}
-  \arrow["f", from=1-1, to=1-3]
-  \arrow["g", from=3-1, to=3-3]
-  \arrow["u"', from=1-1, to=3-1]
-  \arrow["v", from=1-3, to=3-3]
+  \arrow["u", from=1-1, to=1-3]
+  \arrow["v", from=3-1, to=3-3]
+  \arrow["f"', from=1-1, to=3-1]
+  \arrow["g", from=1-3, to=3-3]
 \end{tikzcd}\]
 ~~~
 
@@ -66,17 +66,17 @@ and $g$ *right lifts against* $f$ if for every commutative square
   A && X \\
   \\
   B && {Y\text{.}}
-  \arrow["f", from=1-1, to=1-3]
-  \arrow["g", from=3-1, to=3-3]
-  \arrow["u"', from=1-1, to=3-1]
-  \arrow["v", from=1-3, to=3-3]
+  \arrow["u", from=1-1, to=1-3]
+  \arrow["v", from=3-1, to=3-3]
+  \arrow["f"', from=1-1, to=3-1]
+  \arrow["g", from=1-3, to=3-3]
 \end{tikzcd}\]
 ~~~
 
 there [[merely]] exists a lifting $w$.
 
 We can also talk about objects with left or right lifting properties.
-An object $P : \cC$ left lefts against a morphism $f$ if for every
+An object $P : \cC$ left lifts against a morphism $f$ if for every
 cospan $P \xto{u} X \xot{f} Y$, there merely exists a map $w : \cC(P,
 X)$ with $f \circ w = u$.
 
@@ -343,15 +343,15 @@ $l$ and $k$ are both lifts of the outer square
 
 ~~~{.quiver}
 \begin{tikzcd}
-  a && b \\
+  A && X \\
   \\
-  c && d.
-  \arrow["f", from=1-1, to=1-3]
-  \arrow["u"', from=1-1, to=3-1]
-  \arrow["l"', shift right, from=1-3, to=3-1]
-  \arrow["k", shift left, from=1-3, to=3-1]
-  \arrow["v", from=1-3, to=3-3]
-  \arrow["g"', from=3-1, to=3-3]
+  B && Y
+  \arrow["u", from=1-1, to=1-3]
+  \arrow["f"', from=1-1, to=3-1]
+  \arrow["g", from=1-3, to=3-3]
+  \arrow["k"', shift right=2, from=3-1, to=1-3]
+  \arrow["l", shift left=2, from=3-1, to=1-3]
+  \arrow["v"', from=3-1, to=3-3]
 \end{tikzcd}
 ~~~
 

--- a/src/Cat/Morphism/Lifts.lagda.md
+++ b/src/Cat/Morphism/Lifts.lagda.md
@@ -1,0 +1,355 @@
+---
+description: |
+  Lifting properties.
+---
+<!--
+```agda
+open import Cat.Instances.Shape.Interval
+open import Cat.Morphism.Class
+open import Cat.Prelude
+
+import Cat.Reasoning
+```
+-->
+```agda
+module Cat.Morphism.Lifts where
+```
+
+# Lifting properties of morphisms
+
+<!--
+```agda
+private module Impl {o ℓ} {C : Precategory o ℓ} where
+  open Precategory C
+  private
+    variable
+      a b c d x y : ⌞ C ⌟
+      f g h u v : Hom a b
+```
+-->
+
+
+:::{.definition #lifting}
+Let $f, g, u, v$ be a square of morphisms fitting into a commutative
+square like so:
+
+~~~{.quiver}
+\[\begin{tikzcd}
+  A && X \\
+  \\
+  B && {Y\text{.}}
+  \arrow["f", from=1-1, to=1-3]
+  \arrow["g", from=3-1, to=3-3]
+  \arrow["u"', from=1-1, to=3-1]
+  \arrow["v", from=1-3, to=3-3]
+\end{tikzcd}\]
+~~~
+
+A **lifting** of such a square is a morphism $w : \cC(B, X)$ such
+that $w \circ f = u$ and $g \circ w = v$.
+:::
+
+```agda
+  Lifting
+    : (f : Hom a b) (g : Hom x y) (u : Hom a x) (v : Hom b y)
+    → Type _
+  Lifting {a} {b} {x} {y} f g u v = Σ[ w ∈ Hom b x ] w ∘ f ≡ u × g ∘ w ≡ v
+```
+
+:::{.definition #lifting-property}
+Let $L, R$ be two collections of morphisms of $\cC$. We say
+that $L$ *left lifts against* $R$ and $R$ *right lifts against* $L$
+if for every commutative square
+
+~~~{.quiver}
+\[\begin{tikzcd}
+  A && X \\
+  \\
+  B && {Y\text{.}}
+  \arrow["f", from=1-1, to=1-3]
+  \arrow["g", from=3-1, to=3-3]
+  \arrow["u"', from=1-1, to=3-1]
+  \arrow["v", from=1-3, to=3-3]
+\end{tikzcd}\]
+~~~
+
+with $f \in L$ and $g \in R4, there [[merely]] exists a lifting $w$.
+:::
+
+We can specialize this general definition in quite a few ways, so we will
+make use of instance arguments to avoid a quadratic blowup of definitions.
+
+```agda
+  record Lifts-against
+    {ℓl ℓr}
+    (L : Type ℓl) (R : Type ℓr)
+    (ℓp : Level)
+    : Type (ℓl ⊔ ℓr ⊔ (lsuc ℓp)) where
+    field
+      lifting-prop : L → R → Type ℓp
+
+  open Lifts-against
+
+  Lifts
+    : ∀ {ℓl ℓr ℓp} {L : Type ℓl} {R : Type ℓr}
+    → L → R → ⦃ _ :  Lifts-against L R ℓp ⦄ → Type _
+  Lifts l r ⦃ Lifts ⦄ = Lifts .lifting-prop l r
+```
+
+:::{.definition #lifts-against}
+We say $f$ *lifts against* $g$ if there is a map assigning lifts to
+every commutative squares with opposing $f$ and $g$ faces, as above.
+This is a special case of a lifting property, where $L$ and $R$ are taken
+to be singleton sets containing $f$ and $g$, resp.
+:::
+
+```agda
+  instance
+    Lifts-against-hom-hom : ∀ {a b x y} → Lifts-against (Hom a b) (Hom x y) ℓ
+    Lifts-against-hom-hom .lifting-prop f g = ∀ u v → v ∘ f ≡ g ∘ u → ∥ Lifting f g u v ∥
+```
+
+We can also consider lifting against objects.
+
+```agda
+    Lifts-against-ob-hom : ∀ {x y} → Lifts-against Ob (Hom x y) ℓ
+    Lifts-against-ob-hom {x} {y} .lifting-prop a f = ∀ (u : Hom a y) → ∥ Σ[ h ∈ Hom a x ] f ∘ h ≡ u ∥
+
+    Lifts-against-hom-ob : ∀ {a b} → Lifts-against (Hom a b) Ob ℓ
+    Lifts-against-hom-ob {a} {b} .lifting-prop f x = ∀ (u : Hom a x) → ∥ Σ[ h ∈ Hom b x ] h ∘ f ≡ u ∥
+```
+
+Finally, we can define general lifting properties against sets of morphisms
+via instance resolution.
+
+```agda
+    Lifts-against-arrows-left
+      : ∀ {ℓr ℓp κ} {R : Type ℓr}
+      → ⦃ _ : ∀ {a b} → Lifts-against (Hom a b) R ℓp ⦄
+      → Lifts-against (Arrows C κ) R (o ⊔ ℓ ⊔ ℓp ⊔ κ)
+    Lifts-against-arrows-left .lifting-prop L r = ∀ {a b} → (f : Hom a b) → f ∈ L → Lifts f r
+
+    Lifts-against-arrows-right
+      : ∀ {ℓl ℓp κ} {L : Type ℓl}
+      → ⦃ _ : ∀ {x y} → Lifts-against L (Hom x y) ℓp ⦄
+      → Lifts-against L (Arrows C κ) (o ⊔ ℓ ⊔ ℓp ⊔ κ)
+    Lifts-against-arrows-right .lifting-prop l R = ∀ {x y} → (f : Hom x y) → f ∈ R → Lifts l f
+    {-# INCOHERENT Lifts-against-arrows-right #-}
+```
+
+<!--
+```agda
+open Impl hiding (Lifts; Lifting) public
+private open module Reimpl {o ℓ} (C : Precategory o ℓ) = Impl {C = C} using (Lifts; Lifting) public
+{-# DISPLAY Impl.Lifts {C = C} L R = Lifts C L R #-}
+{-# DISPLAY Impl.Lifting {C = C} f g h k = Lifting C f g h k #-}
+
+module _ {o ℓ} (C : Precategory o ℓ) where
+  open Cat.Reasoning C
+  private
+    module Arr = Cat.Reasoning (Arr C)
+    variable
+      a b c d x y : ⌞ C ⌟
+      f g h u v : Hom a b
+
+```
+-->
+
+## Basic properties of liftings
+
+[[Invertible]] morphisms have left and right liftings against all morphisms.
+
+```agda
+  invertible-left-lifts : Lifts C Isos g
+  invertible-right-lifts : Lifts C f Isos
+```
+
+Consider a square like the one below with $f$ invertible.
+
+~~~{.quiver}
+\begin{tikzcd}
+  A && X \\
+  \\
+  B && Y
+  \arrow["u", from=1-1, to=1-3]
+  \arrow["f"', from=1-1, to=3-1]
+  \arrow["g", from=1-3, to=3-3]
+  \arrow[dashed, from=3-1, to=1-3]
+  \arrow["v"', from=3-1, to=3-3]
+\end{tikzcd}
+~~~
+
+The composite $v \circ f^{-1}$ fits perfectly along the diagonal, and
+some short calculations show that both triangles commute.
+
+~~~{.quiver}
+\begin{tikzcd}
+  A && X \\
+  \\
+  B && Y
+  \arrow["u", from=1-1, to=1-3]
+  \arrow["f"', from=1-1, to=3-1]
+  \arrow["g", from=1-3, to=3-3]
+  \arrow["{u \circ f^{-1}}"{description}, dashed, from=3-1, to=1-3]
+  \arrow["v"', from=3-1, to=3-3]
+\end{tikzcd}
+~~~
+
+```agda
+  invertible-left-lifts f f-inv u v vf=gu =
+    pure (u ∘ f.inv , cancelr f.invr , pulll (sym vf=gu) ∙ cancelr f.invl)
+    where
+      module f = is-invertible f-inv
+```
+
+<details>
+<summary>The proof for right lifts is formally dual.
+</summary>
+
+```agda
+  invertible-right-lifts g g-inv u v vf=gu =
+    pure (g.inv ∘ v , pullr vf=gu ∙ cancell g.invr , cancell g.invl)
+    where
+      module g = is-invertible g-inv
+```
+</details>
+
+If both $f : \cC(B,C)$ and $g : \cC(A,B)$ left lift against some $h : \cC(X,Y)$,
+then so does $f \circ g$.
+
+```agda
+  ∘l-lifts-against : Lifts C f h → Lifts C g h → Lifts C (f ∘ g) h
+```
+
+Showing that $f \circ g$ lifts against $h$ amounts to finding a diagonal
+for the rectangle
+
+~~~{.quiver}
+\begin{tikzcd}
+  A && X \\
+  \\
+  B \\
+  \\
+  C && Y
+  \arrow["u", from=1-1, to=1-3]
+  \arrow["g"', from=1-1, to=3-1]
+  \arrow["h", from=1-3, to=5-3]
+  \arrow["f"', from=3-1, to=5-1]
+  \arrow["v"', from=5-1, to=5-3]
+\end{tikzcd}
+~~~
+
+under the assumption that $v \circ f \circ g = h \circ u$. Our first move
+is to re-orient the square and use $g$'s lifting property to find a map
+$w : \cC(B,X)$ with $g \circ w = u$ and $v \circ f = h \circ w$.
+
+~~~{.quiver}
+\begin{tikzcd}
+  A &&&& X \\
+  \\
+  B && C && Y
+  \arrow["u", from=1-1, to=1-5]
+  \arrow["g"', from=1-1, to=3-1]
+  \arrow["h", from=1-5, to=3-5]
+  \arrow["w"{description}, dashed, from=3-1, to=1-5]
+  \arrow["f"', from=3-1, to=3-3]
+  \arrow["v"', from=3-3, to=3-5]
+\end{tikzcd}
+~~~
+
+The bottom triangle of the above diagram can be arranged as a square
+with $f$ on the right and $h$ on the left, which lets us use $f$'s
+lifting property to find a map $t : \cC(C,X)$.
+
+If we place $t$ along the diagonal of our original square, we can see
+that $t \circ f \circ g = w \circ g = u$ and $h \circ t = v$.
+
+~~~{.quiver}
+\begin{tikzcd}
+  A && X \\
+  \\
+  B \\
+  \\
+  C && Y
+  \arrow["u", from=1-1, to=1-3]
+  \arrow["g"', from=1-1, to=3-1]
+  \arrow["h", from=1-3, to=5-3]
+  \arrow["w"{description}, dashed, from=3-1, to=1-3]
+  \arrow["f"', from=3-1, to=5-1]
+  \arrow["t"{description}, dashed, from=5-1, to=1-3]
+  \arrow["v"', from=5-1, to=5-3]
+\end{tikzcd}
+~~~
+
+```agda
+  ∘l-lifts-against {f = f} f-lifts g-lifts u v vfg=hu = do
+    (w , wg=u , hw=vf) ← g-lifts u (v ∘ f) (reassocl.from vfg=hu)
+    (t , tf=w , ht=v)  ← f-lifts w v (sym hw=vf)
+    pure (t , pulll tf=w ∙ wg=u , ht=v)
+```
+
+Dually, if $g : \cC(Y,Z)$ and $h : \cC(X,Y)$ both right lift against a
+morphism $f$, then so does $g \circ h$.
+
+```agda
+  ∘r-lifts-against : Lifts C f g → Lifts C f h → Lifts C f (g ∘ h)
+```
+
+<details>
+<summary>The proof follows the exact same trajectory as the left case,
+so we will spare the reader the details.
+</summary>
+```agda
+  ∘r-lifts-against {h = h} f-lifts g-lifts u v ve=fgu = do
+    (w , we=gu , fw=v) ← f-lifts (h ∘ u) v (reassocr.to ve=fgu)
+    (t , te=u , gt=w)  ← g-lifts u w we=gu
+    pure (t , te=u , pullr gt=w ∙ fw=v)
+```
+</details>
+
+For the next few lemmas, consider a square of the following form, where
+$l$ and $k$ are both lifts of the outer square
+
+~~~{.quiver}
+\begin{tikzcd}
+  a && b \\
+  \\
+  c && d.
+  \arrow["f", from=1-1, to=1-3]
+  \arrow["u"', from=1-1, to=3-1]
+  \arrow["l"', shift right, from=1-3, to=3-1]
+  \arrow["k", shift left, from=1-3, to=3-1]
+  \arrow["v", from=1-3, to=3-3]
+  \arrow["g"', from=3-1, to=3-3]
+\end{tikzcd}
+~~~
+
+<!--
+```agda
+  ∘l-lifts-class : ∀ {κ} (R : Arrows C κ) → Lifts C f R → Lifts C g R → Lifts C (f ∘ g) R
+  ∘l-lifts-class R f-lifts g-lifts r r∈R = ∘l-lifts-against (f-lifts r r∈R) (g-lifts r r∈R)
+
+  ∘r-lifts-class : ∀ {κ} (L : Arrows C κ) → Lifts C L f → Lifts C L g → Lifts C L (f ∘ g)
+  ∘r-lifts-class L f-lifts g-lifts l l∈L = ∘r-lifts-against (f-lifts l l∈L) (g-lifts l l∈L)
+```
+-->
+
+If $f$ is an [[epimorphism]], then $l = k$. In more succinct terms, the
+type of lifts of such a square is a proposition.
+
+```agda
+  left-epic→lift-is-prop
+    : is-epic f → v ∘ f ≡ g ∘ u → is-prop (Lifting C f g u v)
+  left-epic→lift-is-prop f-epi vf=gu (l , lf=u , _) (k , kf=u , _) =
+    Σ-prop-path! (f-epi l k (lf=u ∙ sym kf=u))
+```
+
+Dually, if $g$ is a [[monomorphism]], then we the type of lifts is also
+a proposition.
+
+```agda
+  right-monic→lift-is-prop
+    : is-monic g → v ∘ f ≡ g ∘ u → is-prop (Lifting C f g u v)
+  right-monic→lift-is-prop g-mono vf=gu (l , _ , gl=v) (k , _ , gk=v) =
+    Σ-prop-path! (g-mono l k (gl=v ∙ sym gk=v))
+```

--- a/src/Cat/Morphism/Lifts.lagda.md
+++ b/src/Cat/Morphism/Lifts.lagda.md
@@ -57,10 +57,9 @@ that $w \circ f = u$ and $g \circ w = v$.
   Lifting {a} {b} {x} {y} f g u v = Σ[ w ∈ Hom b x ] w ∘ f ≡ u × g ∘ w ≡ v
 ```
 
-:::{.definition #lifting-property}
-Let $L, R$ be two collections of morphisms of $\cC$. We say
-that $L$ *left lifts against* $R$ and $R$ *right lifts against* $L$
-if for every commutative square
+:::{.definition #lifts-against}
+Let $f, g$ be two morphisms of $\cC$. We say that $f$ *left lifts against* $g$
+and $g$ *right lifts against* $f$ if for every commutative square
 
 ~~~{.quiver}
 \[\begin{tikzcd}
@@ -74,12 +73,50 @@ if for every commutative square
 \end{tikzcd}\]
 ~~~
 
-with $f \in L$ and $g \in R4, there [[merely]] exists a lifting $w$.
+there [[merely]] exists a lifting $w$.
+
+We can also talk about objects with left or right lifting properties.
+An object $P : \cC$ left lefts against a morphism $f$ if for every
+cospan $P \xto{u} X \xfrom{f} Y$, there merely exists a map $w : \cC(P, X)$
+with $f \circ w = u$.
+
+~~~{.quiver}
+\begin{tikzcd}
+  && X \\
+  \\
+  P && Y
+  \arrow["f", from=1-3, to=3-3]
+  \arrow["{\exists w}", dashed, from=3-1, to=1-3]
+  \arrow["u"', from=3-1, to=3-3]
+\end{tikzcd}
+~~~
+
+Similarly, an object $A$ right lifts against a morphism $f$ if for
+every span $Y \xfrom{f} X \xto{u} A$, there merely exists a map $w : \cC(Y, A)$
+with $w \circ f = u$.
+
+\begin{tikzcd}
+  X && A \\
+  \\
+  Y
+  \arrow["u", from=1-1, to=1-3]
+  \arrow["f"', from=1-1, to=3-1]
+  \arrow["{\exists w}", dashed, from=3-1, to=1-3]
+\end{tikzcd}
+
+Finally, we say that a class of morphisms $L \subseteq \mathrm{Arr}(C)$
+lifts against another class of morphisms $R \subseteq \mathrm{Arr}(C)$
+when every $l \in L$ lifts against every $r \in R$. Note that we
+can also consider liftings of objects/morphisms against classes of
+morphisms, but we will leave the reader to fill in the definitions.
 :::
 
-We can specialize this general definition in quite a few ways, so we will
-make use of instance arguments to avoid a quadratic blowup of definitions.
+:::{.note}
+In the formalisation, we will write `Lifts` to denote all of the
+aforementioned lifting properties.
+:::
 
+<!--
 ```agda
   record Lifts-against
     {ℓl ℓr}
@@ -87,62 +124,56 @@ make use of instance arguments to avoid a quadratic blowup of definitions.
     (ℓp : Level)
     : Type (ℓl ⊔ ℓr ⊔ (lsuc ℓp)) where
     field
-      lifting-prop : L → R → Type ℓp
+      lifts-prop : L → R → Type ℓp
+      orthogonal-prop : L → R → Type ℓp
 
   open Lifts-against
 
   Lifts
     : ∀ {ℓl ℓr ℓp} {L : Type ℓl} {R : Type ℓr}
     → L → R → ⦃ _ :  Lifts-against L R ℓp ⦄ → Type _
-  Lifts l r ⦃ Lifts ⦄ = Lifts .lifting-prop l r
-```
+  Lifts l r ⦃ Lifts ⦄ = Lifts .lifts-prop l r
 
-:::{.definition #lifts-against}
-We say $f$ *lifts against* $g$ if there is a map assigning lifts to
-every commutative squares with opposing $f$ and $g$ faces, as above.
-This is a special case of a lifting property, where $L$ and $R$ are taken
-to be singleton sets containing $f$ and $g$, resp.
-:::
+  Orthogonal
+    : ∀ {ℓl ℓr ℓp} {L : Type ℓl} {R : Type ℓr}
+    → L → R → ⦃ _ :  Lifts-against L R ℓp ⦄ → Type _
+  Orthogonal l r ⦃ Lifts ⦄ = Lifts .orthogonal-prop l r
 
-```agda
   instance
     Lifts-against-hom-hom : ∀ {a b x y} → Lifts-against (Hom a b) (Hom x y) ℓ
-    Lifts-against-hom-hom .lifting-prop f g = ∀ u v → v ∘ f ≡ g ∘ u → ∥ Lifting f g u v ∥
-```
+    Lifts-against-hom-hom .lifts-prop f g = ∀ u v → v ∘ f ≡ g ∘ u → ∥ Lifting f g u v ∥
+    Lifts-against-hom-hom .orthogonal-prop f g = ∀ u v → v ∘ f ≡ g ∘ u → is-contr (Lifting f g u v)
 
-We can also consider lifting against objects.
-
-```agda
     Lifts-against-ob-hom : ∀ {x y} → Lifts-against Ob (Hom x y) ℓ
-    Lifts-against-ob-hom {x} {y} .lifting-prop a f = ∀ (u : Hom a y) → ∥ Σ[ h ∈ Hom a x ] f ∘ h ≡ u ∥
+    Lifts-against-ob-hom {x} {y} .lifts-prop a f = ∀ (u : Hom a y) → ∥ Σ[ h ∈ Hom a x ] f ∘ h ≡ u ∥
+    Lifts-against-ob-hom {x} {y} .orthogonal-prop a f = ∀ (u : Hom a y) → is-contr (Σ[ h ∈ Hom a x ] f ∘ h ≡ u)
 
     Lifts-against-hom-ob : ∀ {a b} → Lifts-against (Hom a b) Ob ℓ
-    Lifts-against-hom-ob {a} {b} .lifting-prop f x = ∀ (u : Hom a x) → ∥ Σ[ h ∈ Hom b x ] h ∘ f ≡ u ∥
-```
+    Lifts-against-hom-ob {a} {b} .lifts-prop f x = ∀ (u : Hom a x) → ∥ Σ[ h ∈ Hom b x ] h ∘ f ≡ u ∥
+    Lifts-against-hom-ob {a} {b} .orthogonal-prop f x = ∀ (u : Hom a x) → is-contr (Σ[ h ∈ Hom b x ] h ∘ f ≡ u)
 
-Finally, we can define general lifting properties against sets of morphisms
-via instance resolution.
-
-```agda
+    -- We need an INCOHERENT here to avoid competing instances for
+    -- 'Lifts L R' when 'L, R : Arrows C'. We prefer to use the left instance first, as that
+    -- will lay out our arguments left-to-right.
     Lifts-against-arrows-left
       : ∀ {ℓr ℓp κ} {R : Type ℓr}
       → ⦃ _ : ∀ {a b} → Lifts-against (Hom a b) R ℓp ⦄
       → Lifts-against (Arrows C κ) R (o ⊔ ℓ ⊔ ℓp ⊔ κ)
-    Lifts-against-arrows-left .lifting-prop L r = ∀ {a b} → (f : Hom a b) → f ∈ L → Lifts f r
+    Lifts-against-arrows-left .lifts-prop L r = ∀ {a b} → (f : Hom a b) → f ∈ L → Lifts f r
+    Lifts-against-arrows-left .orthogonal-prop L r = ∀ {a b} → (f : Hom a b) → f ∈ L → Orthogonal f r
 
     Lifts-against-arrows-right
       : ∀ {ℓl ℓp κ} {L : Type ℓl}
       → ⦃ _ : ∀ {x y} → Lifts-against L (Hom x y) ℓp ⦄
       → Lifts-against L (Arrows C κ) (o ⊔ ℓ ⊔ ℓp ⊔ κ)
-    Lifts-against-arrows-right .lifting-prop l R = ∀ {x y} → (f : Hom x y) → f ∈ R → Lifts l f
+    Lifts-against-arrows-right .lifts-prop l R = ∀ {x y} → (f : Hom x y) → f ∈ R → Lifts l f
+    Lifts-against-arrows-right .orthogonal-prop l R = ∀ {x y} → (f : Hom x y) → f ∈ R → Orthogonal l f
     {-# INCOHERENT Lifts-against-arrows-right #-}
-```
 
-<!--
-```agda
-open Impl hiding (Lifts; Lifting) public
-private open module Reimpl {o ℓ} (C : Precategory o ℓ) = Impl {C = C} using (Lifts; Lifting) public
+open Impl hiding (Lifts; Orthogonal; Lifting) public
+private open module Reimpl {o ℓ} (C : Precategory o ℓ) = Impl {C = C} using (Lifts; Orthogonal; Lifting) public
 {-# DISPLAY Impl.Lifts {C = C} L R = Lifts C L R #-}
+{-# DISPLAY Impl.Orthogonal {C = C} L R = Orthogonal C L R #-}
 {-# DISPLAY Impl.Lifting {C = C} f g h k = Lifting C f g h k #-}
 
 module _ {o ℓ} (C : Precategory o ℓ) where
@@ -152,7 +183,6 @@ module _ {o ℓ} (C : Precategory o ℓ) where
     variable
       a b c d x y : ⌞ C ⌟
       f g h u v : Hom a b
-
 ```
 -->
 

--- a/src/Cat/Morphism/Orthogonal.lagda.md
+++ b/src/Cat/Morphism/Orthogonal.lagda.md
@@ -37,85 +37,16 @@ diagram like
 ~~~
 
 the space of [[liftings]] $c \to b$ (dashed) which commute with everything is
-[[contractible]].
-
-<!--
-```agda
-private module Impl {o ℓ} {C : Precategory o ℓ} where
-  open Precategory C
-  private
-    variable
-      a b c d : ⌞ C ⌟
-      f g h u v : Hom a b
-```
--->
+[[contractible]]. We will also speak of orthogonality of an object and a
+morphism, a morphism and a class of morphisms, and so on.
 
 :::{.note}
-In the formalisation, we don't write $\bot$ infix, since it
-must be explicitly applied to the category in which the morphisms live.
-Moreover, we don't want to have to define 8 different predicates for
-orthogonality, so we use instance arguments so we can just write `Orthogonal`{.Agda}
-for all 8 notions.
+In the formalisation, we will write `Orthogonal`{.Agda} to denote all of the
+aforementioned orthogonality properties.
 :::
-
-```agda
-  record Orthogonal-against
-    {ℓl ℓr}
-    (L : Type ℓl) (R : Type ℓr)
-    (ℓp : Level)
-    : Type (ℓl ⊔ ℓr ⊔ (lsuc ℓp)) where
-    field
-      orthogonal-prop : L → R → Type ℓp
-
-  open Orthogonal-against
-
-  Orthogonal
-    : ∀ {ℓl ℓr ℓp} {L : Type ℓl} {R : Type ℓr}
-    → L → R → ⦃ _ :  Orthogonal-against L R ℓp ⦄ → Type _
-  Orthogonal l r ⦃ Orth ⦄ = Orth .orthogonal-prop l r
-
-  instance
-    Orthogonal-against-hom-hom : ∀ {a b x y} → Orthogonal-against (Hom a b) (Hom x y) ℓ
-    Orthogonal-against-hom-hom .orthogonal-prop f g = ∀ u v → v ∘ f ≡ g ∘ u → is-contr (Lifting C f g u v)
-```
-
-We also outline concepts of a map being orthogonal to an object, which
-is informally written $f \ortho X$, and an object being orthogonal to a
-map $Y \ortho f$.
-
-```agda
-    Orthogonal-against-ob-hom : ∀ {x y} → Orthogonal-against Ob (Hom x y) ℓ
-    Orthogonal-against-ob-hom {x} {y} .orthogonal-prop a f = ∀ (u : Hom a y) → is-contr (Σ[ h ∈ Hom a x ] f ∘ h ≡ u)
-
-    Orthogonal-against-hom-ob : ∀ {a b} → Orthogonal-against (Hom a b) Ob ℓ
-    Orthogonal-against-hom-ob {a} {b} .orthogonal-prop f x = ∀ (u : Hom a x) → is-contr (Σ[ h ∈ Hom b x ] h ∘ f ≡ u)
-```
-
-An object or morphism is left/right orthogonal to a class of morphisms $M$ if it
-is left/right orthogonal to every map in $M$. Likewise, two classes $L$ and $R$
-are orthogonal to each other if every $l \in L$ is orthogonal to every $r \in R$.
-
-```agda
-    Orthogonal-against-arrows-left
-      : ∀ {ℓr ℓp κ} {R : Type ℓr}
-      → ⦃ _ : ∀ {a b} → Orthogonal-against (Hom a b) R ℓp ⦄
-      → Orthogonal-against (Arrows C κ) R (o ⊔ ℓ ⊔ ℓp ⊔ κ)
-    Orthogonal-against-arrows-left .orthogonal-prop L r = ∀ {a b} → (f : Hom a b) → f ∈ L → Orthogonal f r
-
-    Orthogonal-against-arrows-right
-      : ∀ {ℓl ℓp κ} {L : Type ℓl}
-      → ⦃ _ : ∀ {x y} → Orthogonal-against L (Hom x y) ℓp ⦄
-      → Orthogonal-against L (Arrows C κ) (o ⊔ ℓ ⊔ ℓp ⊔ κ)
-    Orthogonal-against-arrows-right .orthogonal-prop l R = ∀ {x y} → (f : Hom x y) → f ∈ R → Orthogonal l f
-    {-# INCOHERENT Orthogonal-against-arrows-right #-}
-```
 
 <!--
 ```agda
-open Impl hiding (Orthogonal) public
-private open module Reimpl {o ℓ} (C : Precategory o ℓ) = Impl {C = C} using (Orthogonal) public
-{-# DISPLAY Impl.Orthogonal {C = C} L R = Orthogonal C L R #-}
-
 module _ {o ℓ} (C : Precategory o ℓ) where
   open Cat.Reasoning C
   open Terminal

--- a/src/Cat/Morphism/Orthogonal.lagda.md
+++ b/src/Cat/Morphism/Orthogonal.lagda.md
@@ -254,7 +254,6 @@ to every other class.
 
   invertible→right-orthogonal-class : ∀ {κ} (L : Arrows C κ) → is-invertible f → Orthogonal C L f
   invertible→right-orthogonal-class L f-inv l _ = invertible→right-orthogonal l _ f-inv
-
 ```
 -->
 

--- a/src/Cat/Morphism/Orthogonal.lagda.md
+++ b/src/Cat/Morphism/Orthogonal.lagda.md
@@ -4,10 +4,12 @@ open import Cat.Functor.Adjoint.Reflective
 open import Cat.Functor.Properties
 open import Cat.Diagram.Terminal
 open import Cat.Functor.Adjoint
+open import Cat.Morphism.Class
+open import Cat.Morphism.Lifts
 open import Cat.Prelude
 
-import Cat.Functor.Reasoning as Func
-import Cat.Reasoning as Cr
+import Cat.Functor.Reasoning
+import Cat.Reasoning
 ```
 -->
 
@@ -22,7 +24,6 @@ A pair of maps $f : a \to b$ and $g : c \ to d$ are called
 formalised notation], if for every $u, v$ fitting into a commutative
 diagram like
 
-~~~{.quiver}
 \[\begin{tikzcd}
   a && b \\
   \\
@@ -35,94 +36,122 @@ diagram like
 \end{tikzcd}\]
 ~~~
 
-the space of arrows $c \to b$ (dashed) which commute with everything is
-contractible. We refer to the type of these dashed arrows as a
-`Lifting`{.Agda}, and this type is parametrised over all maps in the
-square.
+the space of [[liftings]] $c \to b$ (dashed) which commute with everything is
+[[contractible]].
 
 <!--
 ```agda
-module _ {o ℓ} (C : Precategory o ℓ) where
+private module Impl {o ℓ} {C : Precategory o ℓ} where
+  open Precategory C
   private
-    module C = Cr C
     variable
       a b c d : ⌞ C ⌟
-      f g h u v : C.Hom a b
-  open C using (Ob ; Hom ; _∘_ ; _≅_)
+      f g h u v : Hom a b
 ```
 -->
 
-```agda
-  Lifting
-    : (f : Hom a b) (g : Hom c d) (u : Hom a c) (v : Hom b d)
-    → Type _
-  Lifting f g u v = Σ[ w ∈ Hom _ _ ] w ∘ f ≡ u × g ∘ w ≡ v
-
-  m⊥m : Hom a b → Hom c d → Type _
-  m⊥m {b = b} {c = c} f g =
-    ∀ {u v} → v ∘ f ≡ g ∘ u
-    → is-contr (Lifting f g u v)
-```
-
-:::{.definition #lifts-against}
-In some of the proofs below, we'll also need a name for a weakening of
-orthogonality, where the requirement that lifts are unique is dropped.
-We say $f$ *lifts against* $g$ if there is a map assigning lifts to
-every commutative squares with opposing $f$ and $g$ faces, as above.
-
-```agda
-  lifts-against : (f : Hom a b) (g : Hom c d) → Type _
-  lifts-against f g = ∀ {u v} → v ∘ f ≡ g ∘ u → Lifting f g u v
-```
+:::{.note}
+In the formalisation, we don't write $\bot$ infix, since it
+must be explicitly applied to the category in which the morphisms live.
+Moreover, we don't want to have to define 8 different predicates for
+orthogonality, so we use instance arguments so we can just write `Orthogonal`{.Agda}
+for all 8 notions.
 :::
+
+```agda
+  record Orthogonal-against
+    {ℓl ℓr}
+    (L : Type ℓl) (R : Type ℓr)
+    (ℓp : Level)
+    : Type (ℓl ⊔ ℓr ⊔ (lsuc ℓp)) where
+    field
+      orthogonal-prop : L → R → Type ℓp
+
+  open Orthogonal-against
+
+  Orthogonal
+    : ∀ {ℓl ℓr ℓp} {L : Type ℓl} {R : Type ℓr}
+    → L → R → ⦃ _ :  Orthogonal-against L R ℓp ⦄ → Type _
+  Orthogonal l r ⦃ Orth ⦄ = Orth .orthogonal-prop l r
+
+  instance
+    Orthogonal-against-hom-hom : ∀ {a b x y} → Orthogonal-against (Hom a b) (Hom x y) ℓ
+    Orthogonal-against-hom-hom .orthogonal-prop f g = ∀ u v → v ∘ f ≡ g ∘ u → is-contr (Lifting C f g u v)
+```
 
 We also outline concepts of a map being orthogonal to an object, which
 is informally written $f \ortho X$, and an object being orthogonal to a
 map $Y \ortho f$.
 
 ```agda
-  m⊥o : Hom a b → ⌞ C ⌟ → Type _
-  m⊥o {a} {b} f X = (a : Hom a X) → is-contr (Σ[ b ∈ Hom b X ] (b ∘ f ≡ a))
+    Orthogonal-against-ob-hom : ∀ {x y} → Orthogonal-against Ob (Hom x y) ℓ
+    Orthogonal-against-ob-hom {x} {y} .orthogonal-prop a f = ∀ (u : Hom a y) → is-contr (Σ[ h ∈ Hom a x ] f ∘ h ≡ u)
 
-  o⊥m : ⌞ C ⌟ → Hom a b → Type _
-  o⊥m {a} {b} Y f = (c : Hom Y b) → is-contr (Σ[ d ∈ Hom Y a ] (f ∘ d ≡ c))
+    Orthogonal-against-hom-ob : ∀ {a b} → Orthogonal-against (Hom a b) Ob ℓ
+    Orthogonal-against-hom-ob {a} {b} .orthogonal-prop f x = ∀ (u : Hom a x) → is-contr (Σ[ h ∈ Hom b x ] h ∘ f ≡ u)
 ```
 
-:::{.note}
-In the formalisation, we don't write $\bot$ infix, since it
-must be explicitly applied to the category in which the morphisms live.
-Thus, we define three distinct predicates expressing orthogonality:
-`m⊥m`{.Agda} ("map-map"), `m⊥o`{.Agda} ("map-object"), and `o⊥m`
-("object-map"). If the ambient category $\cC$ has enough co/limits,
-being orthogonal to an object is equivalent to being orthogonal to a
-morphism. For example, $f \ortho X$ iff. $f \ortho \mathop{!}_X$, where
-$!_X : X \to 1$ is the unique map from $X$ into the [[terminal object]].
-:::
+An object or morphism is left/right orthogonal to a class of morphisms $M$ if it
+is left/right orthogonal to every map in $M$. Likewise, two classes $L$ and $R$
+are orthogonal to each other if every $l \in L$ is orthogonal to every $r \in R$.
+
+```agda
+    Orthogonal-against-arrows-left
+      : ∀ {ℓr ℓp κ} {R : Type ℓr}
+      → ⦃ _ : ∀ {a b} → Orthogonal-against (Hom a b) R ℓp ⦄
+      → Orthogonal-against (Arrows C κ) R (o ⊔ ℓ ⊔ ℓp ⊔ κ)
+    Orthogonal-against-arrows-left .orthogonal-prop L r = ∀ {a b} → (f : Hom a b) → f ∈ L → Orthogonal f r
+
+    Orthogonal-against-arrows-right
+      : ∀ {ℓl ℓp κ} {L : Type ℓl}
+      → ⦃ _ : ∀ {x y} → Orthogonal-against L (Hom x y) ℓp ⦄
+      → Orthogonal-against L (Arrows C κ) (o ⊔ ℓ ⊔ ℓp ⊔ κ)
+    Orthogonal-against-arrows-right .orthogonal-prop l R = ∀ {x y} → (f : Hom x y) → f ∈ R → Orthogonal l f
+    {-# INCOHERENT Orthogonal-against-arrows-right #-}
+```
 
 <!--
 ```agda
+open Impl hiding (Orthogonal) public
+private open module Reimpl {o ℓ} (C : Precategory o ℓ) = Impl {C = C} using (Orthogonal) public
+{-# DISPLAY Impl.Orthogonal {C = C} L R = Orthogonal C L R #-}
+
+module _ {o ℓ} (C : Precategory o ℓ) where
+  open Cat.Reasoning C
   open Terminal
+  private
+    variable
+      a b c d x y : ⌞ C ⌟
+      f g h u v : Hom a b
 ```
 -->
+
+If the ambient category $\cC$ has enough co/limits,
+being orthogonal to an object is equivalent to being orthogonal to a
+morphism. For example, $f \ortho X$ iff. $f \ortho \mathop{!}_X$, where
+$!_X : X \to 1$ is the unique map from $X$ into the [[terminal object]].
+
+```agda
+  object-orthogonal-!-orthogonal
+    : ∀ {X : Ob} (T : Terminal C) (f : Hom a b)
+    → Orthogonal C f X ≃ Orthogonal C f (! T {X})
+```
 
 The proof is mostly a calculation, so we present it without a lot of comment.
 
 ```agda
-  object-orthogonal-!-orthogonal
-    : ∀ {X} (T : Terminal C) (f : Hom a b) → m⊥o f X ≃ m⊥m f (! T)
   object-orthogonal-!-orthogonal {X = X} T f =
-    prop-ext (hlevel 1) (hlevel 1) to from
+    prop-ext! fwd bwd
     where
-      to : m⊥o f X → m⊥m f (! T)
-      to f⊥X {u} {v} sq =
-        contr (f⊥X u .centre .fst , f⊥X u .centre .snd , !-unique₂ T _ _) λ m →
-          Σ-prop-path! (ap fst (f⊥X u .paths (m .fst , m .snd .fst)))
+      module T = Terminal T
 
-      from : m⊥m f (! T) → m⊥o f X
-      from f⊥! a = contr
-        ( f⊥! {v = ! T} (!-unique₂ T _ _) .centre .fst
-        , f⊥! (!-unique₂ T _ _) .centre .snd .fst ) λ x → Σ-prop-path!
-          (ap fst (f⊥! _ .paths (x .fst , x .snd , !-unique₂ T _ _)))
+      fwd : Orthogonal C f X → Orthogonal C f (! T)
+      fwd f⊥X u v sq .centre = f⊥X u .centre .fst , f⊥X u .centre .snd , T.!-unique₂ _ _
+      fwd f⊥X u v sq .paths m = Σ-prop-path! (ap fst (f⊥X u .paths (m .fst , m .snd .fst)))
+
+      bwd : Orthogonal C f (! T) → Orthogonal C f X
+      bwd f⊥! u .centre =  f⊥! u T.! (T.!-unique₂ _ _) .centre .fst , f⊥! u T.! (T.!-unique₂ _ _) .centre .snd .fst
+      bwd f⊥! u .paths (w , eq) = Σ-prop-path! (ap fst (f⊥! _ _ _ .paths (w , eq , (T.!-unique₂ _ _))))
 ```
 
 As a passing observation we note that if $f \ortho X$ and $X \cong Y$,
@@ -130,20 +159,20 @@ then $f \ortho Y$. Of course, this is immediate in categories, but it
 holds in the generality of precategories.
 
 ```agda
-  m⊥-iso : ∀ {a b} {X Y} (f : Hom a b) → X ≅ Y → m⊥o f X → m⊥o f Y
+  obj-orthogonal-iso : ∀ {a b} {X Y} (f : Hom a b) → X ≅ Y → Orthogonal C f X → Orthogonal C f Y
 ```
 
 <!--
 ```agda
-  m⊥-iso f x≅y f⊥X a =
+  obj-orthogonal-iso f x≅y f⊥X a =
     contr
       ( g.to ∘ contr' .centre .fst
-      , C.pullr (contr' .centre .snd) ∙ C.cancell g.invl )
+      , pullr (contr' .centre .snd) ∙ cancell g.invl )
       λ x → Σ-prop-path! $
-        ap₂ _∘_ refl (ap fst (contr' .paths (g.from ∘ x .fst , C.pullr (x .snd))))
-        ∙ C.cancell g.invl
+        ap₂ _∘_ refl (ap fst (contr' .paths (g.from ∘ x .fst , pullr (x .snd))))
+        ∙ cancell g.invl
     where
-      module g = C._≅_ x≅y
+      module g = _≅_ x≅y
       contr' = f⊥X (g.from ∘ a)
 ```
 -->
@@ -152,220 +181,101 @@ A slightly more interesting lemma is that, if $f$ is orthogonal to
 itself, then it is an isomorphism:
 
 ```agda
-  self-orthogonal→invertible : ∀ {a b} (f : Hom a b) → m⊥m f f → C.is-invertible f
+  self-orthogonal→invertible : ∀ {a b} (f : Hom a b) → Orthogonal C f f → is-invertible f
   self-orthogonal→invertible f f⊥f =
-    C.make-invertible (gpq .fst) (gpq .snd .snd) (gpq .snd .fst)
+    make-invertible (gpq .fst) (gpq .snd .snd) (gpq .snd .fst)
     where
-      gpq = f⊥f (C.idl _ ∙ C.intror refl) .centre
+      gpq = f⊥f id id (idl _ ∙ intror refl) .centre
 ```
 
-For the next few lemmas, consider a square of the following form, where
-$l$ and $k$ are both lifts of the outer square
-
-~~~{.quiver}
-\begin{tikzcd}
-  a && b \\
-  \\
-  c && d.
-  \arrow["f", from=1-1, to=1-3]
-  \arrow["u"', from=1-1, to=3-1]
-  \arrow["l"', shift right, from=1-3, to=3-1]
-  \arrow["k", shift left, from=1-3, to=3-1]
-  \arrow["v", from=1-3, to=3-3]
-  \arrow["g"', from=3-1, to=3-3]
-\end{tikzcd}
-~~~
-
-If $f$ is an [[epimorphism]], then $l = k$. In more succinct terms, the
-type of lifts of such a square is a proposition.
-
-```agda
-  left-epic→lift-is-prop
-    : C.is-epic f → v C.∘ f ≡ g C.∘ u → is-prop (Lifting f g u v)
-  left-epic→lift-is-prop f-epi vf=gu (l , lf=u , _) (k , kf=u , _) =
-    Σ-prop-path! (f-epi l k (lf=u ∙ sym kf=u))
-```
-
-Dually, if $g$ is a [[monomorphism]], then we the type of lifts is also
-a proposition.
-
-```agda
-  right-monic→lift-is-prop
-    : C.is-monic g → v C.∘ f ≡ g C.∘ u → is-prop (Lifting f g u v)
-  right-monic→lift-is-prop g-mono vf=gu (l , _ , gl=v) (k , _ , gk=v) =
-    Σ-prop-path! (g-mono l k (gl=v ∙ sym gk=v))
-```
-
-As a corollary, if $f$ is an epi or $g$ is a mono, then it is sufficient
-to find _any_ lift to establish that $f \bot g$.
+If $f$ is an epi or $g$ is a mono, then the mere existence of a
+_any_ lift is enough to establish that $f \bot g$.
 
 ```agda
   left-epic-lift→orthogonal
-    : (g : C.Hom c d)
-    → C.is-epic f → lifts-against f g → m⊥m f g
-  left-epic-lift→orthogonal g f-epi lifts vf=gu =
-    is-prop∙→is-contr (left-epic→lift-is-prop f-epi vf=gu) (lifts vf=gu)
+    : (g : Hom c d)
+    → is-epic f → Lifts C f g → Orthogonal C f g
+  left-epic-lift→orthogonal g f-epi lifts u v vf=gu =
+    is-prop∥∥→is-contr (left-epic→lift-is-prop C f-epi vf=gu) (lifts u v vf=gu)
 
   right-monic-lift→orthogonal
-    : (f : C.Hom a b)
-    → C.is-monic g → lifts-against f g → m⊥m f g
-  right-monic-lift→orthogonal f g-mono lifts vf=gu =
-    is-prop∙→is-contr (right-monic→lift-is-prop g-mono vf=gu) (lifts vf=gu)
+    : (f : Hom a b)
+    → is-monic g → Lifts C f g → Orthogonal C f g
+  right-monic-lift→orthogonal f g-mono lifts u v vf=gu =
+    is-prop∥∥→is-contr (right-monic→lift-is-prop C g-mono vf=gu) (lifts u v vf=gu)
 ```
-
-Isomorphisms are left and right orthogonal to every other morphism.
-
-```agda
-  invertible→left-orthogonal  : (g : C.Hom c d) → C.is-invertible f → m⊥m f g
-  invertible→right-orthogonal : (f : C.Hom a b) → C.is-invertible g → m⊥m f g
-```
-
-We will focus our attention on the left orthogonal case, as the proof
-for right orthogonality is completely dual. Suppose that $f$ is invertible,
-and $g$ is an arbitrary morphism. Invertible morphisms are epis, so it
-suffices to establish the existence of lifts to prove that $f$ is orthogonal
-to $g$. Luckily, these lifts are easy to find: if we have some square
-$v \circ f = u \circ g$, then $u \circ f^{-1}$ fits perfectly along the
-diagonal:
-
-~~~{.quiver}
-\begin{tikzcd}
-  a && b \\
-  \\
-  c && d.
-  \arrow["f", from=1-1, to=1-3]
-  \arrow["u"', from=1-1, to=3-1]
-  \arrow["{u \circ f^{-1}}"{description}, from=1-3, to=3-1]
-  \arrow["v", from=1-3, to=3-3]
-  \arrow["g"', from=3-1, to=3-3]
-\end{tikzcd}
-~~~
-
-A short calculation verifies that $u \circ f^{-1}$ is indeed a lift.
-
-```agda
-  invertible→left-orthogonal {f = f} g f-inv =
-    left-epic-lift→orthogonal g (C.invertible→epic f-inv) λ {u} {v} vf=gu →
-      u ∘ f.inv ,
-      C.cancelr f.invr ,
-      Equiv.from
-        (g ∘ u ∘ f.inv ≡ v   ≃⟨ C.reassocl e⁻¹ ∙e C.pre-invr f-inv ⟩
-         g ∘ u ≡ v ∘ f       ≃⟨ sym-equiv ⟩
-         v ∘ f ≡ g ∘ u       ≃∎)
-        vf=gu
-    where module f = C.is-invertible f-inv
-```
-
-<details>
-<summary>The proof of right orthogonality follows the exact same plan,
-so we omit the details.
-</summary>
-```agda
-  invertible→right-orthogonal {g = g} f g-inv =
-    right-monic-lift→orthogonal f (C.invertible→monic g-inv) λ {u} {v} vf=gu →
-      g.inv ∘ v ,
-      Equiv.from
-        ((g.inv ∘ v) ∘ f ≡ u ≃⟨ C.reassocl ∙e C.pre-invl g-inv ⟩
-          v ∘ f ≡ g ∘ u      ≃∎)
-        vf=gu ,
-      C.cancell g.invl
-    where module g = C.is-invertible g-inv
-```
-</details>
 
 <!--
 ```agda
-  orthogonal→lifts-against : m⊥m f g → lifts-against f g
-  orthogonal→lifts-against o p = o p .centre
+  left-epic-lift→orthogonal-class
+    : ∀ {κ} (R : Arrows C κ)
+    → is-epic f → Lifts C f R → Orthogonal C f R
+  left-epic-lift→orthogonal-class R f-epic lifts r r∈R =
+    left-epic-lift→orthogonal r f-epic (lifts r r∈R)
+
+  right-monic-lift→orthogonal-class
+    : ∀ {κ} (L : Arrows C κ)
+    → is-monic f → Lifts C L f → Orthogonal C L f
+  right-monic-lift→orthogonal-class L f-epic lifts l l∈L =
+    right-monic-lift→orthogonal l f-epic (lifts l l∈L)
 ```
 -->
 
-We also have the following two properties, which state that "lifting
-against" is, as a property of morphisms, closed under composition on
-both the left and the right. To understand the proof, it's helpful to
-visualise the inputs in a diagram. Suppose we have $f : b \to c$, $g : a
-\to b$, $h : x \to y$, and assume that both $f$ and $g$ lift against
-$h$. Showing that $fg$ lifts against $h$ amounts to finding a diagonal
-for the rectangle
-
-~~~{.quiver}
-\[\begin{tikzcd}[ampersand replacement=\&]
-  a \&\& b \&\& c \\
-  \\
-  x \&\&\&\& y
-  \arrow["g", from=1-1, to=1-3]
-  \arrow["u"', from=1-1, to=3-1]
-  \arrow["f", from=1-3, to=1-5]
-  \arrow["v", from=1-5, to=3-5]
-  \arrow["h"', from=3-1, to=3-5]
-\end{tikzcd}\]
-~~~
-
-under the assumption that $vfg = hu$. We'll populate this diagram a bit
-by observing that, by composing the $f$ and $v$ edges together, we have
-a commutative square with faces $g$, $vf$, $u$ and $h$ --- and since $g$
-lifts against $h$, this implies that we have a diagonal map $w$, which
-appears dashed in
-
-~~~{.quiver}
-\[\begin{tikzcd}[ampersand replacement=\&]
-  a \&\& b \&\& c \\
-  \\
-  x \&\&\&\& {y.}
-  \arrow["g", from=1-1, to=1-3]
-  \arrow["u"', from=1-1, to=3-1]
-  \arrow["f", from=1-3, to=1-5]
-  \arrow["w"', dashed, from=1-3, to=3-1]
-  \arrow["v", from=1-5, to=3-5]
-  \arrow["h"', from=3-1, to=3-5]
-\end{tikzcd}\]
-~~~
-
-This map satisfies $wg = u$, and, importantly, $hw = vf$. This latter
-equation implies that we can now treat the right half of the diagram as
-another square, with faces $f$, $h$, $w$, and $v$. Since $f$ *also*
-lifts against $h$, this implies that we can find the *dotted* map $t$ in
-the diagram
-
-~~~{.quiver}
-\[\begin{tikzcd}[ampersand replacement=\&]
-  a \&\& b \&\& c \\
-  \\
-  x \&\&\&\& y
-  \arrow["g", from=1-1, to=1-3]
-  \arrow["u"', from=1-1, to=3-1]
-  \arrow["f", from=1-3, to=1-5]
-  \arrow["w"', dashed, from=1-3, to=3-1]
-  \arrow["t", dotted, from=1-5, to=3-1]
-  \arrow["v", from=1-5, to=3-5]
-  \arrow["h"', from=3-1, to=3-5]
-\end{tikzcd}\]
-~~~
-
-satisfying $tf = w$ and $mt = v$. The map $t$ fits the *type* of fillers
-for our original rectangle, but we must still show that it makes both
-triangles commute. But this is easy: we have $tfg = wg = u$ by a short
-calculation and $ht = w$ immediately.
+As a corollary, we get that isomorphisms are left and right orthogonal to every
+other morphism.
 
 ```agda
-  ∘l-lifts-against : lifts-against f h → lifts-against g h → lifts-against (f ∘ g) h
-  ∘l-lifts-against f-lifts g-lifts vfg=hu =
-    let (w , wg=u , hw=vf) = g-lifts (C.reassocl.from vfg=hu)
-        (t , tf=w , ht=v)  = f-lifts (sym hw=vf)
-    in t , C.pulll tf=w ∙ wg=u , ht=v
+  invertible→left-orthogonal : (g : Hom c d) → Orthogonal C Isos g
+  invertible→left-orthogonal g f f-inv =
+    left-epic-lift→orthogonal g (invertible→epic f-inv) $
+    invertible-left-lifts C f f-inv
+
+  invertible→right-orthogonal : (f : Hom a b) → Orthogonal C f Isos
+  invertible→right-orthogonal f g g-inv =
+    right-monic-lift→orthogonal f (invertible→monic g-inv) $
+    invertible-right-lifts C g g-inv
 ```
 
-This proof dualises almost term-for-term the case where we're composing
-on the bottom face, i.e., when we have some $f$ which lifts against both
-$g$ and $h$, and we want to show $f$ lifts against $gh$.
+Phrased another way, the class of isomorphisms are left and right orthogonal
+to every other class.
 
 ```agda
-  ∘r-lifts-against : lifts-against f g → lifts-against f h → lifts-against f (g ∘ h)
-  ∘r-lifts-against f-lifts g-lifts ve=fgu =
-    let (w , we=gu , fw=v) = f-lifts (C.reassocr.to ve=fgu)
-        (t , te=u , gt=w)  = g-lifts we=gu
-    in t , te=u , C.pullr gt=w ∙ fw=v
+  isos-left-orthogonal : ∀ {κ} (R : Arrows C κ) → Orthogonal C Isos R
+  isos-left-orthogonal R f f-inv r r∈R = invertible→left-orthogonal r f f-inv
+
+  isos-right-orthogonal : ∀ {κ} (L : Arrows C κ) → Orthogonal C L Isos
+  isos-right-orthogonal L l l∈L f f-inv = invertible→right-orthogonal l f f-inv
 ```
+
+<!--
+```agda
+  invertible→left-orthogonal-class : ∀ {κ} (R : Arrows C κ) → is-invertible f → Orthogonal C f R
+  invertible→left-orthogonal-class R f-inv r _ = invertible→left-orthogonal r _ f-inv
+
+  invertible→right-orthogonal-class : ∀ {κ} (L : Arrows C κ) → is-invertible f → Orthogonal C L f
+  invertible→right-orthogonal-class L f-inv l _ = invertible→right-orthogonal l _ f-inv
+
+```
+-->
+
+<!--
+```agda
+  orthogonal→lifts-against : Orthogonal C f g → Lifts C f g
+  orthogonal→lifts-against o u v p = pure (o u v p .centre)
+
+  orthogonal→lifts-left-class
+    : ∀ {κ} (L : Arrows C κ)
+    → Orthogonal C L f → Lifts C L f
+  orthogonal→lifts-left-class L L⊥f l l∈L =
+    orthogonal→lifts-against (L⊥f l l∈L)
+
+  orthogonal→lifts-right-class
+    : ∀ {κ} (R : Arrows C κ)
+    → Orthogonal C f R → Lifts C f R
+  orthogonal→lifts-right-class R f⊥R r r∈R =
+    orthogonal→lifts-against (f⊥R r r∈R)
+```
+-->
 
 ## Regarding reflections
 
@@ -377,12 +287,12 @@ module
     (r⊣ι : r ⊣ ι) (ι-ff : is-fully-faithful ι)
   where
   private
-    module C = Cr C
-    module D = Cr D
-    module ι = Func ι
-    module r = Func r
-    module rι = Func (r F∘ ι)
-    module ιr = Func (ι F∘ r)
+    module C = Cat.Reasoning C
+    module D = Cat.Reasoning D
+    module ι = Cat.Functor.Reasoning ι
+    module r = Cat.Functor.Reasoning r
+    module rι = Cat.Functor.Reasoning (r F∘ ι)
+    module ιr = Cat.Functor.Reasoning (ι F∘ r)
   open _⊣_ r⊣ι
 ```
 -->
@@ -401,7 +311,7 @@ the object. Given a map $a : a \to \iota X$,
 
 ```agda
   in-subcategory→orthogonal-to-inverted
-    : ∀ {X} {a b} {f : C.Hom a b} → D.is-invertible (r.₁ f) → m⊥o C f (ι.₀ X)
+    : ∀ {X} {a b} {f : C.Hom a b} → D.is-invertible (r.₁ f) → Orthogonal C f (ι.₀ X)
   in-subcategory→orthogonal-to-inverted {X} {A} {B} {f} rf-inv a→x =
     contr (fact , factors) λ { (g , factors') →
       Σ-prop-path! (h≡k factors factors') }
@@ -482,7 +392,7 @@ the subcategory:
 
 ```agda
   orthogonal-to-ηs→in-subcategory
-    : ∀ {X} → (∀ B → m⊥o C (unit.η B) X) → C.is-invertible (unit.η X)
+    : ∀ {X} → (∀ B → Orthogonal C (unit.η B) X) → C.is-invertible (unit.η X)
   orthogonal-to-ηs→in-subcategory {X} ortho =
     C.make-invertible x lemma (ortho X C.id .centre .snd)
     where
@@ -501,9 +411,8 @@ which $\eta$ is an isomorphism.
 
 ```agda
   in-subcategory→orthogonal-to-ηs
-    : ∀ {X B} → C.is-invertible (unit.η X) → m⊥o C (unit.η B) X
+    : ∀ {X B} → C.is-invertible (unit.η X) → Orthogonal C (unit.η B) X
   in-subcategory→orthogonal-to-ηs inv =
-    m⊥-iso C (unit.η _) (C.invertible→iso _ (C.is-invertible-inverse inv))
-      (in-subcategory→orthogonal-to-inverted
-        (is-reflective→left-unit-is-iso r⊣ι ι-ff))
+    obj-orthogonal-iso C (unit.η _) (C.invertible→iso _ (C.is-invertible-inverse inv)) $
+    in-subcategory→orthogonal-to-inverted (is-reflective→left-unit-is-iso r⊣ι ι-ff)
 ```

--- a/src/Cat/Morphism/Orthogonal.lagda.md
+++ b/src/Cat/Morphism/Orthogonal.lagda.md
@@ -33,7 +33,7 @@ diagram like
   \arrow["v", from=3-1, to=3-3]
   \arrow["f"', from=1-1, to=3-1]
   \arrow["g", from=1-3, to=3-3]
-  \arrow[dashed, from=1-3, to=3-1]
+  \arrow[dashed, from=3-1, to=1-3]
 \end{tikzcd}\]
 ~~~
 

--- a/src/Cat/Morphism/Orthogonal.lagda.md
+++ b/src/Cat/Morphism/Orthogonal.lagda.md
@@ -19,11 +19,12 @@ module Cat.Morphism.Orthogonal where
 
 # Orthogonal maps {defines="left-orthogonal right-orthogonal orthogonality"}
 
-A pair of maps $f : a \to b$ and $g : c \ to d$ are called
+A pair of maps $f : a \to b$ and $g : c \to d$ are called
 **orthogonal**, written $f \ortho g$^[Though hang tight for a note on
 formalised notation], if for every $u, v$ fitting into a commutative
 diagram like
 
+~~~{.quiver}
 \[\begin{tikzcd}
   a && b \\
   \\
@@ -119,8 +120,8 @@ itself, then it is an isomorphism:
       gpq = f⊥f id id (idl _ ∙ intror refl) .centre
 ```
 
-If $f$ is an epi or $g$ is a mono, then the mere existence of a
-_any_ lift is enough to establish that $f \bot g$.
+If $f$ is an epi or $g$ is a mono, then the mere existence of
+_any_ lift is enough to establish that $f \ortho g$.
 
 ```agda
   left-epic-lift→orthogonal
@@ -167,7 +168,7 @@ other morphism.
     invertible-right-lifts C g g-inv
 ```
 
-Phrased another way, the class of isomorphisms are left and right orthogonal
+Phrased another way, the class of isomorphisms is left and right orthogonal
 to every other class.
 
 ```agda

--- a/src/Cat/Morphism/Orthogonal.lagda.md
+++ b/src/Cat/Morphism/Orthogonal.lagda.md
@@ -72,18 +72,23 @@ $!_X : X \to 1$ is the unique map from $X$ into the [[terminal object]].
 The proof is mostly a calculation, so we present it without a lot of comment.
 
 ```agda
-  object-orthogonal-!-orthogonal {X = X} T f =
-    prop-ext! fwd bwd
-    where
-      module T = Terminal T
+  object-orthogonal-!-orthogonal {X = X} T f = prop-ext! fwd bwd where
+    module T = Terminal T
 
-      fwd : Orthogonal C f X → Orthogonal C f (! T)
-      fwd f⊥X u v sq .centre = f⊥X u .centre .fst , f⊥X u .centre .snd , T.!-unique₂ _ _
-      fwd f⊥X u v sq .paths m = Σ-prop-path! (ap fst (f⊥X u .paths (m .fst , m .snd .fst)))
+    fwd : Orthogonal C f X → Orthogonal C f T.!
+    fwd f⊥X u v sq .centre =
+        f⊥X u .centre .fst
+      , f⊥X u .centre .snd
+      , T.!-unique₂ _ _
+    fwd f⊥X u v sq .paths m = Σ-prop-path! $
+      ap fst (f⊥X u .paths (m .fst , m .snd .fst))
 
-      bwd : Orthogonal C f (! T) → Orthogonal C f X
-      bwd f⊥! u .centre =  f⊥! u T.! (T.!-unique₂ _ _) .centre .fst , f⊥! u T.! (T.!-unique₂ _ _) .centre .snd .fst
-      bwd f⊥! u .paths (w , eq) = Σ-prop-path! (ap fst (f⊥! _ _ _ .paths (w , eq , (T.!-unique₂ _ _))))
+    bwd : Orthogonal C f (! T) → Orthogonal C f X
+    bwd f⊥! u .centre =
+        f⊥! u T.! (T.!-unique₂ _ _) .centre .fst
+      , f⊥! u T.! (T.!-unique₂ _ _) .centre .snd .fst
+    bwd f⊥! u .paths (w , eq) = Σ-prop-path! $
+      ap fst (f⊥! _ _ _ .paths (w , eq , (T.!-unique₂ _ _)))
 ```
 
 As a passing observation we note that if $f \ortho X$ and $X \cong Y$,
@@ -91,7 +96,9 @@ then $f \ortho Y$. Of course, this is immediate in categories, but it
 holds in the generality of precategories.
 
 ```agda
-  obj-orthogonal-iso : ∀ {a b} {X Y} (f : Hom a b) → X ≅ Y → Orthogonal C f X → Orthogonal C f Y
+  obj-orthogonal-iso
+    : ∀ {a b} {X Y} (f : Hom a b)
+    → X ≅ Y → Orthogonal C f X → Orthogonal C f Y
 ```
 
 <!--
@@ -113,11 +120,11 @@ A slightly more interesting lemma is that, if $f$ is orthogonal to
 itself, then it is an isomorphism:
 
 ```agda
-  self-orthogonal→invertible : ∀ {a b} (f : Hom a b) → Orthogonal C f f → is-invertible f
+  self-orthogonal→invertible
+    : ∀ {a b} (f : Hom a b) → Orthogonal C f f → is-invertible f
   self-orthogonal→invertible f f⊥f =
-    make-invertible (gpq .fst) (gpq .snd .snd) (gpq .snd .fst)
-    where
-      gpq = f⊥f id id (idl _ ∙ intror refl) .centre
+    let (f , p , q) = f⊥f id id (idl _ ∙ intror refl) .centre in
+    make-invertible f q p
 ```
 
 If $f$ is an epi or $g$ is a mono, then the mere existence of
@@ -127,14 +134,16 @@ _any_ lift is enough to establish that $f \ortho g$.
   left-epic-lift→orthogonal
     : (g : Hom c d)
     → is-epic f → Lifts C f g → Orthogonal C f g
-  left-epic-lift→orthogonal g f-epi lifts u v vf=gu =
-    is-prop∥∥→is-contr (left-epic→lift-is-prop C f-epi vf=gu) (lifts u v vf=gu)
+  left-epic-lift→orthogonal g f-epi lifts u v vf=gu = is-prop∥∥→is-contr
+    (left-epic→lift-is-prop C f-epi vf=gu)
+    (lifts u v vf=gu)
 
   right-monic-lift→orthogonal
     : (f : Hom a b)
     → is-monic g → Lifts C f g → Orthogonal C f g
-  right-monic-lift→orthogonal f g-mono lifts u v vf=gu =
-    is-prop∥∥→is-contr (right-monic→lift-is-prop C g-mono vf=gu) (lifts u v vf=gu)
+  right-monic-lift→orthogonal f g-mono lifts u v vf=gu = is-prop∥∥→is-contr
+    (right-monic→lift-is-prop C g-mono vf=gu)
+    (lifts u v vf=gu)
 ```
 
 <!--
@@ -142,8 +151,8 @@ _any_ lift is enough to establish that $f \ortho g$.
   left-epic-lift→orthogonal-class
     : ∀ {κ} (R : Arrows C κ)
     → is-epic f → Lifts C f R → Orthogonal C f R
-  left-epic-lift→orthogonal-class R f-epic lifts r r∈R =
-    left-epic-lift→orthogonal r f-epic (lifts r r∈R)
+  left-epic-lift→orthogonal-class R f-epic lifts r r∈R = left-epic-lift→orthogonal
+    r f-epic (lifts r r∈R)
 
   right-monic-lift→orthogonal-class
     : ∀ {κ} (L : Arrows C κ)
@@ -159,13 +168,13 @@ other morphism.
 ```agda
   invertible→left-orthogonal : (g : Hom c d) → Orthogonal C Isos g
   invertible→left-orthogonal g f f-inv =
-    left-epic-lift→orthogonal g (invertible→epic f-inv) $
-    invertible-left-lifts C f f-inv
+      left-epic-lift→orthogonal g (invertible→epic f-inv)
+    $ invertible-left-lifts C f f-inv
 
   invertible→right-orthogonal : (f : Hom a b) → Orthogonal C f Isos
   invertible→right-orthogonal f g g-inv =
-    right-monic-lift→orthogonal f (invertible→monic g-inv) $
-    invertible-right-lifts C g g-inv
+      right-monic-lift→orthogonal f (invertible→monic g-inv)
+    $ invertible-right-lifts C g g-inv
 ```
 
 Phrased another way, the class of isomorphisms is left and right orthogonal
@@ -244,8 +253,7 @@ the object. Given a map $a : a \to \iota X$,
   in-subcategory→orthogonal-to-inverted
     : ∀ {X} {a b} {f : C.Hom a b} → D.is-invertible (r.₁ f) → Orthogonal C f (ι.₀ X)
   in-subcategory→orthogonal-to-inverted {X} {A} {B} {f} rf-inv a→x =
-    contr (fact , factors) λ { (g , factors') →
-      Σ-prop-path! (h≡k factors factors') }
+    contr (fact , factors) λ { (g , factors') → Σ-prop-path! (h≡k factors factors') }
     where
       module rf = D.is-invertible rf-inv
       module η⁻¹ {a} = C.is-invertible (is-reflective→unit-right-is-iso r⊣ι ι-ff {a})
@@ -325,13 +333,13 @@ the subcategory:
   orthogonal-to-ηs→in-subcategory
     : ∀ {X} → (∀ B → Orthogonal C (unit.η B) X) → C.is-invertible (unit.η X)
   orthogonal-to-ηs→in-subcategory {X} ortho =
-    C.make-invertible x lemma (ortho X C.id .centre .snd)
-    where
+    C.make-invertible x lemma (ortho X C.id .centre .snd) where
       x = ortho X C.id .centre .fst
-      lemma = unit.η _ C.∘ x             ≡⟨ unit.is-natural _ _ _ ⟩
-              ιr.₁ x C.∘ unit.η (ιr.₀ X) ≡⟨ C.refl⟩∘⟨ η-comonad-commute r⊣ι ι-ff ⟩
-              ιr.₁ x C.∘ ιr.₁ (unit.η X) ≡⟨ ιr.annihilate (ortho X C.id .centre .snd) ⟩
-              C.id                       ∎
+      lemma =
+        unit.η _ C.∘ x             ≡⟨ unit.is-natural _ _ _ ⟩
+        ιr.₁ x C.∘ unit.η (ιr.₀ X) ≡⟨ C.refl⟩∘⟨ η-comonad-commute r⊣ι ι-ff ⟩
+        ιr.₁ x C.∘ ιr.₁ (unit.η X) ≡⟨ ιr.annihilate (ortho X C.id .centre .snd) ⟩
+        C.id                       ∎
 ```
 
 And the converse to *that* is a specialisation of the first thing we
@@ -344,6 +352,8 @@ which $\eta$ is an isomorphism.
   in-subcategory→orthogonal-to-ηs
     : ∀ {X B} → C.is-invertible (unit.η X) → Orthogonal C (unit.η B) X
   in-subcategory→orthogonal-to-ηs inv =
-    obj-orthogonal-iso C (unit.η _) (C.invertible→iso _ (C.is-invertible-inverse inv)) $
-    in-subcategory→orthogonal-to-inverted (is-reflective→left-unit-is-iso r⊣ι ι-ff)
+      obj-orthogonal-iso C (unit.η _)
+        (C.invertible→iso _ (C.is-invertible-inverse inv))
+    $ in-subcategory→orthogonal-to-inverted
+        (is-reflective→left-unit-is-iso r⊣ι ι-ff)
 ```

--- a/src/Cat/Morphism/Orthogonal.lagda.md
+++ b/src/Cat/Morphism/Orthogonal.lagda.md
@@ -29,11 +29,11 @@ diagram like
   a && b \\
   \\
   c && {d\text{,}}
-  \arrow["f", from=1-1, to=1-3]
-  \arrow["g", from=3-1, to=3-3]
-  \arrow["u"', from=1-1, to=3-1]
-  \arrow["v", from=1-3, to=3-3]
-	\arrow[dashed, from=1-3, to=3-1]
+  \arrow["u", from=1-1, to=1-3]
+  \arrow["v", from=3-1, to=3-3]
+  \arrow["f"', from=1-1, to=3-1]
+  \arrow["g", from=1-3, to=3-3]
+  \arrow[dashed, from=1-3, to=3-1]
 \end{tikzcd}\]
 ~~~
 

--- a/src/Cat/Morphism/Strong/Epi.lagda.md
+++ b/src/Cat/Morphism/Strong/Epi.lagda.md
@@ -113,14 +113,12 @@ ident=∘l-lifts-class} --- in this case, an arbitrary monomorphism $m$.
 ```agda
 ∘-is-strong-epic
   : ∀ {a b c} {f : Hom b c} {g : Hom a b}
-  → is-strong-epi f
-  → is-strong-epi g
-  → is-strong-epi (f ∘ g)
+  → is-strong-epi f → is-strong-epi g → is-strong-epi (f ∘ g)
 ∘-is-strong-epic (f-epi , f-str) (g-epi , g-str) =
-  lifts→is-strong-epi (∘-is-epic f-epi g-epi) $
-  ∘l-lifts-class C Monos
-    (orthogonal→lifts-right-class C Monos f-str)
-    (orthogonal→lifts-right-class C Monos g-str)
+    lifts→is-strong-epi (∘-is-epic f-epi g-epi)
+  $ ∘l-lifts-class C Monos
+      (orthogonal→lifts-right-class C Monos f-str)
+      (orthogonal→lifts-right-class C Monos g-str)
 ```
 
 Additionally, there is a partial converse to this result: If the
@@ -149,18 +147,15 @@ get a lift $t$.
 ```agda
 strong-epi-cancelr
   : ∀ {a b c} (f : Hom b c) (g : Hom a b)
-  → is-strong-epi (f ∘ g)
-  → is-strong-epi f
-strong-epi-cancelr f g (fg-epi , fg-str) =
-  lifts→is-strong-epi f-epi f-str
-  where
-    f-epi : is-epic f
-    f-epi = epic-cancelr fg-epi
+  → is-strong-epi (f ∘ g) → is-strong-epi f
+strong-epi-cancelr f g (fg-epi , fg-str) = lifts→is-strong-epi f-epi f-str where
+  f-epi : is-epic f
+  f-epi = epic-cancelr fg-epi
 
-    f-str : Lifts C f Monos
-    f-str m m-monic u v vf=mu =
-      let (w , wfg=ug , mw=v) = fg-str m m-monic (u ∘ g) v (extendl vf=mu) .centre
-      in pure (w , m-monic (w ∘ f) u (pulll mw=v ∙ vf=mu) , mw=v)
+  f-str : Lifts C f Monos
+  f-str m m-monic u v vf=mu =
+    let (w , wfg=ug , mw=v) = fg-str m m-monic (u ∘ g) v (extendl vf=mu) .centre in
+    pure (w , m-monic (w ∘ f) u (pulll mw=v ∙ vf=mu) , mw=v)
 ```
 
 As an immediate consequence of the definition, a monic strong epi is an
@@ -170,8 +165,9 @@ self-orthogonal maps are isos.
 
 ```agda
 strong-epi+mono→invertible
-  : ∀ {a b} {f : Hom a b} → is-strong-epi f → is-monic f → is-invertible f
-strong-epi+mono→invertible (_ , strong) mono  =
+  : ∀ {a b} {f : Hom a b}
+  → is-strong-epi f → is-monic f → is-invertible f
+strong-epi+mono→invertible (_ , strong) mono =
   self-orthogonal→invertible C _ (strong _ mono)
 ```
 
@@ -228,10 +224,9 @@ is-regular-epi→is-strong-epi
   → is-regular-epi C f
   → is-strong-epi f
 is-regular-epi→is-strong-epi {a} {b} f regular =
-  lifts→is-strong-epi
-    r.is-regular-epi→is-epic λ m m-monic u v vf=mu →
-      pure (map m-monic vf=mu , r.factors , lemma m-monic vf=mu)
-    where
+  lifts→is-strong-epi r.is-regular-epi→is-epic λ m m-monic u v vf=mu →
+    pure (map m-monic vf=mu , r.factors , lemma m-monic vf=mu)
+  where
     module r = is-regular-epi regular renaming (arr₁ to s ; arr₂ to t)
     module _ {c} {d} {m : Hom c d} {u} {v} (m-monic : is-monic m) (vf=mu : v ∘ f ≡ m ∘ u) where
       map : Hom b c
@@ -373,13 +368,14 @@ $ew = \mathrm{id}$ --- so that $e$, being a retract, is an epimorphism.
 ```agda
   epi : is-epic f
   epi u v uf=vf = ∥-∥-out! do
-    let module ker = Equaliser (eqs u v)
-    let k = ker.universal uf=vf
-    (w , p , q) ←
-      lifts ker.equ (is-equaliser→is-monic _ ker.has-is-eq) k id
-        (idl _ ∙ sym ker.factors)
-    let e-epi : is-epic ker.equ
-        e-epi = retract-is-epi q
+    let
+      module ker = Equaliser (eqs u v)
+      k = ker.universal uf=vf
+    (w , p , q) ← lifts ker.equ (is-equaliser→is-monic _ ker.has-is-eq) k id
+      (idl _ ∙ sym ker.factors)
+    let
+      e-epi : is-epic ker.equ
+      e-epi = retract-is-epi q
 ```
 
 Now, $e : Eq(u,v) \to B$ is the universal map which equalises $u$ and
@@ -493,8 +489,7 @@ is-strong-epi→is-extremal-epi
 is-strong-epi→is-extremal-epi (s , ortho) m g p =
   make-invertible (inv' .centre .fst) (inv' .centre .snd .snd)
     (m .monic _ _ (pulll (inv' .centre .snd .snd) ∙ id-comm-sym))
-  where
-  inv' = ortho (m .mor) (m .monic) g id (idl _ ∙ p)
+  where inv' = ortho (m .mor) (m .monic) g id (idl _ ∙ p)
 ```
 -->
 
@@ -514,7 +509,9 @@ subst-is-strong-epi
   → is-strong-epi g
 subst-is-strong-epi f=g f-strong-epi =
   lifts→is-strong-epi (subst-is-epic f=g (f-strong-epi .fst)) λ m m-monic u v vg=mu →
-    let (h , hf=u , mh=v) = f-strong-epi .snd m m-monic u v (ap₂ _∘_ refl f=g ∙ vg=mu) .centre
+    let
+      (h , hf=u , mh=v) = f-strong-epi .snd m m-monic u v
+        (ap₂ _∘_ refl f=g ∙ vg=mu) .centre
     in pure (h , ap (h ∘_) (sym f=g) ∙ hf=u , mh=v)
 ```
 -->

--- a/src/Cat/Morphism/Strong/Epi.lagda.md
+++ b/src/Cat/Morphism/Strong/Epi.lagda.md
@@ -103,9 +103,9 @@ The first thing we show is that strong epimorphisms are closed under
 composition. It will suffice to show that the composite $fg$ of a pair
 of strong epimorphisms is epic, and that it [[lifts against]] every
 monomorphism. But this is just a pasting of existing results: we already
-know that being epic is `closed under composition`{.Agda ident=∘-is-epic},
-and that so is `lifting against a given map`{.Agda
-ident=∘l-lifts-against} --- in this case, an arbitrary monomorphism $m$.
+know that being epic is `closed under composition`{.Agda
+ident=∘-is-epic}, and that so is `lifting against a given map`{.Agda
+ident=∘l-lifts-class} --- in this case, an arbitrary monomorphism $m$.
 
 ```agda
 strong-epi-∘

--- a/src/Cat/Morphism/Strong/Epi.lagda.md
+++ b/src/Cat/Morphism/Strong/Epi.lagda.md
@@ -108,12 +108,12 @@ ident=∘-is-epic}, and that so is `lifting against a given map`{.Agda
 ident=∘l-lifts-class} --- in this case, an arbitrary monomorphism $m$.
 
 ```agda
-strong-epi-∘
-  : ∀ {a b c} (f : Hom b c) (g : Hom a b)
+∘-is-strong-epic
+  : ∀ {a b c} {f : Hom b c} {g : Hom a b}
   → is-strong-epi f
   → is-strong-epi g
   → is-strong-epi (f ∘ g)
-strong-epi-∘ f g (f-epi , f-str) (g-epi , g-str) =
+∘-is-strong-epic (f-epi , f-str) (g-epi , g-str) =
   lifts→is-strong-epi (∘-is-epic f-epi g-epi) $
   ∘l-lifts-class C Monos
     (orthogonal→lifts-right-class C Monos f-str)

--- a/src/Cat/Morphism/Strong/Epi.lagda.md
+++ b/src/Cat/Morphism/Strong/Epi.lagda.md
@@ -11,6 +11,8 @@ open import Cat.Diagram.Pullback
 open import Cat.Diagram.Initial
 open import Cat.Instances.Comma
 open import Cat.Instances.Slice
+open import Cat.Morphism.Class
+open import Cat.Morphism.Lifts
 open import Cat.Diagram.Image
 open import Cat.Prelude
 
@@ -50,17 +52,15 @@ actually suffices to have _any_ lift: they are automatically unique.
 
 ```agda
 is-strong-epi : ∀ {a b} → Hom a b → Type _
-is-strong-epi f = is-epic f × ∀ {c d} (m : c ↪ d) → m⊥m C f (m .mor)
+is-strong-epi f = is-epic f × Orthogonal C f Monos
 
 lifts→is-strong-epi
   : ∀ {a b} {f : Hom a b}
   → is-epic f
-  → ( ∀ {c d} (m : c ↪ d) {u} {v} → v ∘ f ≡ m .mor ∘ u
-    → Lifting C f (m .mor) u v)
+  → Lifts C f Monos
   → is-strong-epi f
-lifts→is-strong-epi epic lift-it = epic , λ {c} {d} mm sq →
-  contr (lift-it mm sq) λ { (x , p , q) → Σ-prop-path!
-    (mm .monic _ _ (sym (q ∙ sym (lift-it mm sq .snd .snd)))) }
+lifts→is-strong-epi epic lifts =
+  epic , left-epic-lift→orthogonal-class C Monos epic lifts
 ```
 
 <!--
@@ -69,6 +69,10 @@ abstract
   is-strong-epi-is-prop
     : ∀ {a b} (f : Hom a b) → is-prop (is-strong-epi f)
   is-strong-epi-is-prop f = hlevel 1
+
+StrongEpis : Arrows C (o ⊔ ℓ)
+StrongEpis .arrows = is-strong-epi
+StrongEpis .is-tr = hlevel 1
 ```
 -->
 
@@ -110,9 +114,10 @@ strong-epi-∘
   → is-strong-epi g
   → is-strong-epi (f ∘ g)
 strong-epi-∘ f g (f-epi , f-str) (g-epi , g-str) =
-  lifts→is-strong-epi (∘-is-epic f-epi g-epi) λ e → ∘l-lifts-against C
-    (orthogonal→lifts-against C (f-str e))
-    (orthogonal→lifts-against C (g-str e))
+  lifts→is-strong-epi (∘-is-epic f-epi g-epi) $
+  ∘l-lifts-class C Monos
+    (orthogonal→lifts-right-class C Monos f-str)
+    (orthogonal→lifts-right-class C Monos g-str)
 ```
 
 Additionally, there is a partial converse to this result: If the
@@ -149,10 +154,10 @@ strong-epi-cancelr f g (fg-epi , fg-str) =
     f-epi : is-epic f
     f-epi = epic-cancelr fg-epi
 
-    f-str : ∀ {c d} (m : c ↪ d) {u} {v} → v ∘ f ≡ m .mor ∘ u → _
-    f-str m {u} {v} vf=mu =
-      let (w , wfg=ug , mw=v) = fg-str m (extendl vf=mu) .centre
-      in w , m .monic (w ∘ f) u (pulll mw=v ∙ vf=mu) , mw=v
+    f-str : Lifts C f Monos
+    f-str m m-monic u v vf=mu =
+      let (w , wfg=ug , mw=v) = fg-str m m-monic (u ∘ g) v (extendl vf=mu) .centre
+      in pure (w , m-monic (w ∘ f) u (pulll mw=v ∙ vf=mu) , mw=v)
 ```
 
 As an immediate consequence of the definition, a monic strong epi is an
@@ -164,7 +169,7 @@ self-orthogonal maps are isos.
 strong-epi+mono→invertible
   : ∀ {a b} {f : Hom a b} → is-strong-epi f → is-monic f → is-invertible f
 strong-epi+mono→invertible (_ , strong) mono  =
-  self-orthogonal→invertible C _ (strong (record { monic = mono }))
+  self-orthogonal→invertible C _ (strong _ mono)
 ```
 
 # Regular epis are strong
@@ -221,20 +226,20 @@ is-regular-epi→is-strong-epi
   → is-strong-epi f
 is-regular-epi→is-strong-epi {a} {b} f regular =
   lifts→is-strong-epi
-    r.is-regular-epi→is-epic
-    (λ m x → map m x , r.factors , lemma m x)
+    r.is-regular-epi→is-epic λ m m-monic u v vf=mu →
+      pure (map m-monic vf=mu , r.factors , lemma m-monic vf=mu)
     where
     module r = is-regular-epi regular renaming (arr₁ to s ; arr₂ to t)
-    module _ {c} {d} (z : c ↪ d) {u} {v} (vf=zu : v ∘ f ≡ z .mor ∘ u) where
-      module z = _↪_ z
+    module _ {c} {d} {m : Hom c d} {u} {v} (m-monic : is-monic m) (vf=mu : v ∘ f ≡ m ∘ u) where
       map : Hom b c
-      map = r.universal {e' = u} $ z.monic _ _ $
-        z .mor ∘ u ∘ r.s ≡⟨ extendl (sym vf=zu) ⟩
-        v ∘ f ∘ r.s      ≡⟨ refl⟩∘⟨ r.coequal ⟩
-        v ∘ f ∘ r.t      ≡˘⟨ extendl (sym vf=zu) ⟩
-        z .mor ∘ u ∘ r.t ∎
+      map = r.universal {e' = u} $ m-monic _ _ $
+        m ∘ u ∘ r.s ≡⟨ extendl (sym vf=mu) ⟩
+        v ∘ f ∘ r.s ≡⟨ refl⟩∘⟨ r.coequal ⟩
+        v ∘ f ∘ r.t ≡˘⟨ extendl (sym vf=mu) ⟩
+        m ∘ u ∘ r.t ∎
+
       lemma = r.is-regular-epi→is-epic _ _ $
-        sym (vf=zu ∙ pushr (sym r.factors))
+        sym (vf=mu ∙ pushr (sym r.factors))
 ```
 
 # Images
@@ -291,10 +296,8 @@ in the relevant comma categories.
     module o = ↓Obj other
 
     the-lifting =
-      str-epi
-        (record { monic = o.cod .snd })
-        {u = o.map .map}
-        {v = im→b} (sym (o.map .com ∙ sym fact))
+      str-epi _ (o.cod .snd) (o.map .map) im→b
+        (sym (o.map .com ∙ sym fact))
 
     dh : ↓Hom (!Const (cut f)) _ obj other
     dh .top      = tt
@@ -353,10 +356,9 @@ equaliser $Eq(u,v)$ and arrange them like
 equaliser-lifts→is-strong-epi
   : ∀ {a b} {f : Hom a b}
   → (∀ {a b} (f g : Hom a b) → Equaliser C f g)
-  → ( ∀ {c d} (m : c ↪ d) {u} {v} → v ∘ f ≡ m .mor ∘ u
-    → Σ[ w ∈ Hom b c ] ((w ∘ f ≡ u) × (m .mor ∘ w ≡ v)))
+  → Lifts C f Monos
   → is-strong-epi f
-equaliser-lifts→is-strong-epi {f = f} eqs ls = lifts→is-strong-epi epi ls where
+equaliser-lifts→is-strong-epi {f = f} eqs lifts = lifts→is-strong-epi epi lifts where
 ```
 
 By the universal property of $Eq(u,v)$, since there's $uf = vf$, there's
@@ -367,16 +369,14 @@ $ew = \mathrm{id}$ --- so that $e$, being a retract, is an epimorphism.
 
 ```agda
   epi : is-epic f
-  epi u v uf=vf =
-    let
-      module ker = Equaliser (eqs u v)
-      k = ker.universal uf=vf
-      (w , p , q) = ls
-        (record { monic = is-equaliser→is-monic _ ker.has-is-eq })
-        {u = k} {v = id}
+  epi u v uf=vf = ∥-∥-out! do
+    let module ker = Equaliser (eqs u v)
+    let k = ker.universal uf=vf
+    (w , p , q) ←
+      lifts ker.equ (is-equaliser→is-monic _ ker.has-is-eq) k id
         (idl _ ∙ sym ker.factors)
-      e-epi : is-epic ker.equ
-      e-epi = retract-is-epi q
+    let e-epi : is-epic ker.equ
+        e-epi = retract-is-epi q
 ```
 
 Now, $e : Eq(u,v) \to B$ is the universal map which equalises $u$ and
@@ -384,7 +384,7 @@ $v$ --- so that we have $ue = ve$, and since we've _just_ shown that $e$
 is epic, this means we have $u = v$ --- exactly what we wanted!
 
 ```agda
-    in e-epi u v ker.equal
+    pure (e-epi u v ker.equal)
 ```
 
 ## Extremal epimorphisms {defines="extremal-epi extremal-epimorphism"}
@@ -408,7 +408,7 @@ is-extremal-epi→is-strong-epi
   → is-extremal-epi e
   → is-strong-epi e
 is-extremal-epi→is-strong-epi {a} {b} {e} lex extremal =
-  equaliser-lifts→is-strong-epi lex.equalisers λ w → Mk.the-lift w where
+  equaliser-lifts→is-strong-epi lex.equalisers Mk.the-lift where
     module lex = Finitely-complete lex
 ```
 
@@ -439,15 +439,19 @@ map $u : A \times_D B \mono B$ is a monomorphism since it results from
 pulling back a monomorphism.
 
 ```agda
-    module Mk {c d : Ob} (m : c ↪ d) {u : Hom a c} {v : Hom b d}
-              (wit : v ∘ e ≡ m .mor ∘ u) where
-      module P = Pullback (lex.pullbacks v (m .mor)) renaming (p₁ to q ; p₂ to p)
+    module Mk
+      {c d : Ob}
+      (m : Hom c d) (m-monic : is-monic m)
+      (u : Hom a c) (v : Hom b d)
+      (wit : v ∘ e ≡ m ∘ u)
+      where
+      module P = Pullback (lex.pullbacks v m) renaming (p₁ to q ; p₂ to p)
       r : Hom a P.apex
       r = P.universal {p₁' = e} {p₂' = u} wit
 
       abstract
         q-mono : is-monic P.q
-        q-mono = is-monic→pullback-is-monic (m .monic) (rotate-pullback P.has-is-pb)
+        q-mono = is-monic→pullback-is-monic (m-monic) (rotate-pullback P.has-is-pb)
 ```
 
 We thus have a factorisation $e = qr$ of $e$ through a monomorphism $q$,
@@ -461,17 +465,20 @@ appropriately:
 
       q⁻¹ = q-iso .is-invertible.inv
 
-      the-lift : Σ (Hom b c) λ w → (w ∘ e ≡ u) × (m .mor ∘ w ≡ v)
-      the-lift .fst = P.p ∘ q⁻¹
-      the-lift .snd .fst = m .monic _ _ $
-        m .mor ∘ (P.p ∘ q⁻¹) ∘ e ≡⟨ extendl (pulll (sym P.square)) ⟩
-        (v ∘ P.q) ∘ q⁻¹ ∘ e      ≡⟨ cancel-inner (q-iso .is-invertible.invl) ⟩
-        v ∘ e                    ≡⟨ wit ⟩
-        m .mor ∘ u               ∎
-      the-lift .snd .snd = invertible→epic q-iso _ _ $
-        (m .mor ∘ (P.p ∘ q⁻¹)) ∘ P.q ≡⟨ pullr (cancelr (q-iso .is-invertible.invr)) ⟩
-        m .mor ∘ P.p                 ≡˘⟨ P.square ⟩
-        v ∘ P.q                      ∎
+      the-lifting : Lifting C e m u v
+      the-lifting .fst = P.p ∘ q⁻¹
+      the-lifting .snd .fst = m-monic _ _ $
+        m ∘ (P.p ∘ q⁻¹) ∘ e ≡⟨ extendl (pulll (sym P.square)) ⟩
+        (v ∘ P.q) ∘ q⁻¹ ∘ e ≡⟨ cancel-inner (q-iso .is-invertible.invl) ⟩
+        v ∘ e               ≡⟨ wit ⟩
+        m ∘ u               ∎
+      the-lifting .snd .snd = invertible→epic q-iso _ _ $
+        (m ∘ (P.p ∘ q⁻¹)) ∘ P.q ≡⟨ pullr (cancelr (q-iso .is-invertible.invr)) ⟩
+        m ∘ P.p                 ≡˘⟨ P.square ⟩
+        v ∘ P.q                 ∎
+
+      the-lift : ∥ Lifting C e m u v ∥
+      the-lift = pure the-lifting
 ```
 
 <!--
@@ -479,12 +486,12 @@ appropriately:
 is-strong-epi→is-extremal-epi
   : ∀ {a b} {e : Hom a b}
   → is-strong-epi e
-  → ∀ {c} (m : c ↪ b) (g : Hom a c) → e ≡ m .mor ∘ g → is-invertible (m .mor)
+  → is-extremal-epi e
 is-strong-epi→is-extremal-epi (s , ortho) m g p =
   make-invertible (inv' .centre .fst) (inv' .centre .snd .snd)
     (m .monic _ _ (pulll (inv' .centre .snd .snd) ∙ id-comm-sym))
   where
-  inv' = ortho m (idl _ ∙ p)
+  inv' = ortho (m .mor) (m .monic) g id (idl _ ∙ p)
 ```
 -->
 
@@ -495,8 +502,7 @@ invertible→strong-epi
   → is-invertible f
   → is-strong-epi f
 invertible→strong-epi f-inv =
-  invertible→epic f-inv , λ m →
-  invertible→left-orthogonal C (m .mor) f-inv
+  invertible→epic f-inv , invertible→left-orthogonal-class C Monos f-inv
 
 subst-is-strong-epi
   : ∀ {a b} {f g : Hom a b}
@@ -504,8 +510,8 @@ subst-is-strong-epi
   → is-strong-epi f
   → is-strong-epi g
 subst-is-strong-epi f=g f-strong-epi =
-  lifts→is-strong-epi (subst-is-epic f=g (f-strong-epi .fst)) λ m vg=mu →
-    let (h , hf=u , mh=v) = f-strong-epi .snd m (ap₂ _∘_ refl f=g ∙ vg=mu) .centre
-    in h , ap (h ∘_) (sym f=g) ∙ hf=u , mh=v
+  lifts→is-strong-epi (subst-is-epic f=g (f-strong-epi .fst)) λ m m-monic u v vg=mu →
+    let (h , hf=u , mh=v) = f-strong-epi .snd m m-monic u v (ap₂ _∘_ refl f=g ∙ vg=mu) .centre
+    in pure (h , ap (h ∘_) (sym f=g) ∙ hf=u , mh=v)
 ```
 -->

--- a/src/Cat/Morphism/Strong/Epi.lagda.md
+++ b/src/Cat/Morphism/Strong/Epi.lagda.md
@@ -73,6 +73,9 @@ abstract
 StrongEpis : Arrows C (o ⊔ ℓ)
 StrongEpis .arrows = is-strong-epi
 StrongEpis .is-tr = hlevel 1
+
+StrongEpis⊥Monos : Orthogonal C StrongEpis Monos
+StrongEpis⊥Monos f (f-epi , f⊥Monos) = f⊥Monos
 ```
 -->
 

--- a/src/Cat/Morphism/Strong/Mono.lagda.md
+++ b/src/Cat/Morphism/Strong/Mono.lagda.md
@@ -115,12 +115,12 @@ for exposition.
 [strong epis compose]: Cat.Morphism.Strong.Epi.html#properties
 
 ```agda
-strong-mono-∘
-  : ∀ {a b c} (f : Hom b c) (g : Hom a b)
+∘-is-strong-monic
+  : ∀ {a b c} {f : Hom b c} {g : Hom a b}
   → is-strong-mono f
   → is-strong-mono g
   → is-strong-mono (f ∘ g)
-strong-mono-∘ f g (f-mono , f-str) (g-mono , g-str) =
+∘-is-strong-monic (f-mono , f-str) (g-mono , g-str) =
   lifts→is-strong-mono (∘-is-monic f-mono g-mono) $
     ∘r-lifts-class C Epis
       (orthogonal→lifts-left-class C Epis f-str)

--- a/src/Cat/Morphism/Strong/Mono.lagda.md
+++ b/src/Cat/Morphism/Strong/Mono.lagda.md
@@ -53,6 +53,9 @@ is-strong-mono f = is-monic f × Orthogonal C Epis f
 StrongMonos : Arrows C (o ⊔ ℓ)
 StrongMonos .arrows = is-strong-mono
 StrongMonos .is-tr = hlevel 1
+
+Epis⊥StrongMonos : Orthogonal C Epis StrongMonos
+Epis⊥StrongMonos f f-epi g (g-mono , Epis⊥g) = Epis⊥g f f-epi
 ```
 -->
 

--- a/src/Cat/Regular.lagda.md
+++ b/src/Cat/Regular.lagda.md
@@ -365,7 +365,7 @@ construction, so $k = l$ --- so $g$ is _also_ monic.
           gh ∘ l              ∎
 ```
 
--- Having shown that $g$ is monic, and knowing that $f$ --- a strong (thus
+Having shown that $g$ is monic, and knowing that $f$ --- a strong (thus
 extremal) epimorphism --- factors through it, we conclude that $g$ is an
 isomorphism. It remains to `compute`{.Agda} that $hg\inv f = c$, which
 we do below.

--- a/src/Cat/Regular.lagda.md
+++ b/src/Cat/Regular.lagda.md
@@ -344,7 +344,7 @@ construction, so $k = l$ --- so $g$ is _also_ monic.
 
 ```agda
         rem₅ : C.is-strong-epi d×d
-        rem₅ = C.subst-is-strong-epi rem₄ (C.strong-epi-∘ _ _ rem₃ rem₂)
+        rem₅ = C.subst-is-strong-epi rem₄ (C.∘-is-strong-epic rem₃ rem₂)
 
         rem₆ : C.is-strong-epi p
         rem₆ = r.stable _ _ rem₅ pb.has-is-pb

--- a/src/Cat/Regular.lagda.md
+++ b/src/Cat/Regular.lagda.md
@@ -1,5 +1,6 @@
 <!--
 ```agda
+open import Cat.Morphism.Factorisation.Orthogonal
 open import Cat.Diagram.Coequaliser.RegularEpi
 open import Cat.Morphism.Factorisation
 open import Cat.Diagram.Limit.Finite
@@ -96,6 +97,20 @@ latter two names have a placeholder for the morphism we are factoring.
         (factor-monic→left-monic (r.factor f) f-monic)
 ```
 -->
+
+We can extend our factorisations to an [[orthogonal factorisation system]]
+on $\cC$, as the classes of strong epis and monos are closed under composites
+and invertible maps, and strong epis are [[left orthogonal]] to monomorphisms by definition.
+
+```agda
+    strong-epi-mono-is-ofs : is-ofs 𝒞 C.StrongEpis C.Monos
+    strong-epi-mono-is-ofs .is-ofs.factor = r.factor
+    strong-epi-mono-is-ofs .is-ofs.is-iso→in-L f = invertible→strong-epi
+    strong-epi-mono-is-ofs .is-ofs.L-is-stable f g = ∘-is-strong-epic
+    strong-epi-mono-is-ofs .is-ofs.is-iso→in-R f = invertible→monic
+    strong-epi-mono-is-ofs .is-ofs.R-is-stable f g = ∘-is-monic
+    strong-epi-mono-is-ofs .is-ofs.L⊥R = StrongEpis⊥Monos
+```
 
 ## Motivation
 

--- a/src/Cat/Regular.lagda.md
+++ b/src/Cat/Regular.lagda.md
@@ -4,12 +4,14 @@ open import Cat.Diagram.Coequaliser.RegularEpi
 open import Cat.Morphism.Factorisation
 open import Cat.Diagram.Limit.Finite
 open import Cat.Diagram.Coequaliser
-open import Cat.Morphism.Strong.Epi
 open import Cat.Diagram.Pullback
 open import Cat.Diagram.Product
+open import Cat.Morphism.Class
+open import Cat.Morphism.Lifts
 open import Cat.Prelude
 
-import Cat.Reasoning as Cr
+import Cat.Morphism.Strong.Epi
+import Cat.Reasoning
 ```
 -->
 
@@ -43,24 +45,19 @@ every strong epimorphism is regular.
 open Functor
 
 module _ {o ℓ} (𝒞 : Precategory o ℓ) where
-  private module C = Cr 𝒞
-
-  StrongEpi : ∀ {a b} → C.Hom a b → Ω
-  StrongEpi x = elΩ (is-strong-epi 𝒞 x)
-
-  Mono : ∀ {a b} → C.Hom a b → Ω
-  Mono x = elΩ (C.is-monic x)
+  private module C where
+    open Cat.Morphism.Strong.Epi 𝒞 public
+    open Cat.Reasoning 𝒞 public
 ```
 -->
 
 ```agda
   record is-regular : Type (o ⊔ ℓ) where
     field
-      factor : ∀ {a b} (f : C.Hom a b) → Factorisation 𝒞 StrongEpi Mono f
-      stable : is-pullback-stable 𝒞 (is-strong-epi 𝒞)
+      factor : ∀ {a b} (f : C.Hom a b) → Factorisation 𝒞 C.StrongEpis C.Monos f
+      stable : is-pullback-stable 𝒞 C.is-strong-epi
       has-is-lex : Finitely-complete 𝒞
 
-    module factor {a b} (f : C.Hom a b) = Factorisation (factor f)
     module lex = Finitely-complete has-is-lex
 ```
 
@@ -71,14 +68,16 @@ provided factorisations: Letting $f : A \to B$ be a map and $A \epi X
 latter two names have a placeholder for the morphism we are factoring.
 
 ```agda
-    im[_] : ∀ {a b} (f : C.Hom a b) → C.Ob
-    im[ f ] = factor f .Factorisation.mediating
-
-    im[_]↪b : ∀ {a b} (f : C.Hom a b) → im[ f ] C.↪ b
-    im[ f ]↪b = record { monic = □-out! (factor f .Factorisation.forget∈M) }
-
-    a↠im[_] : ∀ {a b} (f : C.Hom a b) → C.Hom a im[ f ]
-    a↠im[ f ] = factor f .Factorisation.mediate
+    module factor {a b} (f : C.Hom a b) =
+      Factorisation (factor f) renaming
+        ( mid to im[_]
+        ; left to a↠im[_]
+        ; right to im[_]↪b
+        ; left∈L to a↠im[_]-strong-epic
+        ; right∈R to im[_]↪b-monic
+        ; factors to im[_]-factors
+        )
+    open factor public
 ```
 
 <!--
@@ -91,17 +90,10 @@ latter two names have a placeholder for the morphism we are factoring.
       : ∀ {a b} (f : C.Hom a b)
       → C.is-monic f
       → C.is-invertible r.a↠im[ f ]
-    mono→im-iso f x = res where
-      open Factorisation
-      rem₁ : f ≡ r.im[ f ]↪b .C.mor C.∘ r.a↠im[ f ]
-      rem₁ = r.factor f .factors
-
-      p = □-out! (r.factor f .mediate∈E) .snd (record { monic = x })
-        (sym (r.factor f .factors) ∙ sym (C.idr _))
-      res = C.make-invertible (p .centre .fst)
-        (□-out! (r.factor f .mediate∈E) .fst _ _
-          (C.pullr (p .centre .snd .fst) ∙ C.id-comm))
-        (p .centre .snd .fst)
+    mono→im-iso {a} {b} f f-monic =
+      C.strong-epi+mono→invertible
+        r.a↠im[ f ]-strong-epic
+        (factor-monic→left-monic (r.factor f) f-monic)
 ```
 -->
 
@@ -186,7 +178,7 @@ of its kernel pair.
 
 ```agda
   -- Johnstone, A.1.3.4
-  module _ (r : is-regular) {A B} (f : C.Hom A B) (is-s : is-strong-epi 𝒞 f) where
+  module _ (r : is-regular) {A B} (f : C.Hom A B) (is-s : C.is-strong-epi f) where
     private
       module r = is-regular r
       module kp = Pullback (r.lex.pullbacks f f)
@@ -220,10 +212,10 @@ $$.
 
 
 ```agda
-      dgh : Factorisation 𝒞 StrongEpi Mono ⟨ f , c ⟩
+      dgh : Factorisation 𝒞 C.StrongEpis C.Monos ⟨ f , c ⟩
       dgh = r.factor ⟨ f , c ⟩
       module dgh = Factorisation dgh
-        renaming (mediating to D ; forget to gh ; mediate to d)
+        renaming (mid to D ; right to gh ; left to d)
       open dgh using (D ; d ; gh)
 
       g : C.Hom D B
@@ -263,7 +255,7 @@ obtaining
 
 ```agda
       g-monic : C.is-monic g
-      g-monic {e} k l w' = □-out! dgh.forget∈M _ _ rem₈ where
+      g-monic {e} k l w' = dgh.right∈R _ _ rem₈ where
         d×d = ×-functor .F₁ (d , d)
         module pb = Pullback (r.lex.pullbacks ⟨ k , l ⟩ d×d)
           renaming (p₁ to p ; apex to P ; p₂ to mn ; square to sq'-)
@@ -316,8 +308,8 @@ skip it.
 ```agda
         open is-pullback
 
-        rem₂ : is-strong-epi 𝒞 (×-functor .F₁ (d , id))
-        rem₂ = r.stable d π₁ {p2 = π₁} (□-out! dgh.mediate∈E) λ where
+        rem₂ : C.is-strong-epi (×-functor .F₁ (d , id))
+        rem₂ = r.stable d π₁ {p2 = π₁} dgh.left∈L λ where
           .square → π₁∘⟨⟩
           .universal {p₁' = p₁'} {p₂'} p → ⟨ p₂' , π₂ ∘ p₁' ⟩
           .p₁∘universal {p₁' = p₁'} {p₂'} {p = p} → ⟨⟩∘ _
@@ -327,8 +319,8 @@ skip it.
           .unique {p = p} {lim'} q r → ⟨⟩-unique r $ sym $
             ap (π₂ ∘_) (sym q) ∙ pulll π₂∘⟨⟩ ∙ ap (_∘ lim') (idl _)
 
-        rem₃ : is-strong-epi 𝒞 (×-functor .F₁ (id , d))
-        rem₃ = r.stable d π₂ {p2 = π₂} (□-out! dgh.mediate∈E) λ where
+        rem₃ : C.is-strong-epi (×-functor .F₁ (id , d))
+        rem₃ = r.stable d π₂ {p2 = π₂} dgh.left∈L λ where
           .square → π₂∘⟨⟩
           .universal {p₁' = p₁'} {p₂'} p → ⟨ π₁ ∘ p₁' , p₂' ⟩
           .p₁∘universal {p = p} → ⟨⟩∘ _
@@ -351,10 +343,10 @@ $(g,h)k = (g,h)l$ (`rem₈`{.Agda}), but $(g,h)$ is a monomorphism by
 construction, so $k = l$ --- so $g$ is _also_ monic.
 
 ```agda
-        rem₅ : is-strong-epi 𝒞 d×d
-        rem₅ = subst-is-strong-epi 𝒞 rem₄ (strong-epi-∘ 𝒞 _ _ rem₃ rem₂)
+        rem₅ : C.is-strong-epi d×d
+        rem₅ = C.subst-is-strong-epi rem₄ (C.strong-epi-∘ _ _ rem₃ rem₂)
 
-        rem₆ : is-strong-epi 𝒞 p
+        rem₆ : C.is-strong-epi p
         rem₆ = r.stable _ _ rem₅ pb.has-is-pb
 
         rem₇ : h ∘ k ≡ h ∘ l
@@ -373,7 +365,7 @@ construction, so $k = l$ --- so $g$ is _also_ monic.
           gh ∘ l              ∎
 ```
 
-Having shown that $g$ is monic, and knowing that $f$ --- a strong (thus
+-- Having shown that $g$ is monic, and knowing that $f$ --- a strong (thus
 extremal) epimorphism --- factors through it, we conclude that $g$ is an
 isomorphism. It remains to `compute`{.Agda} that $hg\inv f = c$, which
 we do below.
@@ -382,12 +374,11 @@ we do below.
 ```agda
       g-iso : is-invertible g
       g-iso = make-invertible (p .centre .fst) (p .centre .snd .snd)
-        (□-out! dgh.mediate∈E .fst _ _
+        (dgh.left∈L .fst _ _
           ( pullr (pullr (sym dgh.factors) ∙ π₁∘⟨⟩)
           ∙ p .centre .snd .fst ∙ introl refl))
         module g-ortho where
-          p = is-s .snd (record { monic = g-monic })
-            (idl _ ∙ sym (pullr (sym dgh.factors) ∙ π₁∘⟨⟩))
+          p = is-s .snd g g-monic _ _ (idl _ ∙ sym (pullr (sym dgh.factors) ∙ π₁∘⟨⟩))
       module g = _≅_ (invertible→iso _ g-iso)
 ```
 -->

--- a/src/Cat/Regular/Image.lagda.md
+++ b/src/Cat/Regular/Image.lagda.md
@@ -48,8 +48,8 @@ $\im f$ whenever $f : x \to y$.
 ```agda
 Im : ∀ {x y} (f : Hom x y) → Subobject y
 Im f .dom   = _
-Im f .map   = factor f .forget
-Im f .monic = □-out! (factor f .forget∈M)
+Im f .map   = factor f .right
+Im f .monic = factor f .right∈R
 ```
 
 We may then use this to rephrase the universal property of $\im f$ as
@@ -62,8 +62,9 @@ Im-universal
   → f ≡ m .map ∘ e
   → Im f ≤ₘ m
 Im-universal f m {e = e} p = r where
-  the-lift = □-out! (factor f .mediate∈E) .snd
-    record { Subobject m } (sym (factor f .factors) ∙ p)
+  the-lift =
+    factor f .left∈L .snd (m .map) (m .monic) _ _
+      (sym (factor f .factors) ∙ p)
 
   r : _ ≤ₘ _
   r .map = the-lift .centre .fst
@@ -91,14 +92,13 @@ image-pre-cover {a = a} {b} {c} f g g-covers = Sub-antisym imf≤imfg imfg≤imf
   imfg≤imf = Im-universal _ _ (pushl (factor f .factors))
 
   the-lift : Σ (Hom b im[ f ∘ g ]) _
-  the-lift = g-covers .snd
-    (≤ₘ→mono imfg≤imf)
-    {factor (f ∘ g) .mediate}
-    {factor f .mediate}
-    (□-out! (factor f .forget∈M) _ _ (sym (pulll (sym (imfg≤imf .com) ∙ idl _) ∙ sym (factor (f ∘ g) .factors) ∙ pushl (factor f .factors)))) .centre
+  the-lift = g-covers .snd _ (≤ₘ→monic imfg≤imf)
+    (factor (f ∘ g) .left)
+    (factor f .left)
+    (factor f .right∈R _ _ (sym (pulll (sym (imfg≤imf .com) ∙ idl _) ∙ sym (factor (f ∘ g) .factors) ∙ pushl (factor f .factors)))) .centre
 
   inverse : is-invertible (imfg≤imf .map)
-  inverse = is-strong-epi→is-extremal-epi C (□-out! (factor f .mediate∈E))
+  inverse = is-strong-epi→is-extremal-epi C (factor f .left∈L)
     (≤ₘ→mono imfg≤imf) (the-lift .fst) (sym (the-lift .snd .snd))
 
   imf≤imfg : Im f ≤ₘ Im (f ∘ g)

--- a/src/Cat/Regular/Instances/Sets.lagda.md
+++ b/src/Cat/Regular/Instances/Sets.lagda.md
@@ -44,16 +44,14 @@ and an embedding $\im(f) \mono b$.
 
 ```agda
 Sets-regular .factor {a} {b} f = λ where
-  .mediating → el! (image f)
-  .mediate x → (f x) , inc (x , refl)
-  .forget    → fst
-
-  .mediate∈E → inc (is-regular-epi→is-strong-epi (Sets _) {a} {el! (image f)} _
+  .mid → el! (image f)
+  .left x → (f x) , inc (x , refl)
+  .right → fst
+  .left∈L → is-regular-epi→is-strong-epi (Sets _) {a} {el! (image f)} _
     (surjective→regular-epi _ _ _ λ {
-      (x , y) → ∥-∥-rec squash (λ { (pre , p) → inc (pre , Σ-prop-path! p) }) y }))
-
-  .forget∈M  → inc (embedding→monic (Subset-proj-embedding (λ _ → squash)))
-  .factors   → refl
+      (x , y) → ∥-∥-rec squash (λ { (pre , p) → inc (pre , Σ-prop-path! p) }) y })
+  .right∈R → embedding→monic (Subset-proj-embedding (λ _ → squash))
+  .factors → refl
 ```
 
 It additionally suffices to verify this only for our choice of pullbacks


### PR DESCRIPTION
# Description

This PR refactors the APIs for lifting and orthogonality properties, and also redefines projective/injective objects in
terms of lifts. I've also made some minor code improvements along the way, like pulling out `Factorisation` into its own module. Closes #552.
