### PR TITLE
chore: fix header

### DIFF
--- a/src/Data/List/Properties.lagda.md
+++ b/src/Data/List/Properties.lagda.md
@@ -24,7 +24,7 @@ open import Meta.Idiom
 module Data.List.Properties where
 ```
 
-# header
+# Properties of lists
 
 <!--
 ```agda


### PR DESCRIPTION
This prevents the `data.list.properties` page to have a `<title>` of "header"