### PR TITLE
Ranges of Natural Numbers

### DIFF
--- a/src/Data/Fin/Base.lagda.md
+++ b/src/Data/Fin/Base.lagda.md
@@ -1,6 +1,7 @@
 <!--
 ```agda
 open import 1Lab.Path.IdentitySystem
+open import 1Lab.Function.Embedding
 open import 1Lab.HLevel.Closure
 open import 1Lab.HLevel
 open import 1Lab.Equiv
@@ -190,6 +191,20 @@ We can also relax the upper bounds if `m ≤ n`.
 ```agda
 inject : ∀ {m n} → m Nat.≤ n → Fin m → Fin n
 inject p (fin n ⦃ b ⦄) = fin n ⦃ (λ e → Nat.≤-trans e p) <$> b ⦄
+```
+
+## As a subset of the natural numbers
+
+We can also view `Fin` as a subset of the natural numbers.
+
+```agda
+lower-inj : ∀ {n : Nat} {x y : Fin n} → x .lower ≡ y .lower → x ≡ y
+lower-inj {n} {fin x ⦃ x<n ⦄} {fin y ⦃ _ ⦄} p i =
+  fin (p i) ⦃ coe0→i (λ i → p i Nat.< n) i <$> x<n ⦄
+
+Fin↪Nat : ∀ {n} → Fin n ↪ Nat
+Fin↪Nat .fst = lower
+Fin↪Nat .snd = injective→is-embedding (hlevel 2) lower lower-inj
 ```
 
 ## Discreteness

--- a/src/Data/Fin/Closure.lagda.md
+++ b/src/Data/Fin/Closure.lagda.md
@@ -120,13 +120,13 @@ Finite-coproduct {m} {n} = Iso→Equiv (to , iso from ir il) where
       q = monus-≤ i m
 
       .r : i - m Nat.< n
-      r = +-reflects-≤l (suc (i - m)) n m (≤-trans (≤-refl' (+-sucr m (i - m))) (≤-trans (≤-refl' (ap suc (monus-inversel i m p'))) b))
+      r = +-reflects-≤l (suc (i - m)) n m (≤-trans (≤-refl' (+-sucr m (i - m))) (≤-trans (≤-refl' (ap Nat.suc (monus-+l-inverse m i p'))) b))
     in inr (fin (i - m) ⦃ forget r ⦄)
 
   ir : is-right-inverse from to
   ir (fin i ⦃ forget b ⦄) with holds? (i Nat.< m)
   ... | yes p = fin-ap refl
-  ... | no ¬p = fin-ap (monus-inversel i m (≤-peel (<-from-not-≤ _ _ ¬p)))
+  ... | no ¬p = fin-ap (monus-+l-inverse m i (≤-peel (<-from-not-≤ _ _ ¬p)))
 
   il : is-left-inverse from to
   il (inl (fin i ⦃ forget b ⦄)) with holds? (i Nat.< m)
@@ -134,7 +134,7 @@ Finite-coproduct {m} {n} = Iso→Equiv (to , iso from ir il) where
   ... | no ¬p = absurd (¬p b)
   il (inr (fin i ⦃ forget b ⦄)) with holds? ((m + i) Nat.< m)
   ... | yes p = absurd (¬sucx≤x m (+-reflects-≤l (suc m) m i (≤-trans (≤-refl' (+-sucr i m ∙ ap suc (+-commutative i m))) (≤-trans p (+-≤r i m)))))
-  ... | no ¬p = ap inr (fin-ap (monus-inverser i m))
+  ... | no ¬p = ap inr (fin-ap (+l-monus-inverse i m))
 ```
 -->
 
@@ -204,7 +204,7 @@ Finite-multiply {m@(suc m')} {n@(suc n')} = Iso→Equiv (to , iso from ir il) wh
   from (fin i ⦃ forget b ⦄) with divmod q r quot rem ← divide-pos i n =
     let
       .b' : q Nat.≤ m
-      b' = *-cancel-≤r n {q} {m} $
+      b' = *-reflects-≤r n {q} {m} $
         ≤-trans (difference→≤ r (sym quot)) (≤-sucr (≤-peel b))
 
       .ne : q ≠ m

--- a/src/Data/Int/Order.lagda.md
+++ b/src/Data/Int/Order.lagda.md
@@ -247,11 +247,11 @@ abstract
 
   *ℤ-cancel-≤r : ∀ {x y z} ⦃ _ : Positive x ⦄ → (y *ℤ x) ≤ (z *ℤ x) → y ≤ z
   *ℤ-cancel-≤r {possuc x} {y = pos y} {pos z} ⦃ pos _ ⦄ p = pos≤pos
-    (Nat.*-cancel-≤r (suc x) (unapos≤apos p))
+    (Nat.*-reflects-≤r (suc x) (unapos≤apos p))
   *ℤ-cancel-≤r {possuc x} {y = pos y} {negsuc z} ⦃ pos _ ⦄ p = absurd (¬pos≤neg (≤-trans (≤-refl' (sym (assign-pos (y * suc x)))) p))
   *ℤ-cancel-≤r {possuc x} {y = negsuc y} {pos z} ⦃ pos _ ⦄ p = neg≤pos
   *ℤ-cancel-≤r {possuc x} {y = negsuc y} {negsuc z} ⦃ pos _ ⦄ p = neg≤neg
-    (Nat.*-cancel-≤r (suc x) (Nat.+-reflects-≤l (z * suc x) (y * suc x) x (unneg≤neg p)))
+    (Nat.*-reflects-≤r (suc x) (Nat.+-reflects-≤l (z * suc x) (y * suc x) x (unneg≤neg p)))
 
   *ℤ-cancel-≤l : ∀ {x y z} ⦃ _ : Positive x ⦄ → (x *ℤ y) ≤ (x *ℤ z) → y ≤ z
   *ℤ-cancel-≤l {x} {y} {z} p = *ℤ-cancel-≤r {x} {y} {z} (≤-trans (≤-refl' (*ℤ-commutative y x)) (≤-trans p (≤-refl' (*ℤ-commutative x z))))

--- a/src/Data/List/Base.lagda.md
+++ b/src/Data/List/Base.lagda.md
@@ -99,7 +99,11 @@ List-elim P p[] p∷ (x ∷ xs) = p∷ x xs (List-elim P p[] p∷ xs)
 ```agda
 instance
   Foldable-List : Foldable (eff List)
-  Foldable-List .foldr f x = List-elim _ x (λ x _ → f x)
+  Foldable-List .foldr {a = A} {b = B} f b = go module foldr where
+    go : List A → B
+    go [] = b
+    go (x ∷ xs) = f x (go xs)
+
 
   Traversable-List : Traversable (eff List)
   Traversable-List = record { traverse = go } where
@@ -109,6 +113,9 @@ instance
       → (a → M.₀ b) → List a → M.₀ (List b)
     go f []       = pure []
     go f (x ∷ xs) = ⦇ f x ∷ go f xs ⦈
+
+{-# DISPLAY foldr.go f b xs = foldr f b xs #-}
+
 
 foldl : (B → A → B) → B → List A → B
 foldl f x []       = x
@@ -124,10 +131,12 @@ List B`.
 ```agda
 instance
   Map-List : Map (eff List)
-  Map-List = record { map = go } where
+  Map-List = record { map = go } module map where
     go : (A → B) → List A → List B
     go f []       = []
     go f (x ∷ xs) = f x ∷ go f xs
+
+{-# DISPLAY map.go f xs = map f xs #-}
 ```
 
 ## Monoidal structure
@@ -297,6 +306,9 @@ any-of f (x ∷ xs) = or (f x) (any-of f xs)
   distinguish : List A → Type
   distinguish []     = ⊥
   distinguish (_ ∷ _) = ⊤
+
+[]≠∷ : ∀ {x : A} {xs} → ¬ [] ≡ (x ∷ xs)
+[]≠∷ {A = A} p = ∷≠[] (sym p)
 
 instance
   Discrete-List : ∀ ⦃ d : Discrete A ⦄ → Discrete (List A)

--- a/src/Data/List/Membership.lagda.md
+++ b/src/Data/List/Membership.lagda.md
@@ -4,9 +4,10 @@ open import 1Lab.Prelude
 
 open import Data.List.Properties
 open import Data.Id.Properties
+open import Data.List.NonEmpty
 open import Data.List.Base
 open import Data.Dec.Base
-open import Data.Fin.Base
+open import Data.Fin.Base hiding (_≤_)
 open import Data.Nat.Base
 open import Data.Sum.Base
 open import Data.Id.Base
@@ -121,6 +122,40 @@ member≃lookup .snd = is-iso→is-equiv λ where
 ```
 -->
 
+Explicitly, if $A$ is an [[$3+n$-type|n-type]], then the type of membership
+proofs for lists of $A$s are an [[$2+n$|type]].
+
+```agda
+∈ₗ-is-hlevel
+  : ∀ {A : Type ℓ} {x : A} {xs : List A}
+  → (n : Nat)
+  → is-hlevel A (3 + n)
+  → is-hlevel (x ∈ xs) (2 + n)
+∈ₗ-is-hlevel {x = x} {xs = xs} n ahl =
+  Equiv→is-hlevel (2 + n) (member≃lookup ∙e Σ-ap-snd (λ i → Id≃path)) $
+  Σ-is-hlevel (2 + n) (hlevel (2 + n)) λ i → ahl (xs ! i) x
+```
+
+<!--
+```agda
+instance
+  H-Level-∈ₗ
+    : ∀ {A : Type ℓ} {x : A} {xs : List A} {n : Nat}
+    → ⦃ _ : 2 ≤ n ⦄
+    → ⦃ _ : H-Level A (suc n) ⦄
+    → H-Level (x ∈ₗ xs) n
+  H-Level-∈ₗ {n = suc (suc n)} ⦃ s≤s (s≤s _) ⦄ ⦃ ahl ⦄ = hlevel-instance (∈ₗ-is-hlevel n (ahl .H-Level.has-hlevel))
+```
+-->
+
+<!--
+```agda
+index-of : ∀ {x : A} {xs : List A} → x ∈ₗ xs → Nat
+index-of x∈xs = lower (member→lookup x∈xs .fst)
+{-# NOINLINE index-of #-}
+```
+-->
+
 Despite the potential complexity of $a \in_l as$, we do note that if $A$
 is a [[set]], then all that matters is the index; If $A$ is moreover
 [[discrete]], then $a \in_l as$ is [[decidable]].
@@ -203,6 +238,35 @@ member→member-nub {xs = x ∷ xs} (there α) with elem? x (nub xs)
 ```
 
 </details>
+
+## Properties
+
+A list $xs$ is nonempty if and only if there [[merely]] exists
+some $x \in xs$.
+
+```agda
+has-member→nonempty
+  : ∀ {x : A} {xs : List A}
+  → x ∈ xs
+  → is-nonempty xs
+has-member→nonempty {xs = x ∷ xs} x∈xs = nonempty
+
+nonempty→has-member
+  : ∀ {xs : List A}
+  → is-nonempty xs
+  → Σ[ x ∈ A ] (x ∈ xs)
+nonempty→has-member {xs = x ∷ xs} ne = x , here reflᵢ
+
+nonempty≃has-member
+  : ∀ (xs : List A)
+  → is-nonempty xs ≃ (∃[ x ∈ A ] (x ∈ xs))
+nonempty≃has-member xs =
+  prop-ext!
+    (λ ne → inc (nonempty→has-member ne))
+    (rec! (λ x x∈xs → has-member→nonempty x∈xs))
+```
+
+<!-- [TODO: Reed M, 26/08/2025] Prose for these. -->
 
 <!--
 ```agda

--- a/src/Data/List/NonEmpty.lagda.md
+++ b/src/Data/List/NonEmpty.lagda.md
@@ -1,0 +1,153 @@
+---
+description: |
+  Nonempty lists.
+---
+
+<!--
+```agda
+open import 1Lab.Reflection.HLevel
+open import 1Lab.HLevel.Closure
+open import 1Lab.Truncation
+open import 1Lab.Inductive
+open import 1Lab.HLevel
+open import 1Lab.Equiv
+open import 1Lab.Path
+open import 1Lab.Type
+
+open import Data.List.Properties
+open import Data.List.Base
+open import Data.Sum.Base
+open import Data.Dec.Base
+```
+-->
+
+```agda
+module Data.List.NonEmpty where
+```
+
+# Nonempty lists
+
+<!--
+```agda
+private variable
+  ℓ : Level
+  A : Type ℓ
+  xs : List A
+```
+-->
+
+:::{.definition #nonempty-list}
+A list $xs : \List{A}$ is **nonempty** if it can be written as $u \cons us$
+for some $u : A$, $us : \List{A}$.
+:::
+
+We can encode this neatly in Agda by using an indexed inductive type,
+which makes it more amenable to proof automation.
+
+```agda
+data is-nonempty {ℓ} {A : Type ℓ} : (xs : List A) → Type ℓ where
+  instance nonempty : ∀ {x xs} → is-nonempty (x ∷ xs)
+```
+
+Being nonempty is a proposition.
+
+```agda
+is-nonempty-is-prop
+  : ∀ {xs : List A}
+  → is-prop (is-nonempty xs)
+is-nonempty-is-prop {xs = x ∷ xs} nonempty nonempty = refl
+```
+
+<!--
+```agda
+is-nonempty-is-contr
+  : ∀ {x : A} {xs : List A}
+  → is-contr (is-nonempty (x ∷ xs))
+is-nonempty-is-contr = is-prop∙→is-contr is-nonempty-is-prop nonempty
+
+instance
+  H-Level-is-nonempty : ∀ {xs : List A} {n : Nat} → H-Level (is-nonempty xs) (suc n)
+  H-Level-is-nonempty = prop-instance is-nonempty-is-prop
+```
+-->
+
+A list is non-empty if and only if it is not equal to the empty list.
+
+```agda
+is-nonempty→not-empty
+  : is-nonempty xs
+  → xs ≠ []
+is-nonempty→not-empty nonempty = ∷≠[]
+
+not-empty→is-nonempty
+  : xs ≠ []
+  → is-nonempty xs
+not-empty→is-nonempty {xs = []} xs≠[] = absurd (xs≠[] refl)
+not-empty→is-nonempty {xs = x ∷ xs} xs≠[] = nonempty
+
+is-nonempty≃not-empty : is-nonempty xs ≃ (xs ≠ [])
+is-nonempty≃not-empty = prop-ext! is-nonempty→not-empty not-empty→is-nonempty
+```
+
+A list $xs$ is nonempty if and only if there is some $u : A$ and
+$us : \List{A}$ such that $xs = u \cons us$.
+
+```agda
+is-nonempty≃∷
+  : ∀ {xs : List A}
+  → is-nonempty xs ≃ (Σ[ u ∈ A ] Σ[ us ∈ List A ] xs ≡ u ∷ us)
+is-nonempty≃∷ {xs = []} =
+  is-empty→≃
+    (λ ())
+    (λ (u , us , []=u∷us) → absurd ([]≠∷ []=u∷us))
+is-nonempty≃∷ {xs = x ∷ xs} =
+  is-contr→≃
+    is-nonempty-is-contr
+    (∷-singleton-is-contr x xs)
+```
+
+## Properties
+
+We can decide if a list is nonempty by just checking if it is empty.
+
+```agda
+instance
+  Dec-nonempty : ∀ {xs : List A} → Dec (is-nonempty xs)
+  Dec-nonempty {xs = []} = no (λ ())
+  Dec-nonempty {xs = x ∷ xs} = yes nonempty
+```
+
+## Closure properties
+
+A list $xs \concat ys$ is nonempty if and only if
+one of $xs$ or $ys$ is nonempty.
+
+```agda
+++-nonemptyl
+  : ∀ (xs ys : List A)
+  → is-nonempty xs
+  → is-nonempty (xs ++ ys)
+++-nonemptyl (x ∷ xs) ys ne = nonempty
+
+++-nonemptyr
+  : ∀ (xs ys : List A)
+  → is-nonempty ys
+  → is-nonempty (xs ++ ys)
+++-nonemptyr [] ys ne = ne
+++-nonemptyr (x ∷ xs) ys ne = nonempty
+
+++-nonempty-split
+  : ∀ (xs ys : List A)
+  → is-nonempty (xs ++ ys)
+  → is-nonempty xs ⊎ is-nonempty ys
+++-nonempty-split [] ys ne = inr ne
+++-nonempty-split (x ∷ xs) ys ne = inl nonempty
+
+++-nonempty≃
+  : ∀ (xs ys : List A)
+  → is-nonempty (xs ++ ys) ≃ ∥ (is-nonempty xs ⊎ is-nonempty ys) ∥
+++-nonempty≃ xs ys =
+  prop-ext!
+    (λ ne → inc (++-nonempty-split xs ys ne))
+    (rec! [ ++-nonemptyl xs ys , ++-nonemptyr xs ys ])
+```

--- a/src/Data/List/Properties.lagda.md
+++ b/src/Data/List/Properties.lagda.md
@@ -3,6 +3,7 @@
 open import 1Lab.Reflection.HLevel
 open import 1Lab.HLevel.Universe
 open import 1Lab.HLevel.Closure
+open import 1Lab.Type.Sigma
 open import 1Lab.HLevel
 open import 1Lab.Equiv
 open import 1Lab.Path
@@ -16,6 +17,7 @@ open import Data.Sum.Base
 open import Data.Id.Base
 open import Data.Bool
 
+open import Meta.Foldable
 open import Meta.Idiom
 ```
 -->
@@ -29,7 +31,7 @@ module Data.List.Properties where
 <!--
 ```agda
 private variable
-  ℓ : Level
+  ℓ ℓ' : Level
   A B : Type ℓ
 ```
 -->
@@ -103,6 +105,40 @@ We use this to prove that lists preserve h-levels for $n \ge 2$, i.e. if
 
   is-set→List-is-set : is-set A → is-set (List A)
   is-set→List-is-set = List-is-hlevel zero
+
+```
+
+This characterisation has quiet a few useful corollaries.
+To start, paths between $x \cons xs$ and $y \cons ys$ are
+equivalent to pairs of paths.
+
+```agda
+∷-path≃
+  : ∀ {x y : A} {xs ys : List A}
+  → (x ∷ xs ≡ y ∷ ys) ≃ (x ≡ y × xs ≡ ys)
+∷-path≃ {x = x} {y = y} {xs = xs} {ys = ys} =
+  x ∷ xs ≡ y ∷ ys             ≃⟨ ListPath.Code≃Path ⟩
+  x ≡ y × ListPath.Code xs ys ≃˘⟨ Σ-ap-snd (λ _ → ListPath.Code≃Path) ⟩
+  x ≡ y × xs ≡ ys ≃∎
+```
+
+This in turn means that the type $\Sigma (y : A)\; (ys : \List{A})\; (x \cons xs = y \cons ys)$
+is [[contractible]] for ever $x : A$, $xs : \List{A}$, as we can re-arrange
+it into a pair of singletons.
+
+```agda
+∷-singleton-is-contr
+  : ∀ (x : A) (xs : List A)
+  → is-contr (Σ[ y ∈ A ] Σ[ ys ∈ List A ] x ∷ xs ≡ y ∷ ys)
+∷-singleton-is-contr {A = A} x xs =
+  Equiv→is-hlevel 0 eqv (×-is-hlevel 0 Singleton-is-contr Singleton-is-contr)
+  where
+    eqv : (Σ[ y ∈ A ] Σ[ ys ∈ List A ] x ∷ xs ≡ y ∷ ys) ≃ ((Σ[ y ∈ A ] x ≡ y) × (Σ[ ys ∈ List A ] xs ≡ ys))
+    eqv =
+      Σ[ y ∈ A ] Σ[ ys ∈ List A ] x ∷ xs ≡ y ∷ ys     ≃⟨ Σ-ap-snd (λ y → Σ-ap-snd λ ys → ∷-path≃) ⟩
+      Σ[ y ∈ A ] Σ[ ys ∈ List A ] x ≡ y × xs ≡ ys     ≃⟨ Σ-ap-snd (λ y → Σ-swap₂) ⟩
+      Σ[ y ∈ A ] x ≡ y × (Σ[ ys ∈ List A ] xs ≡ ys)   ≃⟨ Σ-assoc ⟩
+      (Σ[ y ∈ A ] x ≡ y) × (Σ[ ys ∈ List A ] xs ≡ ys) ≃∎
 ```
 
 <!--
@@ -261,3 +297,15 @@ length-tabulate {n = zero}  f = refl
 length-tabulate {n = suc n} f = ap suc (length-tabulate (f ∘ fsuc))
 ```
 -->
+
+# Folds
+
+```agda
+foldr-++
+  : ∀ {A : Type ℓ} {B : Type ℓ'}
+  → (f : A → B → B) (b : B)
+  → (xs ys : List A)
+  → foldr f b (xs ++ ys) ≡ foldr f (foldr f b ys) xs
+foldr-++ f b [] ys = refl
+foldr-++ f b (x ∷ xs) ys = ap (f x) (foldr-++ f b xs ys)
+```

--- a/src/Data/Nat/DivMod.lagda.md
+++ b/src/Data/Nat/DivMod.lagda.md
@@ -221,31 +221,25 @@ instance
 
       lemma' : ∀ q q' b r r' → r' < r → r < b → q * b + r ≡ q' * b + r' → ⊥
       lemma' q q' b r r' r'<r r<b β =
-        let
-          γ : r' + (r - r') ≡ r
-          γ = monus-inversel _ _ (<-weaken r'<r)
+        <-≤-asym q<q' q'≤q
+        where
+          r-r'<b : r - r' < b
+          r-r'<b = ≤-trans (s≤s (monus-≤ r r')) r<b
 
-          p : (q * b + (r - r')) + r' ≡ q' * b + r'
-          p = sym (+-associative (q * b) (r - r') r') ∙ ap (q * b +_) (+-commutative (r - r') r' ∙ γ) ∙ β
+          q<q' : q < q'
+          q<q' =
+            *-reflects-<r b ⦃ ≤-trans (s≤s 0≤x) r<b ⦄ $
+            +-balance-<l (q' * b) r' (q * b) r (sym β) (r'<r)
 
-          p' : q * b + (r - r') ≡ q' * b
-          p' = +-inj r' _ _ (+-commutative r' _ ∙ p ∙ +-commutative _ r')
-
-          p'' : b * (q' - q) + r' ≡ r
-          p'' =
-            ap (_+ r') (monus-distribl b q' q ∙ ap₂ _-_ (*-commutative b q' ∙ sym p') (*-commutative b q) ∙ monus-inverser (r - r') (q * b))
-            ∙ +-commutative (r - r') r' ∙ γ
-
-          d0 : r - r' < b
-          d0 = ≤-trans (s≤s (monus-≤ r r')) r<b
-
-          d1 : r - r' ≡ b * (q' - q)
-          d1 = sym (monus-swapr (b * (q' - q)) r' r p'')
-
-          d2 : q' - q ≡ 0
-          d2 = lemma _ _ (q' - q) d0 d1
-        in <-not-equal r'<r (sym (ap (_+ r') (*-zeror b)) ∙ ap (λ e → b * e + r') (sym d2) ∙ p'')
-
+          q'≤q : q' ≤ q
+          q'≤q =
+            monus-zero→≤ q' q $
+            lemma (r - r') b (q' - q) r-r'<b $
+            sym $ monus-swapr (b * (q' - q)) 0 (r - r') $
+              b * (q' - q) + 0 ≡⟨ +-zeror _ ∙ *-commutative b (q' - q) ⟩
+              (q' - q) * b     ≡⟨ monus-distribr q' q b ⟩
+              q' * b - q * b   ≡˘⟨ monus-swapl (q * b) (r - r') (q' * b) (monus-exchanger (q * b) r (q' * b) r' β (<-weaken r'<r)) ⟩
+              r - r'           ∎
 ```
 -->
 

--- a/src/Data/Nat/DivMod.lagda.md
+++ b/src/Data/Nat/DivMod.lagda.md
@@ -205,7 +205,7 @@ instance
   H-Level-DivMod {a} {b@(suc b')} =
     prop-instance λ where
       (divmod q r α β) (divmod q' r' α' β') → case ≤-split r r' of λ where
-        (inr (inr r=r')) → divmod-ap (*-injr b q q' (+-inj r (q * b) (q' * b) (+-commutative r (q * b) ∙ sym (recover α) ∙ recover α' ∙ +-commutative (q' * b) r' ∙ ap (_+ q' * b) (sym r=r')))) r=r'
+        (inr (inr r=r')) → divmod-ap (*-injr b q q' (+-injl r (q * b) (q' * b) (+-commutative r (q * b) ∙ sym (recover α) ∙ recover α' ∙ +-commutative (q' * b) r' ∙ ap (_+ q' * b) (sym r=r')))) r=r'
         (inr (inl r'<r)) → absurd (lemma' q q' b r r' r'<r (recover β) (recover (sym α ∙ α')))
         (inl r<r')       → absurd (lemma' q' q b r' r r<r' (recover β') (recover (sym α' ∙ α)))
     where

--- a/src/Data/Nat/Divisible.lagda.md
+++ b/src/Data/Nat/Divisible.lagda.md
@@ -91,7 +91,7 @@ antisymmetry will take a bit of working up to:
 ∣-trans {zero} {suc y} p q = absurd (suc≠zero p)
 ∣-trans {suc x} {zero} p q = 0 , sym q
 ∣-trans {suc x} {suc y} {z} (k , p) (k' , q) = k' * k , (
-  k' * k * suc x   ≡⟨ *-associative k' k (suc x) ⟩
+  k' * k * suc x   ≡˘⟨ *-associative k' k (suc x) ⟩
   k' * (k * suc x) ≡⟨ ap (k' *_) p ⟩
   k' * suc y       ≡⟨ q ⟩
   z                ∎)
@@ -149,10 +149,10 @@ expect a number to divide its multiples. Fortunately, this is the case:
 ∣-*r {y = y} = fibre→∣ (y , refl)
 
 |-*l-pres : ∀ {n a b} → n ∣ b → n ∣ a * b
-|-*l-pres {n} {a} {b} p1 with (q , α) ← ∣→fibre p1 = fibre→∣ (a * q , *-associative a q n ∙ ap (a *_) α)
+|-*l-pres {n} {a} {b} p1 with (q , α) ← ∣→fibre p1 = fibre→∣ (a * q , sym (*-associative a q n) ∙ ap (a *_) α)
 
 ∣-*-cancelr : ∀ {n a b} .⦃ _ : Positive n ⦄ → a * n ∣ b * n → a ∣ b
-∣-*-cancelr {n} {a} {b} p1 with (q , α) ← ∣→fibre p1 = fibre→∣ (q , *-injr n (q * a) b (*-associative q a n ∙ α))
+∣-*-cancelr {n} {a} {b} p1 with (q , α) ← ∣→fibre p1 = fibre→∣ (q , *-injr n (q * a) b (sym (*-associative q a n) ∙ α))
 ```
 
 If two numbers are multiples of $k$, then so is their sum.

--- a/src/Data/Nat/Divisible/GCD.lagda.md
+++ b/src/Data/Nat/Divisible/GCD.lagda.md
@@ -126,7 +126,7 @@ and `lem₂`{.Agda}, will allow us to compute the inductive step for GCD.
       r =
         (dm.q * c₁ + c₂) * d   ≡⟨ *-distrib-+r (dm.q * c₁) _ _ ⟩
         dm.q * c₁ * d + ⌜ c₂ * d ⌝ ≡⟨ ap! q ⟩
-        ⌜ dm.q * c₁ * d ⌝ + dm.r   ≡⟨ ap! (*-associative dm.q c₁ d) ⟩
+        ⌜ dm.q * c₁ * d ⌝ + dm.r   ≡⟨ ap! (sym (*-associative dm.q c₁ d)) ⟩
         dm.q * ⌜ c₁ * d ⌝ + dm.r   ≡⟨ ap! p ⟩
         dm.q * suc n + dm.r        ≡˘⟨ is-divmod m (suc n) ⟩
         m                          ∎
@@ -135,7 +135,7 @@ and `lem₂`{.Agda}, will allow us to compute the inductive step for GCD.
     lem₂ {d = d} {n} {m} (c₁ , p) (c₂ , q) = c₂ - dm.q * c₁ , r where
       module dm = DivMod (divide-pos m (suc n)) renaming (quot to q ; rem to r)
       r = (c₂ - dm.q * c₁) * d                   ≡⟨ monus-distribr c₂ (dm.q * c₁) d ⟩
-          c₂ * d - ⌜ dm.q * c₁ * d ⌝             ≡⟨ ap! (*-associative dm.q c₁ d ∙ ap (dm.q *_) p) ⟩
+          c₂ * d - ⌜ dm.q * c₁ * d ⌝             ≡⟨ ap! (sym (*-associative dm.q c₁ d) ∙ ap (dm.q *_) p) ⟩
           ⌜ c₂ * d ⌝ - dm.q * suc n              ≡⟨ ap! (q ∙ is-divmod m (suc n)) ⟩
           ⌜ dm.q * suc n + dm.r ⌝ - dm.q * suc n ≡⟨ ap! (+-commutative (dm.q * suc n) dm.r) ⟩
           (dm.r + dm.q * suc n) - dm.q * suc n   ≡⟨ monus-cancelr dm.r 0 (dm.q * suc n) ⟩
@@ -196,10 +196,10 @@ is-gcd-graphs-gcd {m = m} {n} {d} = prop-ext!
 <!--
 ```agda
 is-gcd-factor : ∀ x y n k .⦃ _ : Positive k ⦄ → is-gcd (x * k) (y * k) (n * k) → is-gcd x y n
-is-gcd-factor x y n k p .gcd-∣l with (q , α) ← ∣→fibre (p .gcd-∣l) = fibre→∣ (q , *-injr k (q * n) x (*-associative q n k ∙ α))
-is-gcd-factor x y n k p .gcd-∣r with (q , α) ← ∣→fibre (p .gcd-∣r) = fibre→∣ (q , *-injr k (q * n) y (*-associative q n k ∙ α))
+is-gcd-factor x y n k p .gcd-∣l with (q , α) ← ∣→fibre (p .gcd-∣l) = fibre→∣ (q , *-injr k (q * n) x (sym (*-associative q n k) ∙ α))
+is-gcd-factor x y n k p .gcd-∣r with (q , α) ← ∣→fibre (p .gcd-∣r) = fibre→∣ (q , *-injr k (q * n) y (sym (*-associative q n k) ∙ α))
 is-gcd-factor x y n k p .greatest {g'} α β with (q , α) ← ∣→fibre α | (r , β) ← ∣→fibre β =
-  ∣-*-cancelr {n = k} (p .greatest (fibre→∣ (q , sym (*-associative q g' k) ∙ ap (_* k) α)) (fibre→∣ (r , sym (*-associative r g' k) ∙ ap (_* k) β)))
+  ∣-*-cancelr {n = k} (p .greatest (fibre→∣ (q , *-associative q g' k ∙ ap (_* k) α)) (fibre→∣ (r , *-associative r g' k ∙ ap (_* k) β)))
 
 gcd-factor : ∀ x y k → gcd (x * k) (y * k) ≡ gcd x y * k
 gcd-factor x y zero = ap₂ gcd (*-zeror x) (*-zeror y) ∙ sym (*-zeror (gcd x y))
@@ -235,7 +235,7 @@ gcd-factor x y k@(suc _) = sym (k∣gcd .snd) ∙ ap (_* k) (sym (Equiv.to is-gc
       d' = subst (n ∣_) (ap (_* b) (recover α) ∙ *-distrib-+r (q * has .fst) r b) d
 
       d'' : n ∣ r * b
-      d'' = ∣-+-cancel {n} {q * has .fst * b} {r * b} (subst (n ∣_) (sym (*-associative q (has .fst) b)) (|-*l-pres {a = q} (has .snd .fst .snd))) d'
+      d'' = ∣-+-cancel {n} {q * has .fst * b} {r * b} (subst (n ∣_) (*-associative q (has .fst) b) (|-*l-pres {a = q} (has .snd .fst .snd))) d'
     in case r ≡? 0 of λ where
       (yes p) → fibre→∣ (q , sym (recover α ∙ ap (q * has .fst +_) p ∙ +-zeror (q * has .fst)))
       (no ¬p) → absurd (<-irrefl

--- a/src/Data/Nat/Order.lagda.md
+++ b/src/Data/Nat/Order.lagda.md
@@ -35,11 +35,14 @@ naturals automatically.
 
 <!--
 ```agda
-≤-refl' : ∀ {x y} → x ≡ y → x ≤ y
+≤-refl' : ∀ {x y} → .(x ≡ y) → x ≤ y
 ≤-refl' {zero} {zero} p = 0≤x
 ≤-refl' {zero} {suc y} p = absurd (zero≠suc p)
 ≤-refl' {suc x} {zero} p = absurd (suc≠zero p)
 ≤-refl' {suc x} {suc y} p = s≤s (≤-refl' (suc-inj p))
+
+≤-reflᵢ : ∀ {x y} → .(x ≡ᵢ y) → x ≤ y
+≤-reflᵢ p = ≤-refl' (Id-identity-system .to-path p)
 ```
 -->
 
@@ -96,10 +99,10 @@ instance
 <-irrefl {zero}  {suc y} p      _  = absurd (zero≠suc p)
 <-irrefl {suc x} {suc y} p (s≤s q) = <-irrefl (suc-inj p) q
 
-≤-strengthen : ∀ {x y} → x ≤ y → (x ≡ y) ⊎ (x < y)
-≤-strengthen {zero} {zero} 0≤x = inl refl
-≤-strengthen {zero} {suc y} 0≤x = inr (s≤s 0≤x)
-≤-strengthen {suc x} {suc y} (s≤s p) with ≤-strengthen p
+≤-strengthen : ∀ {x y} → .(x ≤ y) → (x ≡ y) ⊎ (x < y)
+≤-strengthen {zero} {zero} x≤y = inl refl
+≤-strengthen {zero} {suc y} x≤y = inr (s≤s 0≤x)
+≤-strengthen {suc x} {suc y} x≤y with ≤-strengthen (≤-peel x≤y)
 ... | inl eq = inl (ap suc eq)
 ... | inr le = inr (s≤s le)
 

--- a/src/Data/Nat/Prime.lagda.md
+++ b/src/Data/Nat/Prime.lagda.md
@@ -209,7 +209,7 @@ record Factorisation (n : Nat) : Type where
       let
         it = work x xs p
         (div , p) = ∣→fibre it
-      in fibre→∣ (y * div , *-associative y div x ∙ ap (y *_) p)
+      in fibre→∣ (y * div , sym (*-associative y div x) ∙ ap (y *_) p)
 
   find-prime-factor : ∀ {x} → is-prime x → x ∣ n → x ∈ₗ primes
   find-prime-factor {num} x d =

--- a/src/Data/Nat/Properties.lagda.md
+++ b/src/Data/Nat/Properties.lagda.md
@@ -104,12 +104,12 @@ numbers]. Since they're mostly simple inductive arguments written in
   x * z + y * z ≡⟨ ap₂ _+_ (*-commutative x z) (*-commutative y z) ⟩
   z * x + z * y ∎
 
-*-associative : (x y z : Nat) → (x * y) * z ≡ x * (y * z)
+*-associative : (x y z : Nat) → x * (y * z) ≡ (x * y) * z
 *-associative zero y z = refl
 *-associative (suc x) y z =
-  (y + x * y) * z     ≡⟨ *-distrib-+r y (x * y) z ⟩
-  y * z + (x * y) * z ≡⟨ ap₂ _+_ refl (*-associative x y z) ⟩
-  y * z + x * (y * z) ∎
+  y * z + x * (y * z) ≡⟨ ap₂ _+_ refl (*-associative x y z) ⟩
+  y * z + x * y * z   ≡˘⟨ *-distrib-+r y (x * y) z ⟩
+  (y + x * y) * z     ∎
 
 *-suc-inj : ∀ k x y → x * suc k ≡ y * suc k → x ≡ y
 *-suc-inj k zero zero p = refl
@@ -169,18 +169,18 @@ numbers]. Since they're mostly simple inductive arguments written in
 ^-+-hom-*r x zero z = sym (+-zeror (x ^ z))
 ^-+-hom-*r x (suc y) z =
   x * x ^ (y + z)     ≡⟨ ap (x *_) (^-+-hom-*r x y z) ⟩
-  x * (x ^ y * x ^ z) ≡⟨ sym (*-associative x (x ^ y) (x ^ z)) ⟩
+  x * (x ^ y * x ^ z) ≡⟨ (*-associative x (x ^ y) (x ^ z)) ⟩
   x * x ^ y * x ^ z ∎
 
 ^-distrib-*r : (x y z : Nat) → (x * y) ^ z ≡ x ^ z * y ^ z
 ^-distrib-*r x y zero = refl
 ^-distrib-*r x y (suc z) =
   x * y * (x * y) ^ z     ≡⟨ ap (λ a → x * y * a) (^-distrib-*r x y z) ⟩
-  x * y * (x ^ z * y ^ z) ≡⟨ sym (*-associative (x * y) (x ^ z) (y ^ z)) ⟩
-  x * y * x ^ z * y ^ z   ≡⟨ ap (_* y ^ z) (*-associative x y (x ^ z)) ⟩
+  x * y * (x ^ z * y ^ z) ≡⟨ *-associative (x * y) (x ^ z) (y ^ z) ⟩
+  x * y * x ^ z * y ^ z   ≡˘⟨ ap (_* y ^ z) (*-associative x y (x ^ z)) ⟩
   x * (y * x ^ z) * y ^ z ≡⟨ ap (λ a → x * a * y ^ z) (*-commutative y (x ^ z)) ⟩
-  x * (x ^ z * y) * y ^ z ≡⟨ ap (_* y ^ z) (sym (*-associative x (x ^ z) y)) ⟩
-  x * x ^ z * y * y ^ z   ≡⟨ *-associative (x * x ^ z) y (y ^ z) ⟩
+  x * (x ^ z * y) * y ^ z ≡⟨ ap (_* y ^ z) (*-associative x (x ^ z) y) ⟩
+  x * x ^ z * y * y ^ z   ≡˘⟨ *-associative (x * x ^ z) y (y ^ z) ⟩
   x * x ^ z * (y * y ^ z) ∎
 
 ^-*-adjunct : (x y z : Nat) → (x ^ y) ^ z ≡ x ^ (y * z)
@@ -190,7 +190,7 @@ numbers]. Since they're mostly simple inductive arguments written in
   x * x ^ y * (x * x ^ y) ^ z       ≡⟨ ap (λ a → x * x ^ y * a) (^-distrib-*r x (x ^ y) z) ⟩
   x * x ^ y * (x ^ z * (x ^ y) ^ z) ≡⟨ ap (λ a → x * x ^ y * (x ^ z * a)) (^-*-adjunct x y z) ⟩
   x * x ^ y * (x ^ z * x ^ (y * z)) ≡⟨ ap (λ a → x * x ^ y * a) (sym (^-+-hom-*r x z (y * z))) ⟩
-  x * x ^ y * (x ^ (z + (y * z)))   ≡⟨ *-associative x (x ^ y) (x ^ (z + y * z)) ⟩
+  x * x ^ y * (x ^ (z + (y * z)))   ≡˘⟨ *-associative x (x ^ y) (x ^ (z + y * z)) ⟩
   x * (x ^ y * (x ^ (z + (y * z)))) ≡⟨ ap (x *_) (sym (^-+-hom-*r x y (z + y * z))) ⟩
   x * x ^ (y + (z + y * z))         ≡⟨ ap (λ a → x * x ^ a) (+-associative y z (y * z)) ⟩
   x * x ^ (y + z + y * z)           ≡⟨ ap (λ a → x * x ^ (a + y * z)) (+-commutative y z) ⟩

--- a/src/Data/Nat/Properties.lagda.md
+++ b/src/Data/Nat/Properties.lagda.md
@@ -33,6 +33,9 @@ numbers]. Since they're mostly simple inductive arguments written in
   suc (x + (y + z)) ≡⟨ ap suc (+-associative x y z) ⟩
   suc ((x + y) + z) ∎
 
++-zerol : (x : Nat) → 0 + x ≡ x
++-zerol x = refl
+
 +-zeror : (x : Nat) → x + 0 ≡ x
 +-zeror zero = refl
 +-zeror (suc x) =
@@ -50,9 +53,12 @@ numbers]. Since they're mostly simple inductive arguments written in
   suc (y + x) ≡⟨ sym (+-sucr y x) ⟩
   y + suc x   ∎
 
-+-inj : ∀ k x y → k + x ≡ k + y → x ≡ y
-+-inj zero x y p = p
-+-inj (suc k) x y p = +-inj k x y (suc-inj p)
++-injl : ∀ k x y → k + x ≡ k + y → x ≡ y
++-injl zero x y p = p
++-injl (suc k) x y p = +-injl k x y (suc-inj p)
+
++-injr : ∀ k x y → x + k ≡ y + k → x ≡ y
++-injr k x y p = +-injl k x y (+-commutative k x ∙ p ∙ +-commutative y k)
 ```
 
 ## Multiplication
@@ -115,7 +121,7 @@ numbers]. Since they're mostly simple inductive arguments written in
 *-suc-inj k zero zero p = refl
 *-suc-inj k zero (suc y) p = absurd (zero≠suc p)
 *-suc-inj k (suc x) zero p = absurd (suc≠zero p)
-*-suc-inj k (suc x) (suc y) p = ap suc (*-suc-inj k x y (+-inj _ _ _ p))
+*-suc-inj k (suc x) (suc y) p = ap suc (*-suc-inj k x y (+-injl _ _ _ p))
 
 *-suc-inj' : ∀ k x y → suc k * x ≡ suc k * y → x ≡ y
 *-suc-inj' k x y p = *-suc-inj k x y (*-commutative x (suc k) ∙∙ p ∙∙ *-commutative (suc k) y)

--- a/src/Data/Nat/Range.lagda.md
+++ b/src/Data/Nat/Range.lagda.md
@@ -1,0 +1,297 @@
+---
+description: |
+  Ranges of natural numbers.
+---
+
+<!--
+```agda
+open import 1Lab.Prelude
+
+open import Data.List.Membership
+open import Data.Nat.Properties
+open import Data.List.NonEmpty
+open import Data.List.Base
+open import Data.Nat.Order
+open import Data.Dec.Base
+open import Data.Nat.Base
+open import Data.Fin.Base hiding (_≤_; _<_)
+open import Data.Sum.Base
+```
+-->
+
+```agda
+module Data.Nat.Range where
+```
+
+<!--
+```agda
+private variable
+  x y : Nat
+```
+-->
+
+# Ranges of natural numbers
+
+This module contains various tools for working with contiguous ranges
+of [[natural numbers]]. We are mainly interested in ranges as something
+to iterate over when performing other constructions. For example, the
+factorial function
+
+$$
+n! = \product_{i=1}^n x
+$$
+
+can be expressed as taking the product of all numbers in the range
+$[1, n]$.
+
+We will focus our attention on half-open ranges of numbers $[x, y)$.
+Ranges of this form have a couple of nice properties:
+
+- If $xs$ is a list, then $[0, \mathrm{length}\; xs)$ gives us all valid indices into $xs$.
+  If we used a closed range, then we'd have to subtract 1 from the length of
+  $xs$ to get the same list.
+- If we have two half-open ranges $[x, y)$ and $[y,z)$ with $x \leq y \leq z$,
+  then we can directly concatenate them to get the range $[x, z)$.
+- All the ranges $[x,y]$, $(x,y)$, and $(x,y]$ can be expressed as a
+  half-open range using only successors. In contrast, deriving $[x,y)$
+  from any of the other range types requires us to use predecessors,
+  which are much more annoying to reason about.
+
+Unfortunately, ranges $[x,y)$ are a bit annoying to construct directly
+via structural recursion on $x$ and $y$. The recurrence relation that
+defines $[x,y)$ is:
+
+$$
+[i,j) =
+\begin{cases}
+  [] & y \leq x \\
+  x \dblcolon [x+1,y)
+\end{cases}
+$$
+
+Note that $x$ is increasing and $y$ is constant in this recurrence relation,
+so Agda's termination checker will reject this definition. Instead, the
+termination metric is $y - x$, which decreases by 1 every step.
+We could use [[well-founded]] induction to define $[x,y)$, but luckily
+there is a simpler solution: we can define an auxiliary function
+`count-up`{.Agda} that computes the range $[x,x+n)$, and then define
+$[x,y)$ as `count-up x (y - x)`.
+
+```agda
+count-up : Nat → Nat → List Nat
+count-up x zero = []
+count-up x (suc n) = x ∷ count-up (suc x) n
+
+range : Nat → Nat → List Nat
+range x y = count-up x (y - x)
+```
+
+We can prove that `range`{.Agda} satisfies our recurrence relation
+via some elementary results about monus.
+
+```agda
+range-≥-empty : ∀ {x y} → .(y ≤ x) → range x y ≡ []
+range-≥-empty {x} {y} y≤x =
+  count-up x (y - x) ≡⟨ ap (count-up x) (monus-≤-zero y x y≤x) ⟩
+  count-up x 0        ≡⟨⟩
+  []                  ∎
+
+range-<-∷ : .(x < y) → range x y ≡ x ∷ range (suc x) y
+range-<-∷ {x} {suc y} x<y =
+  count-up x (suc y - x)        ≡⟨ ap (count-up x) (monus-≤-suc x y (≤-peel x<y)) ⟩
+  count-up x (suc (y - x))      ≡⟨⟩
+  x ∷ count-up (suc x) (y - x)  ∎
+```
+
+## Properties of half-open ranges
+
+The length of $[x,y)$ is $y - x$.
+
+```agda
+length-count-up : ∀ (x n : Nat) → length (count-up x n) ≡ n
+length-count-up x zero = refl
+length-count-up x (suc n) = ap suc (length-count-up (suc x) n)
+
+length-range : ∀ (x y : Nat) → length (range x y) ≡ y - x
+length-range x y = length-count-up x (y - x)
+```
+
+The range $[x,x+1)$ is the singleton list $[x]$.
+
+```agda
+range-single : ∀ (x : Nat) → range x (suc x) ≡ x ∷ []
+range-single x =
+  range x (suc x)           ≡⟨ range-<-∷ ≤-refl ⟩
+  x ∷ range (suc x) (suc x) ≡⟨ ap (x ∷_) (range-≥-empty ≤-refl) ⟩
+  x ∷ []                    ∎
+```
+
+If $x \leq y$ and $y \leq z$, then $[x, y) \concat [y, z) = [x, z)$.
+
+First, an auxiliary lemma: if we count `m` numbers up from `x`, and then
+count `n` numbers up from `x + m`, then this is the same as counting
+`m + n` numbers up from `x`.
+
+```agda
+count-up-++ : ∀ (x m n : Nat) → count-up x m ++ count-up (x + m) n ≡ count-up x (m + n)
+count-up-++ x zero n =
+  count-up ⌜ x + 0 ⌝ n ≡⟨ ap! (+-zeror x) ⟩
+  count-up x n         ∎
+count-up-++ x (suc m) n =
+  x ∷ (count-up (suc x) m ++ count-up ⌜ x + suc m ⌝ n) ≡⟨ ap! (+-sucr x m) ⟩
+  x ∷ (count-up (suc x) m ++ count-up (suc x + m) n)   ≡⟨ ap (x ∷_) (count-up-++ (suc x) m n) ⟩
+  count-up x (suc m + n)                               ∎
+```
+
+Our result on ranges follows immediately from this count-up-index-of after we do
+some monus munging.
+
+```agda
+range-++ : ∀ {x z : Nat} → (y : Nat) → x ≤ y → y ≤ z → range x y ++ range y z ≡ range x z
+range-++ {x = x} {z = z} y x≤y y≤z =
+  count-up x (y - x) ++ count-up ⌜ y ⌝  (z - y)        ≡⟨ ap! (sym (monus-+l-inverse x y x≤y)) ⟩
+  count-up x (y - x) ++ count-up (x + (y - x)) (z - y) ≡⟨ count-up-++ x (y - x) (z - y) ⟩
+  count-up x ⌜ (y - x) + (z - y) ⌝                     ≡⟨ ap! (monus-cancel-outer x y z x≤y y≤z) ⟩
+  count-up x (z - x)                                   ∎
+```
+
+<!--
+```agda
+range-∷r : x ≤ y → range x (suc y) ≡ range x y ∷r y
+range-∷r {x = x} {y = y} x≤y =
+  range x (suc y)                  ≡˘⟨ range-++ y x≤y ≤-ascend ⟩
+  range x y ++ ⌜ range y (suc y) ⌝ ≡⟨ ap! (range-single y) ⟩
+  range x y ∷r y                   ∎
+```
+-->
+
+If $[x,y)$ is nonempty, then $x < y$.
+
+```agda
+nonempty-range→< : ∀ {x y} → is-nonempty (range x y) → x < y
+nonempty-range→< {x = x} {y = y} ne with holds? (x < y)
+... | yes x<y = x<y
+... | no ¬x<y =
+  absurd (is-nonempty→not-empty ne (range-≥-empty (≤-from-not-< x y ¬x<y)))
+```
+
+## Membership in half-open ranges
+
+If $i \in [x,y)$, then $x \leq i$.
+
+```agda
+count-up-lower
+  : ∀ {x n i}
+  → i ∈ count-up x n
+  → x ≤ i
+count-up-lower {n = suc n} (here i=x) = ≤-reflᵢ (symᵢ i=x)
+count-up-lower {n = suc n} (there i∈xn) = <-weaken (count-up-lower i∈xn)
+
+range-lower
+  : ∀ {x y i : Nat}
+  → i ∈ range x y
+  → x ≤ i
+range-lower x∈ij = count-up-lower x∈ij
+```
+
+Likewise, if $i \in [x,y)$, then $i < y$. The argument here is a *bit*
+trickier than the previous one due to some annoying monus manipulation.
+A short inductive argument shows us that `i ∈ count-up x n` implies
+that `i < n + x`. To transfer this to `range x y`, we need to show
+that $(y - x) + y = y$, which is only true when $x \leq y$. We can
+discharge this side condition by observing that if $i \in [x,y)$,
+then $[x,y)$ must be nonempty, and thus $x < y$.
+
+```agda
+count-up-upper
+  : ∀ {x n i : Nat}
+  → i ∈ count-up x n
+  → i < n + x
+count-up-upper {x = x} {n = suc n} {i = i} (here i=x) =
+  s≤s (≤-trans (≤-reflᵢ i=x) (+-≤r n x))
+count-up-upper {x = x} {n = suc n} {i = i} (there i∈xy) =
+  ≤-trans (count-up-upper i∈xy) (≤-refl' (+-sucr n x))
+
+range-upper
+  : ∀ {x y i : Nat}
+  → i ∈ range x y
+  → i < y
+range-upper {x = x} {y = y} {i = i} i∈xy =
+  ≤-trans (count-up-upper i∈xy) $ ≤-refl' $ᵢ
+    monus-+r-inverse y x $ᵢ
+    <-weaken (nonempty-range→< (has-member→nonempty i∈xy))
+```
+
+Conversely, if $x \leq i < y$, then $i \in [x, y)$.
+
+```agda
+count-up-∈
+  : ∀ {x n i}
+  → .(x ≤ i) → .(i < n + x)
+  → i ∈ count-up x n
+count-up-∈ {x = x} {n = zero} {i = i} x≤i i<n+x =
+  absurd (<-irrefl refl (≤-trans i<n+x x≤i))
+count-up-∈ {x = x} {n = suc n} {i = i} x≤i i<n+x with ≤-strengthen x≤i
+... | inl x=i = here (Equiv.from Id≃path (sym x=i))
+... | inr x<i = there (count-up-∈ x<i (≤-trans i<n+x (≤-refl' (sym (+-sucr n x)))))
+
+range-∈
+  : ∀ {x y i}
+  → .(x ≤ i) → .(i < y)
+  → i ∈ range x y
+range-∈ {x = x} {y = y} {i = i} x≤i i<y =
+  count-up-∈ x≤i $ᵢ ≤-trans i<y $ ≤-refl' $ᵢ sym $
+    monus-+r-inverse y x (≤-trans x≤i (<-weaken i<y))
+```
+
+Next, observe that if $i \in [x,y)$, then the index of $i$
+in $[x,y)$ is $i - x$.
+
+```agda
+count-up-index-of
+  : ∀ {x n i : Nat}
+  → (i∈xn : i ∈ count-up x n)
+  → index-of i∈xn ≡ i - x
+count-up-index-of {x = x} {n = suc n} {i = i} (here i=x) =
+  0     ≡˘⟨ monus-≤-zero i x (≤-reflᵢ i=x) ⟩
+  i - x ∎
+count-up-index-of {x = x} {n = suc n} {i = i} (there i∈xn) =
+  suc (index-of i∈xn) ≡⟨ ap suc (count-up-index-of i∈xn) ⟩
+  1 + (i - (1 + x))   ≡˘⟨ monus-pres-+l 1 i (1 + x) (count-up-lower i∈xn) ⟩
+  (1 + i) - (1 + x)   ≡⟨ monus-cancell 1 i x ⟩
+  i - x               ∎
+
+range-index-of
+  : ∀ {x y i : Nat}
+  → (i∈xn : i ∈ range x y)
+  → index-of i∈xn ≡ i - x
+range-index-of = count-up-index-of
+```
+
+This means that $i \in range x y$ is a [[proposition]],
+as any two possible indices of $i$ must both be equal
+to $i - x$.
+
+```agda
+range-∈-is-prop
+  : ∀ (x y i : Nat)
+  → is-prop (i ∈ range x y)
+range-∈-is-prop x y i i∈xy i∈xy' =
+  Equiv.injective member≃lookup $ Σ-prop-path! $ ext $
+    index-of i∈xy  ≡⟨ range-index-of i∈xy ⟩
+    i - x          ≡˘⟨ range-index-of i∈xy' ⟩
+    index-of i∈xy' ∎
+```
+
+This is the last ingredient we need to prove that $i \in [x,y)$
+is equivalent to $x \leq i < y$.
+
+```agda
+range-∈≃bounded
+  : ∀ (x y i : Nat)
+  → (i ∈ range x y) ≃ (x ≤ i × i < y)
+range-∈≃bounded x y i =
+  prop-ext (range-∈-is-prop x y i) (hlevel 1)
+    (λ i∈xy → range-lower i∈xy , range-upper i∈xy)
+    (λ x≤i<y → range-∈ (x≤i<y .fst) (x≤i<y .snd))
+```

--- a/src/Data/Nat/Range.lagda.md
+++ b/src/Data/Nat/Range.lagda.md
@@ -277,7 +277,7 @@ range-∈-is-prop
   : ∀ (x y i : Nat)
   → is-prop (i ∈ range x y)
 range-∈-is-prop x y i i∈xy i∈xy' =
-  Equiv.injective member≃lookup $ Σ-prop-path! $ ext $
+  Equiv.injective member≃lookup $ Σ-prop-path! $ lower-inj $
     index-of i∈xy  ≡⟨ range-index-of i∈xy ⟩
     i - x          ≡˘⟨ range-index-of i∈xy' ⟩
     index-of i∈xy' ∎

--- a/src/Data/Nat/Solver.lagda.md
+++ b/src/Data/Nat/Solver.lagda.md
@@ -107,9 +107,9 @@ commute-inner w x y z =
 
 commute-last : ∀ x y z → (x * y) * z ≡ (x * z) * y
 commute-last x y z =
-  x * y * z   ≡⟨ *-associative x y z ⟩
+  x * y * z   ≡˘⟨ *-associative x y z ⟩
   x * (y * z) ≡⟨ ap (x *_) (*-commutative y z) ⟩
-  x * (z * y) ≡˘⟨ *-associative x z y ⟩
+  x * (z * y) ≡⟨ *-associative x z y ⟩
   x * z * y ∎
 ```
 -->
@@ -354,7 +354,7 @@ sound-*ₚ (p *X+ r) (q *X+ s) (x₀ ∷ env) =
   (⟦p*⟨qx+s⟩⟧ + ⟦r*q⟧) * x₀ + ⟦r⟧ * ⟦s⟧                        ≡⟨ ap₂ (λ ϕ ψ → (ϕ + ψ) * x₀ + ⟦r⟧ * ⟦s⟧) (sound-*ₚ p (q *X+ s) (x₀ ∷ env)) (sound-*ₚ' r q x₀ env) ⟩
   (⟦p⟧ * (⟦q⟧ * x₀ + ⟦s⟧) + ⟦r⟧ * ⟦q⟧) * x₀ + ⟦r⟧ * ⟦s⟧        ≡⟨ ap (λ ϕ → ϕ + ⟦r⟧ * ⟦s⟧) (*-distrib-+r (⟦p⟧ * (⟦q⟧ * x₀ + ⟦s⟧)) (⟦r⟧ * ⟦q⟧) x₀) ⟩
   ⟦p⟧ * (⟦q⟧ * x₀ + ⟦s⟧) * x₀ + ⟦r⟧ * ⟦q⟧ * x₀ + ⟦r⟧ * ⟦s⟧     ≡˘⟨ +-associative (⟦p⟧ * (⟦q⟧ * x₀ + ⟦s⟧) * x₀) (⟦r⟧ * ⟦q⟧ * x₀) (⟦r⟧ * ⟦s⟧) ⟩
-  ⟦p⟧ * (⟦q⟧ * x₀ + ⟦s⟧) * x₀ + (⟦r⟧ * ⟦q⟧ * x₀ + ⟦r⟧ * ⟦s⟧)   ≡⟨ ap (λ ϕ →  ⟦p⟧ * (⟦q⟧ * x₀ + ⟦s⟧) * x₀ + (ϕ + ⟦r⟧ * ⟦s⟧)) (*-associative ⟦r⟧ ⟦q⟧ x₀) ⟩
+  ⟦p⟧ * (⟦q⟧ * x₀ + ⟦s⟧) * x₀ + (⟦r⟧ * ⟦q⟧ * x₀ + ⟦r⟧ * ⟦s⟧)   ≡˘⟨ ap (λ ϕ →  ⟦p⟧ * (⟦q⟧ * x₀ + ⟦s⟧) * x₀ + (ϕ + ⟦r⟧ * ⟦s⟧)) (*-associative ⟦r⟧ ⟦q⟧ x₀) ⟩
   ⟦p⟧ * (⟦q⟧ * x₀ + ⟦s⟧) * x₀ + (⟦r⟧ * (⟦q⟧ * x₀) + ⟦r⟧ * ⟦s⟧) ≡˘⟨ ap (λ ϕ → ⟦p⟧ * (⟦q⟧ * x₀ + ⟦s⟧) * x₀ + ϕ) (*-distrib-+l (⟦q⟧ * x₀) ⟦s⟧ ⟦r⟧) ⟩
   ⟦p⟧ * (⟦q⟧ * x₀ + ⟦s⟧) * x₀ + ⟦r⟧ * (⟦q⟧ * x₀ + ⟦s⟧)         ≡⟨ ap (λ ϕ → ϕ + ⟦r⟧ * (⟦q⟧ * x₀ + ⟦s⟧)) (commute-last ⟦p⟧ (⟦q⟧ * x₀ + ⟦s⟧) x₀) ⟩
   ⟦p⟧ * x₀ * (⟦q⟧ * x₀ + ⟦s⟧) + ⟦r⟧ * (⟦q⟧ * x₀ + ⟦s⟧)         ≡˘⟨ *-distrib-+r (⟦p⟧ * x₀) ⟦r⟧ (⟦q⟧ * x₀ + ⟦s⟧) ⟩
@@ -376,7 +376,7 @@ are nowhere near as bad.
 sound-*ₚ' p zerop x₀ env = sym (*-zeror (⟦ p ⟧ₚ env))
 sound-*ₚ' r (p *X+ q) x₀ env =
   ⟦ r *ₚ' p ⟧ₚ (x₀ ∷ env) * x₀ + ⟦ r *ₚ q ⟧ₚ env ≡⟨ ap₂ (λ ϕ ψ → ϕ * x₀ + ψ) (sound-*ₚ' r p x₀ env) (sound-*ₚ r q env) ⟩
-  ⟦r⟧ * ⟦p⟧ * x₀ + ⟦r⟧ * ⟦q⟧                     ≡⟨ ap (λ ϕ → ϕ + ⟦r⟧ * ⟦q⟧) (*-associative ⟦r⟧ ⟦p⟧ x₀) ⟩
+  ⟦r⟧ * ⟦p⟧ * x₀ + ⟦r⟧ * ⟦q⟧                     ≡˘⟨ ap (λ ϕ → ϕ + ⟦r⟧ * ⟦q⟧) (*-associative ⟦r⟧ ⟦p⟧ x₀) ⟩
   ⟦r⟧ * (⟦p⟧ * x₀) + ⟦r⟧ * ⟦q⟧                   ≡˘⟨ *-distrib-+l  (⟦p⟧ * x₀) ⟦q⟧ ⟦r⟧ ⟩
   ⟦r⟧ * (⟦p⟧ * x₀ + ⟦q⟧)                         ∎
   where

--- a/src/Data/Rational/Base.lagda.md
+++ b/src/Data/Rational/Base.lagda.md
@@ -422,10 +422,10 @@ Finally, we can calculate that these fractions are similar.
     ∣-*-cancelr {g} {g'} {1} ⦃ nonzero→positive rem₂ ⦄ (∣-trans (gcd[x,y] .snd .is-gcd.greatest p1 p2) (subst (g ∣_) (sym (+-zeror g)) ∣-refl))
     where
       p1 : g' * g ∣ abs x
-      p1 = fibre→∣ (p , sym (*-associative p g' g) ∙ ap (_* g) α ∙ x/g*g=x)
+      p1 = fibre→∣ (p , *-associative p g' g ∙ ap (_* g) α ∙ x/g*g=x)
 
       p2 : g' * g ∣ abs y
-      p2 = fibre→∣ (q , sym (*-associative q g' g) ∙ ap (_* g) β ∙ y/g*g=y)
+      p2 = fibre→∣ (q , *-associative q g' g ∙ ap (_* g) β ∙ y/g*g=y)
 
 ```
 -->
@@ -486,7 +486,7 @@ Therefore, our numerators have the same absolute value.
 ```agda
   num' : xs/gcd * gcdℤ x y ≡ abs x
   num' = *-injr (abs s) (xs/gcd * m.g) (abs x) $
-    xs/gcd * gcdℤ x y * abs s       ≡⟨ *-associative xs/gcd m.g (abs s) ⟩
+    xs/gcd * gcdℤ x y * abs s       ≡˘⟨ *-associative xs/gcd m.g (abs s) ⟩
     xs/gcd * (gcdℤ x y * abs s)     ≡˘⟨ ap (xs/gcd *_) p1 ⟩
     xs/gcd * gcdℤ (x *ℤ s) (y *ℤ s) ≡⟨ n.x/g*g=x ⟩
     abs (x *ℤ s)                    ≡⟨ abs-*ℤ x s ⟩
@@ -513,7 +513,7 @@ fraction, we're done.
 
 ```agda
   denom' : ys/gcd * gcdℤ x y ≡ abs y
-  denom' = *-injr (abs s) (ys/gcd * m.g) (abs y) (*-associative ys/gcd m.g (abs s) ∙ sym (ap (ys/gcd *_) p1) ∙ n.y/g*g=y ∙ abs-*ℤ y s)
+  denom' = *-injr (abs s) (ys/gcd * m.g) (abs y) (sym (*-associative ys/gcd m.g (abs s)) ∙ sym (ap (ys/gcd *_) p1) ∙ n.y/g*g=y ∙ abs-*ℤ y s)
 
   denom : ys/gcd ≡ y/gcd
   denom = *-injr (gcdℤ x y) ys/gcd y/gcd (denom' ∙ sym m.y/g*g=y)

--- a/src/preamble.tex
+++ b/src/preamble.tex
@@ -134,7 +134,10 @@
 \DeclareMathOperator*{\baut}{\mathbf{B}}
 \newcommand{\B}[1]{\mathbf{B} #1}
 \newcommand{\point}[1]{\bullet_{#1}}
+
 \newcommand{\List}[1]{\operatorname{List}(#1)}
+\newcommand{\concat}{\ensuremath{\mathbin{+\mkern-10mu+}}}
+\newcommand{\cons}{\mathbin{\dblcolon}}
 
 \DeclareMathOperator{\Lan}{Lan}
 \DeclareMathOperator{\Ran}{Ran}


### PR DESCRIPTION
# Description

This PR lays the groundwork for big operators by defining an API for working with ranges `[x, y)` of natural numbers, and proves some useful facts about them. It also does a bit of clean-up on `Data.Nat.Properties`.

## Checklist

Before submitting a merge request, please check the items below:

- [ ] I've read [the contributing guidelines](https://github.com/plt-amy/1lab/blob/main/CONTRIBUTING.md).
- [ ] The imports of new modules have been sorted with `support/sort-imports.hs` (or `nix run --experimental-features nix-command -f . sort-imports`).
- [ ] All new code blocks have "agda" as their language.

If your change affects many files without adding substantial content, and
you don't want your name to appear on those pages (for example, treewide
refactorings or reformattings), start the commit message and PR title with `chore:`.
