### PR TITLE
The regular hyperdoctrine of subobjects of a regular category

### DIFF
--- a/src/Cat/Bi/Instances/Relations.lagda.md
+++ b/src/Cat/Bi/Instances/Relations.lagda.md
@@ -335,7 +335,6 @@ rectangle is a pullback, too.
   rem₀ = pasting-left→outer-is-pullback
     (st.inter .has-is-pb)
     (rotate-pullback (X .has-is-pb))
-    (pulll (st.inter .square) ∙ extendr (sym (X .square)))
 ```
 
 Now, by definition, we have $\xi_1\alpha = u_1x_1$, and $s_1v_1$ is also
@@ -423,8 +422,7 @@ want to look at the formalisation.
         (sym (r[st].inter .p₂∘universal))
         (sym (pullr (sym (factor st.it .factors)) ∙ π₂∘⟨⟩)))
       (pasting-left→outer-is-pullback
-        (rotate-pullback (rs.inter .has-is-pb)) (X .has-is-pb)
-        (extendl (sym (rs.inter .square)) ∙ pushr (X .square)))
+        (rotate-pullback (rs.inter .has-is-pb)) (X .has-is-pb))
 
     β-is-pb : is-pullback C β ζ₁ x₁ q
     β-is-pb = pasting-outer→left-is-pullback

--- a/src/Cat/Bi/Instances/Relations.lagda.md
+++ b/src/Cat/Bi/Instances/Relations.lagda.md
@@ -185,7 +185,7 @@ into a subobject.]
   → (φ : c ↬ d)
   → (ψ : b ↬ c)
   → (χ : a ↬ b)
-  → (∘-rel φ (∘-rel ψ χ)) Sub.≅ (∘-rel (∘-rel φ ψ) χ)
+  → (∘-rel φ (∘-rel ψ χ)) ≅ₘ (∘-rel (∘-rel φ ψ) χ)
 ∘-rel-assoc {a} {b} {c} {d} r s t = done where
   module rs = ∘-rel r s
   module st = ∘-rel s t
@@ -390,13 +390,13 @@ which we can calculate is exactly $\langle t_1u_1x_1 , r_2v_2x_2
 
 ```agda
   [rs]t≅i : Im ⟨ t₁ ∘ [rs]t.inter .p₁ , (π₂ ∘ i) ∘ [rs]t.inter .p₂ ⟩
-      Sub.≅ Im ⟨ t₁ ∘ u₁ ∘ x₁ , r₂ ∘ v₂ ∘ x₂ ⟩
-  [rs]t≅i = subst (λ e → Im [rs]t.it Sub.≅ Im e)
+      ≅ₘ Im ⟨ t₁ ∘ u₁ ∘ x₁ , r₂ ∘ v₂ ∘ x₂ ⟩
+  [rs]t≅i = subst (λ e → Im [rs]t.it ≅ₘ Im e)
     (⟨⟩∘ _ ∙ ap₂ ⟨_,_⟩
       (pullr ([rs]t.inter .p₁∘universal))
       ( pullr ([rs]t.inter .p₂∘universal)
       ∙ extendl (pullr (sym (factor _ .factors)) ∙ π₂∘⟨⟩)))
-    (image-pre-cover [rs]t.it _ α-cover)
+    (image-pre-cover [rs]t.it _ α-cover Sub.Iso⁻¹)
 ```
 
 Now do that whole thing over again. I'm not joking: start by forming the
@@ -433,13 +433,13 @@ want to look at the formalisation.
   β-cover : is-strong-epi C β
   β-cover = stable _ _ (factor st.it .left∈L) β-is-pb
 
-  r[st]≅i : Im r[st].it Sub.≅ Im j
-  r[st]≅i = subst (λ e → Im r[st].it Sub.≅ Im e)
+  r[st]≅i : Im r[st].it ≅ₘ Im j
+  r[st]≅i = subst (λ e → Im r[st].it ≅ₘ Im e)
     (⟨⟩∘ _ ∙ ap₂ ⟨_,_⟩ (pullr (r[st].inter .p₁∘universal) ∙ extendl (pullr (sym (factor _ .factors)) ∙ π₁∘⟨⟩))
                        (pullr (r[st].inter .p₂∘universal)))
-    (image-pre-cover r[st].it _ β-cover)
+    (image-pre-cover r[st].it _ β-cover Sub.Iso⁻¹)
 
-  done : Im r[st].it Sub.≅ Im [rs]t.it
+  done : Im r[st].it ≅ₘ Im [rs]t.it
   done = [rs]t≅i Sub.Iso⁻¹ Sub.∘Iso r[st]≅i
 ```
 -->
@@ -454,8 +454,8 @@ construct these three maps:
   : ∀ {b c d} {r r' : c ↬ d} {s s' : b ↬ c}
   → r ≤ₘ r' → s ≤ₘ s' → ∘-rel r s ≤ₘ ∘-rel r' s'
 
-∘-rel-idr : ∀ {a b} (f : a ↬ b) → ∘-rel f id-rel Sub.≅ f
-∘-rel-idl : ∀ {a b} (f : a ↬ b) → ∘-rel id-rel f Sub.≅ f
+∘-rel-idr : ∀ {a b} (f : a ↬ b) → ∘-rel f id-rel ≅ₘ f
+∘-rel-idl : ∀ {a b} (f : a ↬ b) → ∘-rel id-rel f ≅ₘ f
 ```
 
 Witnessing, respectively, that relational composition respects inclusion

--- a/src/Cat/Diagram/Colimit/Universal.lagda.md
+++ b/src/Cat/Diagram/Colimit/Universal.lagda.md
@@ -295,8 +295,8 @@ colimits, we get that $F$ is colimiting.
         (λ j → C/.invertible→iso
           (record { map = eq _ .universal (sym (pb _ _ .Pullback.square))
                   ; com = eq _ .p₁∘universal })
-          (Forget/-is-conservative (Equiv.from (pullback-unique (rotate-pullback (eq _)) _)
-            (pb _ _ .Pullback.has-is-pb))))
+          (Forget/-is-conservative (pullback-unique
+            (rotate-pullback (eq _)) (pb _ _ .Pullback.has-is-pb))))
         λ f → ext (unique₂ (eq _)
           {p = sym (pb _ _ .Pullback.square) ∙ pushl (G .F-∘ _ _)}
           (pulll (sym (F .F-∘ _ _)) ∙ eq _ .p₁∘universal)
@@ -313,8 +313,8 @@ colimits, we get that $F$ is colimiting.
         (!const-isoⁿ (C/.invertible→iso
           (record { map = eq _ .universal (sym (pb _ _ .Pullback.square))
                   ; com = eq _ .p₁∘universal })
-          (Forget/-is-conservative (Equiv.from (pullback-unique (rotate-pullback (eq _)) _)
-            (pb _ _ .Pullback.has-is-pb)))))
+          (Forget/-is-conservative (pullback-unique
+            (rotate-pullback (eq _)) (pb _ _ .Pullback.has-is-pb)))))
         (ext λ j → (idl _ ⟩∘⟨refl) ∙ unique₂ (eq _)
           {p = eq _ .square ∙ pushl (G .F-∘ _ _)}
           (pulll (eq _ .p₁∘universal) ∙∙ pulll (pb _ _ .Pullback.p₂∘universal) ∙∙ pb _ _ .Pullback.p₂∘universal)

--- a/src/Cat/Diagram/Limit/Finite.lagda.md
+++ b/src/Cat/Diagram/Limit/Finite.lagda.md
@@ -80,14 +80,10 @@ to give a terminal object and binary products.
       equalisers : has-equalisers C
       pullbacks  : has-pullbacks C
 
-    Eq : ∀ {A B} (f g : Hom A B) → Ob
-    Eq f g = equalisers f g .Equaliser.apex
-
-    Pb : ∀ {A B C} (f : Hom A C) (g : Hom B C) → Ob
-    Pb f g = pullbacks f g .Pullback.apex
-
     module Products = Binary-products C products
     open Products using (_⊗₀_) public
+    open Equalisers C equalisers public
+    open Pullbacks C pullbacks public
 
   open Finitely-complete
 ```

--- a/src/Cat/Diagram/Pullback/Along.lagda.md
+++ b/src/Cat/Diagram/Pullback/Along.lagda.md
@@ -119,9 +119,7 @@ pullback of $l$ along $n \circ m$.
   paste-is-pullback-along p q r .has-is-pb =
     subst-is-pullback refl r refl refl (rotate-pullback (pasting-left→outer-is-pullback
       (rotate-pullback (p .has-is-pb))
-      (rotate-pullback (q .has-is-pb))
-      ( extendl (sym (p .is-pullback-along.square))
-      ∙ pushr (sym (q .is-pullback-along.square)))))
+      (rotate-pullback (q .has-is-pb))))
 ```
 
 Similarly, if some $l_2$ is the pullback of $r_2$ along some $t_1$,
@@ -166,8 +164,7 @@ pullbacks, so we will skip over the details.
   extend-is-pullback-along pb₁ pb₂ l-comm r-comm .top = pb₂ .top
   extend-is-pullback-along pb₁ pb₂ l-comm r-comm .has-is-pb =
     subst-is-pullback l-comm refl refl r-comm $
-    pasting-left→outer-is-pullback pb₁ (has-is-pb pb₂) $
-    pulll (pb₁ .square) ∙ extendr (pb₂ .is-pullback-along.square)
+    pasting-left→outer-is-pullback pb₁ (has-is-pb pb₂)
 ```
 </details>
 

--- a/src/Cat/Diagram/Pullback/Properties.lagda.md
+++ b/src/Cat/Diagram/Pullback/Properties.lagda.md
@@ -168,14 +168,14 @@ then have a map $x \to a$, as we wanted.
 ```agda
     pasting-left→outer-is-pullback
       : is-pullback C a→b b→e a→d d→e
-      → (square : c→f ∘ b→c ∘ a→b ≡ (e→f ∘ d→e) ∘ a→d)
       → is-pullback C (b→c ∘ a→b) c→f a→d (e→f ∘ d→e)
-    pasting-left→outer-is-pullback left square = pb where
+    pasting-left→outer-is-pullback left = pb where
       module left = is-pullback left
 
       pb : is-pullback C (b→c ∘ a→b) c→f a→d (e→f ∘ d→e)
       pb .is-pullback.square =
-        c→f ∘ b→c ∘ a→b   ≡⟨ square ⟩
+        c→f ∘ b→c ∘ a→b   ≡⟨ extendl right.square ⟩
+        e→f ∘ b→e ∘ a→b   ≡⟨ pushr left.square ⟩
         (e→f ∘ d→e) ∘ a→d ∎
       pb .universal {p₁' = P→c} {p₂' = P→d} x =
         left.universal {p₁' = right.universal (x ∙ sym (assoc _ _ _))} {p₂' = P→d}

--- a/src/Cat/Diagram/Pullback/Properties.lagda.md
+++ b/src/Cat/Diagram/Pullback/Properties.lagda.md
@@ -283,14 +283,14 @@ A similar result holds for isomorphisms.
   rotate-pullback pb .p₂∘universal = pb .p₁∘universal
   rotate-pullback pb .unique p q = pb .unique q p
 
-  pullback-unique
+  invertible≃pullback
     : ∀ {p p' x y z} {f : Hom x z} {g : Hom y z} {p1 : Hom p x} {p2 : Hom p y}
         {p1' : Hom p' x} {p2' : Hom p' y}
     → (pb : is-pullback C p1 f p2 g)
     → (sq : f ∘ p1' ≡ g ∘ p2')
     → is-invertible (pb .universal sq)
     ≃ is-pullback C p1' f p2' g
-  pullback-unique {f = f} {g} {p1} {p2} {p1'} {p2'} pb sq
+  invertible≃pullback {f = f} {g} {p1} {p2} {p1'} {p2'} pb sq
     = prop-ext! inv→pb pb→inv
     where
     module _ (inv : is-invertible (pb .universal sq)) where
@@ -314,14 +314,35 @@ A similar result holds for isomorphisms.
         (pulll (pb' .p₂∘universal) ∙ pb .p₂∘universal)
         (idr _) (idr _))
 
+  pullback-unique
+    : ∀ {p p' x y z} {f : Hom x z} {g : Hom y z} {p1 : Hom p x} {p2 : Hom p y}
+        {p1' : Hom p' x} {p2' : Hom p' y}
+    → (pb : is-pullback C p1 f p2 g)
+    → (pb' : is-pullback C p1' f p2' g)
+    → is-invertible (pb .universal (pb' .square))
+  pullback-unique pb pb' =
+    Equiv.from (invertible≃pullback pb (pb' .square)) pb'
+
   is-pullback-iso
     : ∀ {p p' x y z} {f : Hom x z} {g : Hom y z} {p1 : Hom p x} {p2 : Hom p y}
     → (i : p ≅ p')
     → is-pullback C p1 f p2 g
     → is-pullback C (p1 ∘ _≅_.from i) f (p2 ∘ _≅_.from i) g
   is-pullback-iso i pb = Equiv.to
-    (pullback-unique pb (extendl (pb .square)))
+    (invertible≃pullback pb (extendl (pb .square)))
     (subst is-invertible (pb .unique refl refl) (iso→invertible (i Iso⁻¹)))
+
+  is-pullback-iso'
+    : ∀ {p p' x y z} {f : Hom x z} {g : Hom y z} {p1 : Hom p x} {p2 : Hom p y}
+        {p1' : Hom p' x} {p2' : Hom p' y}
+    → (i : p' ≅ p)
+    → (pb : is-pullback C p1 f p2 g)
+    → p1 ∘ i .to ≡ p1'
+    → p2 ∘ i .to ≡ p2'
+    → is-pullback C p1' f p2' g
+  is-pullback-iso' i pb com₁ com₂ = subst-is-pullback
+    com₁ refl com₂ refl
+    (is-pullback-iso (i Iso⁻¹) pb)
 
   Pullback-unique
     : ∀ {x y z} {f : Hom x z} {g : Hom y z}
@@ -334,7 +355,7 @@ A similar result holds for isomorphisms.
       (Univalent.Hom-pathp-refll-iso c-cat (x .p₂∘universal))
     where
       open Pullback
-      apices = c-cat .to-path (invertible→iso _ (Equiv.from (pullback-unique (y .has-is-pb) (x .square)) (x .has-is-pb)))
+      apices = c-cat .to-path (invertible→iso _ (Equiv.from (invertible≃pullback (y .has-is-pb) (x .square)) (x .has-is-pb)))
 
   canonically-stable
     : ∀ {ℓ'} (P : ∀ {a b} → Hom a b → Type ℓ')

--- a/src/Cat/Displayed/BeckChevalley.lagda.md
+++ b/src/Cat/Displayed/BeckChevalley.lagda.md
@@ -34,7 +34,7 @@ we shall view the corresponding [[base change]] functors $f^{*} :
 \cE_{Y} \to \cE_{X}$ as an operation of substitution on
 predicates/types, and assume that $\cB$ has [[finite products]]. This
 setup leads to a tidy definition of existential quantifiers as left
-adjoints $\exists_{Y} : \cE_{X \times Y} \to \cE{X}$ to the base changes
+adjoints $\exists_{Y} : \cE_{X \times Y} \to \cE_{X}$ to the base changes
 along projections $\pi : X \times Y \to X$:
 
 - The introduction rule is given by the unit

--- a/src/Cat/Displayed/BeckChevalley.lagda.md
+++ b/src/Cat/Displayed/BeckChevalley.lagda.md
@@ -26,7 +26,7 @@ import Cat.Reasoning
 module Cat.Displayed.BeckChevalley where
 ```
 
-# Beck-Chevalley conditions
+# Beck-Chevalley conditions {defines="Beck-Chevalley-condition"}
 
 Let $\cE \liesover \cB$ be a [[cartesian fibration]], which we shall
 view as a setting for some sort of logic or type theory. In particular,

--- a/src/Cat/Displayed/Cartesian.lagda.md
+++ b/src/Cat/Displayed/Cartesian.lagda.md
@@ -691,7 +691,7 @@ module Cartesian-fibration (fib : Cartesian-fibration) where
   module _ {x y} (f : Hom x y) (y' : Ob[ y ]) where
     open Cartesian-lift (fib f y')
       using ()
-      renaming (x' to _^*_; lifting to π*)
+      renaming (x' to infixr 40 _^*_; lifting to π*)
       public
 
   module π* {x y} {f : Hom x y} {y' : Ob[ y ]} where

--- a/src/Cat/Displayed/Cocartesian/Weak.lagda.md
+++ b/src/Cat/Displayed/Cocartesian/Weak.lagda.md
@@ -212,7 +212,7 @@ fibration+weak-cocartesian→cocartesian {x} {y} {x'} {y'} {f} {f'} fib weak = c
     module weak = is-weak-cocartesian weak
 ```
 
-To see show this, we need to construct a unique factorisation of some
+To show this, we need to construct a unique factorisation of some
 morphism $h' : x' \to_{mf} u'$, as depicted in the following diagram
 
 ~~~{.quiver}

--- a/src/Cat/Displayed/Comprehension.lagda.md
+++ b/src/Cat/Displayed/Comprehension.lagda.md
@@ -528,11 +528,11 @@ Comonad→comprehension fib comp-comonad = comprehension where
   vert .F-∘'  = Slice-path (ap fst (W-∘ _ _))
 ```
 
-To see that this functor is fibred, recall that pullbacks in the
-codomain fibration are given by pullbacks. Furthermore, if we
+To see that this functor is fibred, recall that cartesian maps in the
+codomain fibration are given by pullback squares. Furthermore, if we
 have a pullback square in the total category of $\cE$ where two
 opposing sides are cartesian, then we have a corresponding pullback
-square in $\cB$. As the comonad is a comprehension comonad, counit is
+square in $\cB$. As the comonad is a comprehension comonad, the counit is
 cartesian, which finishes off the proof.
 
 ```agda

--- a/src/Cat/Displayed/Doctrine.lagda.md
+++ b/src/Cat/Displayed/Doctrine.lagda.md
@@ -214,10 +214,10 @@ quantification and substitution. While in general the order matters, the
 **Beck-Chevalley condition** says that we can conclude
 
 $$
-\exists_h (a[k]) = (\exists_g a)[f]
+\exists_h (\alpha[k]) = (\exists_g \alpha)[f]
 $$
 
-provided that the square
+given $\alpha : \bP(b)$ and provided that the square
 
 ~~~{.quiver}
 \[\begin{tikzcd}[ampersand replacement=\&]

--- a/src/Cat/Displayed/Functor.lagda.md
+++ b/src/Cat/Displayed/Functor.lagda.md
@@ -187,6 +187,37 @@ module
 ```
 -->
 
+Just like with [[isomorphisms]] and [[limits]], it makes sense to
+consider the converse property: displayed functors that **reflect
+cartesian morphisms**. An example is given by fully faithful displayed
+functors.
+
+```agda
+  record reflects-cartesian-maps (F' : Displayed-functor F ℰ ℱ) : Type lvl where
+    no-eta-equality
+    open Displayed-functor F'
+    field
+      reflects
+        : ∀ {a b a' b'} {f : A.Hom a b} {f' : ℰ.Hom[ f ] a' b'}
+        → ℱ.is-cartesian (F.₁ f) (F₁' f')
+        → ℰ.is-cartesian f f'
+```
+
+<!--
+```agda
+  instance
+    H-Level-reflects-cartesian-maps
+      : ∀ {F' : Displayed-functor F ℰ ℱ}
+      → {n : Nat}
+      → H-Level (reflects-cartesian-maps F') (suc n)
+    H-Level-reflects-cartesian-maps {n = n} =
+      hlevel-instance (Iso→is-hlevel (suc n) eqv (hlevel (suc n)))
+      where
+        unquoteDecl eqv = declare-record-iso eqv (quote reflects-cartesian-maps)
+        open ℱ -- Needed for the is-cartesian H-Level instances.
+```
+-->
+
 One can also define the composition of displayed functors,
 which lies over the composition of the underlying functors.
 
@@ -385,6 +416,12 @@ module
         : ∀ {x} {a b c : ℰ.Ob[ x ]} {f : ℰ.Hom[ B.id ] b c} {g : ℰ.Hom[ B.id ] a b}
         → F₁' (f ℰ↓.∘ g) ≡ F₁' f ℱ↓.∘ F₁' g
       F-∘↓ = ℱ.cast[] (apd (λ i → F₁') (ℰ.unwrap _) ℱ.∙[] F-∘' ℱ.∙[] ℱ.wrap _)
+
+    Fibre-map : ∀ x → Functor (Fibre ℰ x) (Fibre ℱ x)
+    Fibre-map x .Functor.F₀ = F₀'
+    Fibre-map x .Functor.F₁ = F₁'
+    Fibre-map x .Functor.F-id = F-id'
+    Fibre-map x .Functor.F-∘ f g = F-∘↓
 
   open Vertical-functor
 

--- a/src/Cat/Displayed/Instances/Opposite.lagda.md
+++ b/src/Cat/Displayed/Instances/Opposite.lagda.md
@@ -90,7 +90,7 @@ opposites of those of $\cE$. Note that this is still a category over
 $\cB$, unlike in the case of the [[total opposite]], which results in a
 category over $\cB\op$ --- which, generally, will not be a fibration.
 The construction of the fibred opposite proceeds using $\cE$'s
-[[base change]] functors. A morphism $h : y \to\op_f x$, lying over a map
+[[base change]] functors. A morphism $h : x \to\op_f y$, lying over a map
 $f : a \to b$, is defined to be a map $f^*y \to_{\id} x$, as indicated
 (in red) in the diagram below.
 

--- a/src/Cat/Displayed/Instances/Slice/Comprehension.lagda.md
+++ b/src/Cat/Displayed/Instances/Slice/Comprehension.lagda.md
@@ -1,0 +1,88 @@
+<!--
+```agda
+open import Cat.Displayed.Comprehension.Coproduct.VeryStrong
+open import Cat.Displayed.Comprehension.Coproduct.Strong
+open import Cat.Displayed.Comprehension.Coproduct
+open import Cat.Diagram.Pullback.Properties
+open import Cat.Displayed.Instances.Slice
+open import Cat.Displayed.Comprehension
+open import Cat.Displayed.Cocartesian
+open import Cat.Displayed.Cartesian
+open import Cat.Displayed.Functor
+open import Cat.Diagram.Pullback
+open import Cat.Instances.Slice
+open import Cat.Displayed.Base
+open import Cat.Prelude
+
+import Cat.Reasoning as CR
+
+open has-comprehension-coproducts
+open Comprehension-structure
+open /-Obj
+```
+-->
+
+```agda
+module Cat.Displayed.Instances.Slice.Comprehension
+  {o ℓ} (B : Precategory o ℓ)
+  where
+```
+
+# The canonical comprehension category {defines="canonical-comprehension-category"}
+
+The identity [[fibred functor]] of the [[canonical self-indexing]] of
+any category $\cB$ is the prototypical example of a [[comprehension
+category]].
+
+```agda
+  Slices-comprehension : Comprehension-structure (Slices B)
+  Slices-comprehension .Comprehend = Id'
+  Slices-comprehension .Comprehend-is-fibred = Id'-fibred
+```
+
+Assuming that $\cB$ has pullbacks (so that we can talk about its
+[[codomain *fibration*]]), the canonical comprehension category has
+[[comprehension coproducts]] given by its cocartesian lifts, which are
+in turn given by composition.
+
+<!--
+```agda
+  module _ (pullbacks : has-pullbacks B) where
+    private
+      fib = Codomain-fibration B pullbacks
+      opfib = Codomain-opfibration B
+
+    open CR B
+    open Displayed (Slices B)
+    open Cocartesian-fibration (Slices B) opfib
+    open Comprehension (Slices B) fib Slices-comprehension
+
+    opaque
+      unfolding _⨾_
+```
+-->
+
+```agda
+      Slices-comprehension-coproducts
+        : has-comprehension-coproducts fib fib Slices-comprehension
+      Slices-comprehension-coproducts = record where
+        ∐              x y = x .map ^! y
+        ⟨_,_⟩          x y = ι! _ y
+        ⟨⟩-cocartesian x y = ι!.cocartesian
+        ∐-beck-chevalley cart = Slices-beck-chevalley B
+          (rotate-pullback (cartesian→pullback B cart))
+```
+
+These comprehension coproducts are [[very strong|very strong
+comprehension coproduct]] by construction: they model $\Sigma$-types.
+This is one of those proofs whose name is longer than its definition,
+since $\Gamma. X. Y$ and $\Gamma. \coprod_X Y$ are both interpreted as
+the domain of the same map, and the canonical substitution between them
+is just the identity.
+
+```agda
+      Slices-very-strong-comprehension-coproducts
+        : very-strong-comprehension-coproducts
+            Slices-comprehension Slices-comprehension-coproducts
+      Slices-very-strong-comprehension-coproducts x y = id-invertible
+```

--- a/src/Cat/Displayed/Instances/Subobjects/Reasoning.lagda.md
+++ b/src/Cat/Displayed/Instances/Subobjects/Reasoning.lagda.md
@@ -25,32 +25,21 @@ open Subobj C public
 open Pullback
 open Cat C
 
+Subobject-fibration = with-pullbacks.Subobject-fibration pb
+
 private
-  module Ix = Cat.Displayed.Cartesian.Indexing Subobjects (with-pullbacks.Subobject-fibration pb)
+  module Ix = Cat.Displayed.Cartesian.Indexing Subobjects Subobject-fibration
   variable
     X Y Z : Ob
     f g h : Hom X Y
     l m n : Subobject X
-
-open Sub
-  renaming (_≅_ to _≅ₘ_)
-  using ()
-  public
-
-≅ₘ→iso : m ≅ₘ n → m .dom ≅ n .dom
-≅ₘ→iso p .to = p .Sub.to .map
-≅ₘ→iso p .from = p .Sub.from .map
-≅ₘ→iso p .inverses = record
-  { invl = ap ≤-over.map (p .Sub.invl)
-  ; invr = ap ≤-over.map (p .Sub.invr)
-  }
 ```
 -->
 
 # Subobjects in a cartesian category
 
 ```agda
-open with-pullbacks pb renaming (pullback-subobject to infixr 35 _^*_) public
+open Cartesian-fibration Subobjects Subobject-fibration public
 ```
 
 ```agda
@@ -67,18 +56,10 @@ open with-pullbacks pb renaming (pullback-subobject to infixr 35 _^*_) public
 ^*-assoc .from     = Ix.^*-comp-to
 ^*-assoc .inverses = record { invl = prop! ; invr = prop! }
 
-⊤ₘ : Subobject X
-⊤ₘ .dom   = _
-⊤ₘ .map   = id
-⊤ₘ .monic = id-monic
-
-opaque
-  !ₘ : m ≤ₘ ⊤ₘ
-  !ₘ {m = m} = record { map = m .map ; com = refl }
-
 module _ {X} where
   open Binary-products (Sub X) (Sub-products pb) public renaming
     ( _⊗₀_  to infixr 30 _∩ₘ_
+    ; _⊗₁_  to infixr 30 _∩ₘ₁_
     ; π₁    to ∩ₘ≤l
     ; π₂    to ∩ₘ≤r
     ; ⟨_,_⟩ to ∩ₘ-univ
@@ -91,7 +72,7 @@ opaque
   ∩ₘ-idr : m ∩ₘ ⊤ₘ ≅ₘ m
   ∩ₘ-idr = Sub-antisym ∩ₘ≤l (∩ₘ-univ Sub.id !ₘ)
 
-  ∩ₘ-assoc : l ∩ₘ m ∩ₘ n ≅ₘ (l ∩ₘ m) ∩ₘ n
+  ∩ₘ-assoc : l ∩ₘ (m ∩ₘ n) ≅ₘ (l ∩ₘ m) ∩ₘ n
   ∩ₘ-assoc = Sub-antisym
     (∩ₘ-univ (∩ₘ-univ ∩ₘ≤l (∩ₘ≤l Sub.∘ ∩ₘ≤r)) (∩ₘ≤r Sub.∘ ∩ₘ≤r))
     (∩ₘ-univ (∩ₘ≤l Sub.∘ ∩ₘ≤l) (∩ₘ-univ (∩ₘ≤r Sub.∘ ∩ₘ≤l) ∩ₘ≤r))
@@ -112,10 +93,7 @@ opaque
       }
 
   ^*-⊤ₘ : f ^* ⊤ₘ ≅ₘ ⊤ₘ
-  ^*-⊤ₘ {f = f} = Sub-antisym !ₘ record
-    { map = pb _ _ .universal {p₁' = id} {p₂' = f} id-comm
-    ; com = sym (pb _ _ .p₁∘universal ∙ introl refl)
-    }
+  ^*-⊤ₘ {f = f} = Sub-antisym !ₘ (^*-univ (record { map = f ; com = id-comm }))
 
 opaque
   is-pullback-along→iso : is-pullback-along C (m .map) h (n .map) → m ≅ₘ h ^* n

--- a/src/Cat/Functor/Conservative.lagda.md
+++ b/src/Cat/Functor/Conservative.lagda.md
@@ -1,9 +1,11 @@
 <!--
 ```agda
 open import Cat.Diagram.Colimit.Base
+open import Cat.Functor.Equivalence
 open import Cat.Diagram.Limit.Base
 open import Cat.Functor.Kan.Unique
 open import Cat.Functor.Naturality
+open import Cat.Functor.Properties
 open import Cat.Functor.Coherence
 open import Cat.Functor.Kan.Base
 open import Cat.Morphism.Duality
@@ -24,7 +26,7 @@ module Cat.Functor.Conservative where
 ```agda
 private variable
   o h o₁ h₁ : Level
-  C D J : Precategory o h
+  C D E J : Precategory o h
 open Precategory
 open Functor
 open lifts-limit
@@ -47,6 +49,29 @@ is-conservative : Functor C D → Type _
 is-conservative {C = C} {D = D} F =
   ∀ {A B} {f : C .Hom A B}
   → is-invertible D (F .F₁ f) → is-invertible C f
+```
+
+Conservative functors are closed under composition.
+
+```agda
+F∘-is-conservative
+  : (F : Functor D E) (G : Functor C D)
+  → is-conservative F
+  → is-conservative G
+  → is-conservative (F F∘ G)
+F∘-is-conservative F G F-cons G-cons inv = G-cons (F-cons inv)
+```
+
+[[Fully faithful]] functors are conservative, which implies that
+[[equivalences|equivalence of categories]] are conservative.
+
+```agda
+equiv→conservative
+  : (F : Functor C D)
+  → is-equivalence F
+  → is-conservative F
+equiv→conservative F eqv =
+  is-ff→is-conservative {F = F} (is-equivalence→is-ff F eqv) _
 ```
 
 ## Conservative functors reflect (co)limits that they preserve

--- a/src/Cat/Instances/Slice.lagda.md
+++ b/src/Cat/Instances/Slice.lagda.md
@@ -248,7 +248,7 @@ the triangle commute, so that $f$ is invertible in $\cC/c$.
       f⁻¹ .com = C.rswizzle (sym (f .com)) i.invl
 ```
 
-## Finite limits
+## Finite limits {defines="finite-limits-in-slices"}
 
 We discuss the construction of _finite_ limits in the slice of $\cC/c$.
 First, every slice category has a [[terminal object]], given by the

--- a/src/Cat/Morphism/Factorisation.lagda.md
+++ b/src/Cat/Morphism/Factorisation.lagda.md
@@ -39,6 +39,7 @@ such that $l \in L$, $r \in R$, and $f = r \circ l$.
 
 ```agda
   record Factorisation {a b} (f : C.Hom a b) : Type (o ⊔ ℓ ⊔ ℓl ⊔ ℓr) where
+    constructor factorisation
     field
       mid     : C.Ob
       left    : C.Hom a mid

--- a/src/Cat/Morphism/Strong/Epi.lagda.md
+++ b/src/Cat/Morphism/Strong/Epi.lagda.md
@@ -4,6 +4,7 @@ open import Cat.Diagram.Coequaliser.RegularEpi
 open import Cat.Diagram.Pullback.Properties
 open import Cat.Instances.Shape.Terminal
 open import Cat.Functor.FullSubcategory
+open import Cat.Morphism.Factorisation
 open import Cat.Diagram.Limit.Finite
 open import Cat.Morphism.Orthogonal
 open import Cat.Diagram.Equaliser
@@ -264,12 +265,11 @@ factorisation of $f$ on our hands!
 
 ```agda
 strong-epi-mono→image
-  : ∀ {a b im} (f : Hom a b)
-  → (a→im : Hom a im) → is-strong-epi a→im
-  → (im→b : Hom im b) → is-monic im→b
-  → im→b ∘ a→im ≡ f
+  : ∀ {a b} (f : Hom a b)
+  → Factorisation C StrongEpis Monos f
   → Image C f
-strong-epi-mono→image f a→im (_ , str-epi) im→b mono fact = go where
+strong-epi-mono→image f fac = go where
+  open Factorisation fac renaming (left∈L to str-epi; right∈R to mono)
   open Initial
   open /-Obj
   open /-Hom
@@ -278,8 +278,8 @@ strong-epi-mono→image f a→im (_ , str-epi) im→b mono fact = go where
 
   obj : ↓Obj (!Const (cut f)) (Forget-full-subcat {P = is-monic ⊙ map})
   obj .dom = tt
-  obj .cod = cut im→b , mono
-  obj .map = record { map = a→im ; com = fact }
+  obj .cod = cut right , mono
+  obj .map = record { map = left ; com = sym factors }
 ```
 
 Actually, for an image factorisation, we don't need that $a \epi \im(f)$
@@ -294,8 +294,8 @@ in the relevant comma categories.
     module o = ↓Obj other
 
     the-lifting =
-      str-epi _ (o.cod .snd) (o.map .map) im→b
-        (sym (o.map .com ∙ sym fact))
+      str-epi .snd _ (o.cod .snd) (o.map .map) right
+        (sym (o.map .com ∙ factors))
 
     dh : ↓Hom (!Const (cut f)) _ obj other
     dh .top      = tt

--- a/src/Cat/Regular.lagda.md
+++ b/src/Cat/Regular.lagda.md
@@ -9,6 +9,7 @@ open import Cat.Diagram.Pullback
 open import Cat.Diagram.Product
 open import Cat.Morphism.Class
 open import Cat.Morphism.Lifts
+open import Cat.Diagram.Image
 open import Cat.Prelude
 
 import Cat.Morphism.Strong.Epi
@@ -83,18 +84,17 @@ latter two names have a placeholder for the morphism we are factoring.
 
 <!--
 ```agda
-  module _ (r : is-regular) where
-    private module r = is-regular r
-    open C
+    Image[_] : ∀ {x y} (f : C.Hom x y) → Image 𝒞 f
+    Image[ f ] = C.strong-epi-mono→image f (factor f)
 
     mono→im-iso
       : ∀ {a b} (f : C.Hom a b)
       → C.is-monic f
-      → C.is-invertible r.a↠im[ f ]
+      → C.is-invertible a↠im[ f ]
     mono→im-iso {a} {b} f f-monic =
       C.strong-epi+mono→invertible
-        r.a↠im[ f ]-strong-epic
-        (factor-monic→left-monic (r.factor f) f-monic)
+        a↠im[ f ]-strong-epic
+        (factor-monic→left-monic (factor f) f-monic)
 ```
 -->
 
@@ -104,12 +104,12 @@ and invertible maps, and strong epis are [[left orthogonal]] to monomorphisms by
 
 ```agda
     strong-epi-mono-is-ofs : is-ofs 𝒞 C.StrongEpis C.Monos
-    strong-epi-mono-is-ofs .is-ofs.factor = r.factor
-    strong-epi-mono-is-ofs .is-ofs.is-iso→in-L f = invertible→strong-epi
-    strong-epi-mono-is-ofs .is-ofs.L-is-stable f g = ∘-is-strong-epic
-    strong-epi-mono-is-ofs .is-ofs.is-iso→in-R f = invertible→monic
-    strong-epi-mono-is-ofs .is-ofs.R-is-stable f g = ∘-is-monic
-    strong-epi-mono-is-ofs .is-ofs.L⊥R = StrongEpis⊥Monos
+    strong-epi-mono-is-ofs .is-ofs.factor = factor
+    strong-epi-mono-is-ofs .is-ofs.is-iso→in-L f = C.invertible→strong-epi
+    strong-epi-mono-is-ofs .is-ofs.L-is-stable f g = C.∘-is-strong-epic
+    strong-epi-mono-is-ofs .is-ofs.is-iso→in-R f = C.invertible→monic
+    strong-epi-mono-is-ofs .is-ofs.R-is-stable f g = C.∘-is-monic
+    strong-epi-mono-is-ofs .is-ofs.L⊥R = C.StrongEpis⊥Monos
 ```
 
 ## Motivation
@@ -118,7 +118,9 @@ Regular categories are interesting in the study of categorical logic
 since they have exactly the structure required for their [subobject
 fibrations] to interpret existential quantifiers, _and_ for these to
 commute with substitution which, in this case, is interpreted as
-pullback.
+pullback. We explore this in more detail in the construction of the
+[[regular hyperdoctrine of subobjects]], but we sketch the main ideas
+here.
 
 [subobject fibrations]: Cat.Displayed.Instances.Subobjects.html
 
@@ -128,7 +130,7 @@ $\cC/b \adj \cC/a$: the right adjoint models the substitution (base
 change) along $f$, and the [[left adjoint]] models the _dependent sum_ over
 $f$. Between subobject categories, though, pullbacks are not enough
 structure: this can be seen type-theoretically by noting that, even if
-$P : A \to \Omega$ is a family of propositions, the sum $\Sigma_(x : A)
+$P : A \to \Omega$ is a family of propositions, the sum $\Sigma_{x : A}
 P(x)$ will generally not be.
 
 [an adjunction]: Cat.Functor.Pullback.html
@@ -146,7 +148,8 @@ $$
 $$,
 
 holds as long as $f$, $g$, $h$ and $k$ fit into a pullback square,
-expressing that existential quantification commutes with substitution.
+expressing that existential quantification commutes with substitution;
+this is the *Beck-Chevalley condition*.
 
 Another reason to be interested in regular categories is their
 well-behaved calculus of [relations]: any category with pullbacks has an

--- a/src/Cat/Regular/Image.lagda.md
+++ b/src/Cat/Regular/Image.lagda.md
@@ -294,7 +294,7 @@ module _ (cat : is-category C) where
   Sub-regular .subst-aye f = Sub-is-category cat .to-path ^*-⊤ₘ
 ```
 
-It remains to check the Beck-Chevalley condition and Frobenius
+It remains to check the [[Beck-Chevalley condition]] and Frobenius
 reciprocity. The Beck-Chevalley condition follows directly from
 stability of images: we compute
 

--- a/src/Cat/Regular/Image.lagda.md
+++ b/src/Cat/Regular/Image.lagda.md
@@ -1,16 +1,19 @@
 <!--
 ```agda
--- {-# OPTIONS --lossy-unification #-}
-open import Cat.Functor.FullSubcategory
+open import Cat.Morphism.Factorisation.Orthogonal
+open import Cat.Diagram.Pullback.Properties
+open import Cat.Displayed.Instances.Slice
 open import Cat.Morphism.Factorisation
+open import Cat.Displayed.Cocartesian
 open import Cat.Morphism.Strong.Epi
+open import Cat.Displayed.Doctrine
+open import Cat.Displayed.Functor
 open import Cat.Diagram.Pullback
-open import Cat.Diagram.Product
 open import Cat.Instances.Slice
 open import Cat.Prelude
 open import Cat.Regular
 
-import Cat.Displayed.Instances.Subobjects
+import Cat.Displayed.Instances.Subobjects.Reasoning as Sr
 import Cat.Reasoning as Cr
 ```
 -->
@@ -24,26 +27,30 @@ module Cat.Regular.Image
 
 <!--
 ```agda
-open Binary-products C (reg .is-regular.lex.products)
-open Cat.Displayed.Instances.Subobjects C
+open reflects-cartesian-maps
+open Regular-hyperdoctrine hiding (_^*_; _^!_)
+open Displayed-functor
+open is-fibred-functor
 open is-regular reg
 open Factorisation
-open Pullback
-open /-Hom
 open /-Obj
+open /-Hom
 open Cr C
+open Sr lex.pullbacks
+
+private
+  module pb = lex.pullback
+  Sub-opf = Subobject-opfibration Image[_] lex.pullbacks
+open Cocartesian-fibration Subobjects Sub-opf
 ```
 -->
 
 # Images in regular categories
 
 This module provides tools for working with the [[image factorisation]] of
-morphisms in [regular categories], regarded as [subobjects] of the map's
+morphisms in [[regular categories]], regarded as [[subobjects]] of the map's
 codomain. We start by defining a `Subobject`{.Agda} of $y$ standing for
 $\im f$ whenever $f : x \to y$.
-
-[regular categories]: Cat.Regular.html
-[subobjects]: Cat.Displayed.Instances.Subobjects.html
 
 ```agda
 Im : ∀ {x y} (f : Hom x y) → Subobject y
@@ -72,38 +79,323 @@ Im-universal f m {e = e} p = r where
 ```
 
 An important fact that will be used in calculating associativity for
-[relations in regular categories] is that precomposing with a [strong
-epimorphism] preserves images. Intuitively, this is because a strong
+[relations in regular categories] is that precomposing with a [[strong
+epimorphism]] preserves images. Intuitively, this is because a strong
 epimorphism $a \epi b$ expresses $b$ as a quotient, but this
 decomposition does not alter the image of a map $b \to c$.
 
-[strong epimorphism]: Cat.Morphism.Strong.Epi.html
 [relations in regular categories]: Cat.Bi.Instances.Relations.html
+
+We prove this by first showing a uniqueness property for images: as a
+refinement of the previous universal property, if $f : a \to b$ factors
+through a [[subobject]] $m$ of $b$ via a strong epimorphism $g : a \to m$,
+then $m$ must be the image of $f$ by essential uniqueness of
+[[orthogonal factorisations|orthogonal factorisation system]].
+
+```agda
+image-unique
+  : ∀ {a b} (f : Hom a b) (m : Subobject b) (g : Hom a (m .dom))
+  → is-strong-epi C g
+  → (com : f ≡ m .map ∘ g)
+  → Sub.is-invertible (Im-universal f m com)
+image-unique f m g g-covers com =
+  let
+    f-fac = factorisation (m .dom) g (m .map) g-covers (λ {c} → m .monic {c}) com
+    is , _ , is-com = factorisation-essentially-unique C _ _
+      strong-epi-mono-is-ofs f (factor f) f-fac
+  in Sub-cod-conservative _ (iso→invertible is)
+```
+
+The result then follows by noticing that the composite $a \xepi{g} b \epi
+\im(f)$ is a strong epimorphism witnessing $\im(f)$ as the
+image of $f \circ g$.
 
 ```agda
 image-pre-cover
-  : ∀ {a b c}
-  → (f : Hom b c)
-  → (g : Hom a b)
+  : ∀ {a b c} (f : Hom b c) (g : Hom a b)
   → is-strong-epi C g
-  → (Im f) Sub.≅ (Im (f ∘ g))
-image-pre-cover {a = a} {b} {c} f g g-covers = Sub-antisym imf≤imfg imfg≤imf where
-  imfg≤imf : Im (f ∘ g) ≤ₘ Im f
-  imfg≤imf = Im-universal _ _ (pushl (factor f .factors))
+  → Im (f ∘ g) ≅ₘ Im f
+image-pre-cover f g g-covers =
+  Sub.invertible→iso _ $
+    image-unique (f ∘ g) (Im f) (a↠im[ f ] ∘ g)
+      (∘-is-strong-epic C a↠im[ f ]-strong-epic g-covers)
+      (pushl im[ f ]-factors)
+```
 
-  the-lift : Σ (Hom b im[ f ∘ g ]) _
-  the-lift = g-covers .snd _ (≤ₘ→monic imfg≤imf)
-    (factor (f ∘ g) .left)
-    (factor f .left)
-    (factor f .right∈R _ _ (sym (pulll (sym (imfg≤imf .com) ∙ idl _) ∙ sym (factor (f ∘ g) .factors) ∙ pushl (factor f .factors)))) .centre
+## Stability
 
-  inverse : is-invertible (imfg≤imf .map)
-  inverse = is-strong-epi→is-extremal-epi C (factor f .left∈L)
-    (≤ₘ→mono imfg≤imf) (the-lift .fst) (sym (the-lift .snd .snd))
+In a regular category, images don't just exist; they also have the
+good manners of being stable under [[pullback]]. This follows from the
+property that [[strong epimorphisms]] are stable under pullback, which
+is part of the definition of a regular category.
 
-  imf≤imfg : Im f ≤ₘ Im (f ∘ g)
-  imf≤imfg .map = inverse .is-invertible.inv
-  imf≤imfg .com = invertible→epic inverse _ _ $
-    pullr (sym (imfg≤imf .com) ∙ idl _)
-    ∙ sym (cancelr (inverse .is-invertible.invr) ∙ introl refl)
+To see this, first let a commutative square as in the following diagram
+be given.
+
+~~~{.quiver}
+\[\begin{tikzcd}
+  c & d \\
+  a & b
+  \arrow["k", from=1-1, to=1-2]
+  \arrow["h"', from=1-1, to=2-1]
+  \arrow["g", from=1-2, to=2-2]
+  \arrow["f"', from=2-1, to=2-2]
+\end{tikzcd}\]
+~~~
+
+By the universal property of $\im(h)$, we have that $\im(h) \leq
+f^*(\im(g))$ as subobjects of $a$.
+
+```agda
+Im-comparison
+  : ∀ {a b c d} {f : Hom a b} {g : Hom d b} {h : Hom c a} {k : Hom c d}
+  → f ∘ h ≡ g ∘ k
+  → Im h ≤ₘ f ^* Im g
+Im-comparison {f = f} {g} {h} {k} sq =
+  Im-universal h _ {pb.universal _ _ (sq ∙ pushl im[ g ]-factors)}
+    (sym (pb.p₁∘universal _ _))
+```
+
+This extends to a displayed comparison $\im(h) \leq_f \im(g)$ by
+composing with the pullback projection.
+
+~~~{.quiver}
+\[\begin{tikzcd}
+  & c & d \\
+  {\im(h)} & {f^*(\im(g))} & {\im(g)} \\
+  & a & b
+  \arrow["k", from=1-2, to=1-3]
+  \arrow[two heads, from=1-2, to=2-1]
+  \arrow[two heads, from=1-3, to=2-3]
+  \arrow[dashed, from=2-1, to=2-2]
+  \arrow[hook', from=2-1, to=3-2]
+  \arrow[from=2-2, to=2-3]
+  \arrow[hook', from=2-2, to=3-2]
+  \arrow["\lrcorner"{anchor=center, pos=0.125}, draw=none, from=2-2, to=3-3]
+  \arrow[hook', from=2-3, to=3-3]
+  \arrow["f"', from=3-2, to=3-3]
+\end{tikzcd}\]
+~~~
+
+```agda
+Im-map
+  : ∀ {a b c d} {f : Hom a b} {g : Hom d b} {h : Hom c a} {k : Hom c d}
+  → f ∘ h ≡ g ∘ k
+  → ≤-over f (Im h) (Im g)
+Im-map {f = f} {g} {h} sq .map = pb.p₂ _ _ ∘ Im-comparison sq .map
+Im-map {f = f} {g} {h} sq .com =
+  f ∘ im[ h ]↪b                                 ≡⟨ refl⟩∘⟨ sym (idl _) ⟩
+  f ∘ id ∘ im[ h ]↪b                            ≡⟨ refl⟩∘⟨ Im-comparison sq .com ⟩
+  f ∘ pb.p₁ _ _ ∘ Im-comparison sq .map         ≡⟨ extendl (pb.square _ _) ⟩
+  im[ g ]↪b ∘ pb.p₂ _ _ ∘ Im-comparison sq .map ∎
+```
+
+We thus obtain a [[displayed functor]] from the [[fundamental fibration]]
+of $\cC$ to its [[subobject fibration]], which we can think of as
+modelling propositional truncation.
+
+```agda
+Images : Vertical-functor (Slices C) Subobjects
+Images .F₀' m = Im (m .map)
+Images .F₁' f = Im-map (sym (f .com))
+Images .F-id' = prop!
+Images .F-∘' = prop!
+```
+
+The claim is now that this is a [[*fibred* functor]], i.e., that it
+takes cartesian morphisms in the fundamental fibration --- pullback
+squares --- to cartesian morphisms between images in the subobject
+fibration, which are also characterised as pullback squares.
+
+```agda
+image-stable
+  : ∀ {a b c d} {f : Hom a b} {g : Hom d b} {h : Hom c a} {k : Hom c d}
+  → (pb : is-pullback C h f k g) (open is-pullback pb)
+  → is-pullback C im[ h ]↪b f (Im-map square .map) im[ g ]↪b
+image-stable {a} {b} {c} {d} {f} {g} {h} {k} pb = done where
+```
+
+To that end, assume that the outer square in the above diagram is a
+pullback square. We complete the diagram with the map
+$c \to f^*(\im(g))$ obtained by the universal property of the pullback,
+which we observe to be the pullback of the map $d \to \im(g)$ by the
+[[pasting law for pullbacks]]. By the assumed stability property, this
+implies that this map is a strong epimorphism.
+
+~~~{.quiver}
+\[\begin{tikzcd}
+  & c & d \\
+  {\im(h)} & {f^*(\im(g))} & {\im(g)} \\
+  & a & b
+  \arrow["k", from=1-2, to=1-3]
+  \arrow[two heads, from=1-2, to=2-1]
+  \arrow[two heads, from=1-2, to=2-2]
+  \arrow["\lrcorner"{anchor=center, pos=0.125}, draw=none, from=1-2, to=2-3]
+  \arrow[two heads, from=1-3, to=2-3]
+  \arrow[dashed, from=2-1, to=2-2]
+  \arrow[hook', from=2-1, to=3-2]
+  \arrow[from=2-2, to=2-3]
+  \arrow[hook', from=2-2, to=3-2]
+  \arrow["\lrcorner"{anchor=center, pos=0.125}, draw=none, from=2-2, to=3-3]
+  \arrow[hook', from=2-3, to=3-3]
+  \arrow["f"', from=3-2, to=3-3]
+\end{tikzcd}\]
+~~~
+
+```agda
+  down : Hom c (pb.apex f im[ g ]↪b)
+  down = pb.universal _ _ (pb .is-pullback.square ∙ pushl im[ g ]-factors)
+
+  down-is-cover : is-strong-epi C down
+  down-is-cover = stable _ (pb.p₂ _ _) a↠im[ g ]-strong-epic
+    (pasting-outer→left-is-pullback (pb.has-is-pb _ _)
+      (subst-is-pullback (sym (pb.p₁∘universal _ _)) refl refl im[ g ]-factors pb)
+      (pb.p₂∘universal _ _))
+```
+
+But this now gives two different factorisations of $h$ as a strong
+epimorphism followed by a monomorphism, so by uniqueness of images
+the dashed comparison map is invertible, and hence $\im(h)$ is the
+pullback of $\im(g)$ along $f$.
+
+```agda
+  unique : Sub.is-invertible _
+  unique = image-unique h (f ^* Im g) down down-is-cover
+    (sym (pb.p₁∘universal _ _))
+
+  done = is-pullback-iso'
+    (≅ₘ→iso (Sub.invertible→iso _ unique))
+    (pb.has-is-pb _ _)
+    (sym (Im-universal h (f ^* Im g) _ .com) ∙ idl _)
+    refl
+
+Images-is-fibred : is-fibred-functor Images
+Images-is-fibred .F-cartesian cart = pullback→cartesian-sub
+  (image-stable (cartesian→pullback C cart))
+```
+
+## The regular hyperdoctrine of subobjects {defines="regular-hyperdoctrine-of-subobjects"}
+
+One of the main motivations for [[regular categories]], as discussed
+there, is that their fibrations of [[subobjects]] have
+well-behaved existential quantifiers. We can summarise this by
+constructing the [[regular hyperdoctrine]] of subobjects of a regular
+[[univalent category]] $\cC$.
+
+Since $\cC$ has pullbacks, the displayed category $\Sub$ over $\cC$
+is a [[cartesian fibration]]; since $\cC$ has image factorisations, it
+is also a [[cocartesian fibration]]. Observe that the cocartesian lift
+$f_!(\alpha)$, which models the existential quantifier $\exists_f
+\alpha$, is, almost by definition, the image of $f \circ \alpha$.
+
+```agda
+^!-is-Im
+  : ∀ {a b} {f : Hom a b} {α : Subobject a}
+  → f ^! α ≅ₘ Im (f ∘ α .map)
+^!-is-Im = iso→≅ₘ id-iso (sym (idr _))
+```
+
+$\Sub$ also has fibrewise finite products, and those are well-behaved
+under pullback.
+
+```agda
+module _ (cat : is-category C) where
+  Sub-regular : Regular-hyperdoctrine C (o ⊔ ℓ) ℓ
+  Sub-regular .ℙ = Subobjects
+  Sub-regular .has-is-thin _ _ = hlevel 1
+  Sub-regular .has-univalence x = Sub-is-category cat
+  Sub-regular .cartesian = Subobject-fibration
+  Sub-regular .cocartesian = Sub-opf
+  Sub-regular .fibrewise-meet = Sub-products lex.pullbacks
+  Sub-regular .fibrewise-top x = Sub-terminal
+  Sub-regular .subst-& f m n = Sub-is-category cat .to-path ^*-∩ₘ
+  Sub-regular .subst-aye f = Sub-is-category cat .to-path ^*-⊤ₘ
+```
+
+It remains to check the Beck-Chevalley condition and Frobenius
+reciprocity. The Beck-Chevalley condition follows directly from
+stability of images: we compute
+
+$$
+\exists_h (\alpha[k]) = \im(h \circ \alpha[k]) = \im(g \circ \alpha)[f] = (\exists_g \alpha)[f]
+$$
+
+using the [[pasting law for pullbacks]].
+
+```agda
+  Sub-regular .beck-chevalley pb {α} = Sub-is-category cat .to-path
+    (invertible→≅ₘ
+      (record { map = _ ; com = idl _ ∙ sym (pb.p₁∘universal _ _) })
+      (pullback-unique (pb.has-is-pb _ _)
+        (image-stable (pasting-left→outer-is-pullback pb (pb.has-is-pb _ _)))))
+```
+
+Remembering that the intersection $\alpha \cap \beta$ is computed as the
+pullback $\alpha^* \beta$, Frobenius reciprocity can be seen as a
+consequence of the Beck-Chevalley condition. Rather than reuse our
+proof above, we take the opportunity to present an alternative, more
+diagrammatic proof. The following diagram summarises the setup:
+
+~~~{.quiver}
+\[\begin{tikzcd}
+  {\alpha \cap f^* \beta} &&& {f_!\alpha \cap \beta} \\
+  & \alpha &&& {f_! \alpha} \\
+  {f^*\beta} &&& \beta \\
+  & X &&& Y
+  \arrow[dashed, two heads, from=1-1, to=1-4]
+  \arrow[hook', from=1-1, to=2-2]
+  \arrow[hook', from=1-1, to=3-1]
+  \arrow[hook', from=1-4, to=2-5]
+  \arrow[hook', from=1-4, to=3-4]
+  \arrow[two heads, from=2-2, to=2-5]
+  \arrow[hook', from=2-2, to=4-2]
+  \arrow[hook', from=2-5, to=4-5]
+  \arrow[from=3-1, to=3-4]
+  \arrow[hook', from=3-1, to=4-2]
+  \arrow[hook', from=3-4, to=4-5]
+  \arrow["f"', from=4-2, to=4-5]
+\end{tikzcd}\]
+~~~
+
+We start by constructing the dashed map using the universal property
+of the pullback, as the unique map that makes the cube commute.
+
+```agda
+  Sub-regular .frobenius f {α} {β} = Sub-is-category cat .to-path
+    ((is Sub.∘Iso ^!-is-Im) Sub.Iso⁻¹)
+    where
+      dashed : Hom ((α ∩ₘ f ^* β) .dom) (((f ^! α) ∩ₘ β) .dom)
+      dashed = pb.universal _ _ $ sym $
+        β .map ∘ _ ∘ _             ≡⟨ pulll (sym (pb.square _ _)) ⟩
+        (f ∘ _) ∘ _                ≡⟨ pullr (sym (pb.square _ _)) ⟩
+        f ∘ _ ∘ _                  ≡⟨ extendl im[ f ∘ α .map ]-factors ⟩
+        im[ f ∘ α .map ]↪b ∘ _ ∘ _ ∎
+```
+
+We then observe that the left, bottom, and right faces of the cube are
+pullback squares, hence so is the top face by the [[pasting law for
+pullbacks]]. This directly implies that the dashed map is a strong
+epimorphism, since those are stable under pullback.
+
+```agda
+      dashed-is-cover : is-strong-epi C dashed
+      dashed-is-cover = stable _ _ a↠im[ f ∘ α .map ]-strong-epic
+        (pasting-outer→left-is-pullback
+          (rotate-pullback (pb.has-is-pb _ _))
+          (subst-is-pullback (sym (pb.p₂∘universal _ _)) refl refl im[ _ ]-factors
+            (pasting-left→outer-is-pullback
+              (rotate-pullback (pb.has-is-pb _ _))
+              (rotate-pullback (pb.has-is-pb _ _))))
+          (pb.p₁∘universal _ _))
+```
+
+This gives two different image factorisations of the "great diagonal"
+of the cube, which exhibits $f_!\alpha \cap \beta$ as
+$f_!(\alpha \cap f^*\beta)$ by uniqueness of images.
+
+```agda
+      is : Im (f ∘ (α ∩ₘ f ^* β) .map) ≅ₘ (f ^! α) ∩ₘ β
+      is = Sub.invertible→iso _
+         $ image-unique _ ((f ^! α) ∩ₘ β) dashed dashed-is-cover
+         $ sym (pullr (pb.p₁∘universal _ _) ∙ extendl (sym im[ _ ]-factors))
 ```

--- a/src/Cat/Regular/Image.lagda.md
+++ b/src/Cat/Regular/Image.lagda.md
@@ -129,8 +129,16 @@ good manners of being stable under [[pullback]]. This follows from the
 property that [[strong epimorphisms]] are stable under pullback, which
 is part of the definition of a regular category.
 
-To see this, first let a commutative square as in the following diagram
-be given.
+We will make this precise by showing that there is a vertical [[fibred
+functor]] from the [[fundamental fibration]] of $\cC$ to its
+[[subobject fibration]], which we can think of as modelling a
+"propositional truncation" type former; since cartesian morphisms in
+both fibrations are pullback squares, this is equivalent to the
+usual formulation of pullback-stability, namely $f^*(\im(g)) =
+\im(f^*g)$.
+
+First, let a commutative square as in the following diagram be given: a
+map $k : h \to_f g$ in the fundamental fibration.
 
 ~~~{.quiver}
 \[\begin{tikzcd}
@@ -143,21 +151,12 @@ be given.
 \end{tikzcd}\]
 ~~~
 
-By the universal property of $\im(h)$, we have that $\im(h) \leq
-f^*(\im(g))$ as subobjects of $a$.
-
-```agda
-Im-comparison
-  : ∀ {a b c d} {f : Hom a b} {g : Hom d b} {h : Hom c a} {k : Hom c d}
-  → f ∘ h ≡ g ∘ k
-  → Im h ≤ₘ f ^* Im g
-Im-comparison {f = f} {g} {h} {k} sq =
-  Im-universal h _ {pb.universal _ _ (sq ∙ pushl im[ g ]-factors)}
-    (sym (pb.p₁∘universal _ _))
-```
-
-This extends to a displayed comparison $\im(h) \leq_f \im(g)$ by
-composing with the pullback projection.
+After replacing $h$ and $g$ with their image factorisations and pulling
+$\im(g)$ back along $f$, we arrive at the following situation, where
+the map $c \to f^*(\im(g))$ is given by the universal property of
+the pullback, and the dashed comparison map by the universal
+property of the image of $h$. The composite middle row gives us a map
+$\im(h) \leq_f \im(g)$ in the subobject fibration.
 
 ~~~{.quiver}
 \[\begin{tikzcd}
@@ -166,6 +165,7 @@ composing with the pullback projection.
   & a & b
   \arrow["k", from=1-2, to=1-3]
   \arrow[two heads, from=1-2, to=2-1]
+  \arrow[from=1-2, to=2-2]
   \arrow[two heads, from=1-3, to=2-3]
   \arrow[dashed, from=2-1, to=2-2]
   \arrow[hook', from=2-1, to=3-2]
@@ -178,6 +178,14 @@ composing with the pullback projection.
 ~~~
 
 ```agda
+Im-comparison
+  : ∀ {a b c d} {f : Hom a b} {g : Hom d b} {h : Hom c a} {k : Hom c d}
+  → f ∘ h ≡ g ∘ k
+  → Im h ≤ₘ f ^* Im g
+Im-comparison {f = f} {g} {h} {k} sq =
+  Im-universal h _ {pb.universal _ _ (sq ∙ pushl im[ g ]-factors)}
+    (sym (pb.p₁∘universal _ _))
+
 Im-map
   : ∀ {a b c d} {f : Hom a b} {g : Hom d b} {h : Hom c a} {k : Hom c d}
   → f ∘ h ≡ g ∘ k
@@ -190,9 +198,7 @@ Im-map {f = f} {g} {h} sq .com =
   im[ g ]↪b ∘ pb.p₂ _ _ ∘ Im-comparison sq .map ∎
 ```
 
-We thus obtain a [[displayed functor]] from the [[fundamental fibration]]
-of $\cC$ to its [[subobject fibration]], which we can think of as
-modelling propositional truncation.
+This data turns `Im`{.Agda} into a [[vertical functor]].
 
 ```agda
 Images : Vertical-functor (Slices C) Subobjects
@@ -216,37 +222,13 @@ image-stable {a} {b} {c} {d} {f} {g} {h} {k} pb = done where
 ```
 
 To that end, assume that the outer square in the above diagram is a
-pullback square. We complete the diagram with the map
-$c \to f^*(\im(g))$ obtained by the universal property of the pullback,
-which we observe to be the pullback of the map $d \to \im(g)$ by the
-[[pasting law for pullbacks]]. By the assumed stability property, this
-implies that this map is a strong epimorphism.
-
-~~~{.quiver}
-\[\begin{tikzcd}
-  & c & d \\
-  {\im(h)} & {f^*(\im(g))} & {\im(g)} \\
-  & a & b
-  \arrow["k", from=1-2, to=1-3]
-  \arrow[two heads, from=1-2, to=2-1]
-  \arrow[two heads, from=1-2, to=2-2]
-  \arrow["\lrcorner"{anchor=center, pos=0.125}, draw=none, from=1-2, to=2-3]
-  \arrow[two heads, from=1-3, to=2-3]
-  \arrow[dashed, from=2-1, to=2-2]
-  \arrow[hook', from=2-1, to=3-2]
-  \arrow[from=2-2, to=2-3]
-  \arrow[hook', from=2-2, to=3-2]
-  \arrow["\lrcorner"{anchor=center, pos=0.125}, draw=none, from=2-2, to=3-3]
-  \arrow[hook', from=2-3, to=3-3]
-  \arrow["f"', from=3-2, to=3-3]
-\end{tikzcd}\]
-~~~
+pullback square. By the [[pasting law for pullbacks]], the top square
+is also a pullback square. By the assumed stability property of strong
+epimorphisms, this implies that the vertical map $c \to f^*(\im(g))$ is
+a strong epimorphism.
 
 ```agda
-  down : Hom c (pb.apex f im[ g ]↪b)
-  down = pb.universal _ _ (pb .is-pullback.square ∙ pushl im[ g ]-factors)
-
-  down-is-cover : is-strong-epi C down
+  down-is-cover : is-strong-epi C _
   down-is-cover = stable _ (pb.p₂ _ _) a↠im[ g ]-strong-epic
     (pasting-outer→left-is-pullback (pb.has-is-pb _ _)
       (subst-is-pullback (sym (pb.p₁∘universal _ _)) refl refl im[ g ]-factors pb)
@@ -260,7 +242,7 @@ pullback of $\im(g)$ along $f$.
 
 ```agda
   unique : Sub.is-invertible _
-  unique = image-unique h (f ^* Im g) down down-is-cover
+  unique = image-unique h (f ^* Im g) _ down-is-cover
     (sym (pb.p₁∘universal _ _))
 
   done = is-pullback-iso'

--- a/src/Elephant.lagda.md
+++ b/src/Elephant.lagda.md
@@ -4,7 +4,9 @@ description: |
 ---
 <!--
 ```agda
+open import Cat.Displayed.Instances.Subobjects
 open import Cat.Instances.Elements.Covariant
+open import Cat.Displayed.Cocartesian.Weak
 open import Cat.Functor.Adjoint.Reflective
 open import Cat.Site.Instances.Canonical
 open import Cat.CartesianClosed.Locally
@@ -12,10 +14,12 @@ open import Cat.Functor.Monadic.Crude
 open import Cat.Instances.Sheaf.Omega
 open import Cat.Diagram.Limit.Finite
 open import Cat.Diagram.Exponential
+open import Cat.Morphism.Strong.Epi
 open import Cat.Diagram.Congruence
 open import Cat.Instances.Karoubi
 open import Cat.Instances.Sheaves
 open import Cat.Functor.Algebra
+open import Cat.Regular.Image
 open import Cat.Site.Closure
 open import Cat.Site.Base
 open import Cat.Regular
@@ -80,11 +84,20 @@ _ = with-pullbacks
 
 <!--
 ```agda
+_ = Subobject-weak-opfibration
+_ = weak-cocartesian-lift→left-adjoint
+_ = is-extremal-epi→is-strong-epi
+_ = Sub-regular
 _ = is-strong-epi→is-regular-epi
 _ = is-congruence
 ```
 -->
 
+* Lemma 1.3.1:
+  * (i ⇔ ii) essentially by definition, since images are defined in terms of universal morphisms
+  * (i ⇒ iii) `Subobject-weak-opfibration`{.Agda}, `weak-cocartesian-lift→left-adjoint`{.Agda}
+* Lemma 1.3.2: `is-extremal-epi→is-strong-epi`{.Agda}
+* Lemma 1.3.3: Frobenius reciprocity for `Sub-regular`{.Agda}
 * Proposition 1.3.4: `is-strong-epi→is-regular-epi`{.Agda}
 * Definition 1.3.6: `is-congruence`{.Agda}
 

--- a/src/index.lagda.md
+++ b/src/index.lagda.md
@@ -387,6 +387,14 @@ open import Cat.Allegory.Instances.Mat
   -- The allegory of matrices with values in a frame
 ```
 
+Regular categories also have a well-behaved notion of *image
+factorisation*, allowing their fibrations of subobjects to interpret
+existential quantifiers.
+
+```agda
+open import Cat.Regular.Image -- Images in regular categories
+```
+
 ### Monoidal categories
 
 A [[monoidal category]] is the higher-dimensional counterpart of a


### PR DESCRIPTION
- Images are stable in a regular category
- The regular hyperdoctrine of subobjects of a regular category
- Beck-Chevalley over pullback squares for the codomain fibration, hence the canonical comprehension structure on the codomain fibration has (very strong) comprehension coproducts

-------------

The API for images is a bit suboptimal: we define images in `Cat.Diagram.Image` in terms of universal morphisms for full subcategory inclusions into slice categories, but we really want mono-images to be defined in terms of subobject categories instead. Some concrete issues:

- There is some duplication between `Cat.Diagram.Image` and `Cat.Regular.Image`: both define the "same" universal property, for example.
- The cocartesian lifts `f ^! α` given by `Subobject-opfibration` do not definitionally compute to `Im (f ∘ α .map)`, because they have to pass through the `Cat.Diagram.Image` API; see `^!-is-Im`.

I don't really know how to improve the situation. Maybe we could reverse the dependency of `Cat.Displayed.Instances.Subobjects` on `Cat.Diagram.Image` so that the latter can define `Image` in terms of universal maps for `Slice→Sub`, but then we'd have to move the cocartesian stuff somewhere else. Ideas welcome.