### PR TITLE
defn: fundamental pregroupoids

### DIFF
--- a/src/Cat/Diagram/Coproduct/Copower.lagda.md
+++ b/src/Cat/Diagram/Coproduct/Copower.lagda.md
@@ -119,8 +119,7 @@ uniqueness properties of colimiting maps.
 cocomplete→copowering
   : ∀ {o ℓ} {C : Precategory o ℓ}
   → is-cocomplete ℓ ℓ C → Functor (Sets ℓ ×ᶜ C) C
-cocomplete→copowering colim = Copowers.Copowering λ S F →
-  Colimit→IC _ (is-hlevel-suc 2 (S .is-tr)) F (colim _)
+cocomplete→copowering colim = Copowers.Copowering λ S F → Colimit→IC _ F (colim _)
 ```
 -->
 

--- a/src/Cat/Diagram/Initial/Weak.lagda.md
+++ b/src/Cat/Diagram/Initial/Weak.lagda.md
@@ -7,6 +7,7 @@ open import Cat.Diagram.Limit.Product
 open import Cat.Diagram.Limit.Base
 open import Cat.Diagram.Equaliser
 open import Cat.Diagram.Initial
+open import Cat.Univalent
 open import Cat.Prelude
 
 import Cat.Reasoning as Cat
@@ -128,36 +129,36 @@ since $j$ equalises $f$ and $g$ by construction, we have $f = g$!
 ```
 
 Putting this together, we can show that, if a [[complete category]] has
-a small weakly initial family indexed by a [[set]], then it has an
-initial object.
+a small weakly initial family, then it has an initial object.
 
 ```agda
   is-complete-weak-initial→initial
-    : ∀ {κ} {I : Type κ} (F : I → ⌞ C ⌟) ⦃ _ : ∀ {n} → H-Level I (2 + n) ⦄
+    : ∀ {κ} {I : Type κ} (F : I → ⌞ C ⌟)
     → is-complete κ (ℓ ⊔ κ) C
     → is-weak-initial-fam F
     → Initial C
-  is-complete-weak-initial→initial {κ = κ} F compl wif = record { has⊥ = equal-is-initial } where
+  is-complete-weak-initial→initial {κ = κ} {I} F compl wif =
+    record { has⊥ = equal-is-initial } where
 ```
 
 <details>
 <summary>The proof is by pasting together the results above.</summary>
 
 ```agda
-    open Indexed-product
+      open Indexed-product
 
-    prod : Indexed-product C F
-    prod = Limit→IP C (hlevel 3) F (is-complete-lower κ ℓ κ κ compl _)
+      prod : Indexed-product C F
+      prod = Limit→IP C F (is-complete-lower κ ℓ κ κ compl _)
 
-    prod-is-wi : is-weak-initial (prod .ΠF)
-    prod-is-wi = is-wif→is-weak-initial F wif (prod .has-is-ip)
+      prod-is-wi : is-weak-initial (prod .ΠF)
+      prod-is-wi = is-wif→is-weak-initial F wif (prod .has-is-ip)
 
-    equal : Joint-equaliser C {I = Hom (prod .ΠF) (prod .ΠF)} λ h → h
-    equal = Limit→Joint-equaliser C _ id (is-complete-lower κ κ lzero ℓ compl _)
-    open Joint-equaliser equal using (has-is-je)
+      equal : Joint-equaliser C {I = Hom (prod .ΠF) (prod .ΠF)} λ h → h
+      equal = Limit→Joint-equaliser C _ id (is-complete-lower κ κ lzero ℓ compl _)
+      open Joint-equaliser equal using (has-is-je)
 
-    equal-is-initial = is-weak-initial→equaliser _ prod-is-wi has-is-je λ f g →
-      Limit→Equaliser C (is-complete-lower κ (ℓ ⊔ κ) lzero lzero compl _)
+      equal-is-initial = is-weak-initial→equaliser _ prod-is-wi has-is-je λ f g →
+        Limit→Equaliser C (is-complete-lower κ (ℓ ⊔ κ) lzero lzero compl _)
 ```
 
 </details>

--- a/src/Cat/Diagram/Projective/Strong.lagda.md
+++ b/src/Cat/Diagram/Projective/Strong.lagda.md
@@ -106,12 +106,10 @@ ones for projective objects, so we omit the details.
 ```agda
 preserves-strong-epis→strong-projective {P = P} hom-epi {X} {Y} e e-strong p =
   epi→surjective (el! (Hom P X)) (el! (Hom P Y))
-    (e ∘_)
-    (λ {c} → hom-epi e-strong .fst {c = c})
-    p
+    (e ∘_) (λ {c} → hom-epi e-strong .fst {c = c}) p
 
 strong-projective→preserves-strong-epis {P = P} pro {X} {Y} {f = f} f-strong =
-    surjective→strong-epi (el! (Hom P X)) (el! (Hom P Y)) (f ∘_) $ λ p →
+  surjective→strong-epi (el! (Hom P X)) (el! (Hom P Y)) (f ∘_) $ λ p →
     pro f f-strong p
 ```
 </details>
@@ -142,11 +140,12 @@ retract→strong-projective
 <summary>These proofs are more or less identical to the corresponding
 ones for projective objects.
 </summary>
+
 ```agda
 indexed-coproduct-strong-projective {P = P} {ι = ι} Idx-pro P-pro coprod {X} {Y} e e-strong p = do
   s ← Idx-pro
-        (λ i → Σ[ sᵢ ∈ Hom (P i) X ] (e ∘ sᵢ ≡ p ∘ ι i)) (λ i → hlevel 2)
-        (λ i → P-pro i e e-strong (p ∘ ι i))
+    (λ i → Σ[ sᵢ ∈ Hom (P i) X ] (e ∘ sᵢ ≡ p ∘ ι i)) (λ i → hlevel 2)
+    (λ i → P-pro i e e-strong (p ∘ ι i))
   pure (match (λ i → s i .fst) , unique₂ (λ i → pullr commute ∙ s i .snd))
   where open is-indexed-coproduct coprod
 
@@ -154,6 +153,7 @@ retract→strong-projective P-pro s r e e-strong p = do
   (t , t-factor) ← P-pro e e-strong (p ∘ r .retract)
   pure (t ∘ s , pulll t-factor ∙ cancelr (r .is-retract))
 ```
+
 </details>
 
 Moreover, if $\cC$ has a [[zero object]] and a strong projective
@@ -174,11 +174,13 @@ zero+indexed-coproduct-strong-projective→strong-projective
 <summary>Following the general theme, the proof is identical
 to the non-strong case.
 </summary>
+
 ```agda
 zero+indexed-coproduct-strong-projective→strong-projective {ι = ι} z coprod ∐P-pro i =
   retract→strong-projective ∐P-pro (ι i) $
   zero→ι-has-retract C coprod z i
 ```
+
 </details>
 
 ## Enough strong projectives
@@ -235,15 +237,11 @@ so the corresponding coproduct is a strong projective.
     open Strong-projectives
 
     strong-projectives : Strong-projectives
-    strong-projectives .Pro X =
-      ∐! (Σ[ i ∈ ∣ Idx ∣ ] (Hom (Pᵢ i) X)) (Pᵢ ⊙ fst)
+    strong-projectives .Pro X = ∐! (Σ[ i ∈ ∣ Idx ∣ ] (Hom (Pᵢ i) X)) (Pᵢ ⊙ fst)
     strong-projectives .present {X = X} =
       ∐!.match (Σ[ i ∈ ∣ Idx ∣ ] (Hom (Pᵢ i) X)) (Pᵢ ⊙ fst) snd
-    strong-projectives .present-strong-epi =
-      strong-sep
-    strong-projectives .projective {X = X} =
-      indexed-coproduct-strong-projective
-        (Idx-pro X)
-        (Pᵢ-pro ⊙ fst)
-        (∐!.has-is-ic (Σ[ i ∈ ∣ Idx ∣ ] (Hom (Pᵢ i) X)) (Pᵢ ⊙ fst))
+    strong-projectives .present-strong-epi = strong-sep
+    strong-projectives .projective {X = X} = indexed-coproduct-strong-projective
+      (Idx-pro X) (Pᵢ-pro ⊙ fst)
+      (∐!.has-is-ic (Σ[ i ∈ ∣ Idx ∣ ] (Hom (Pᵢ i) X)) (Pᵢ ⊙ fst))
 ```

--- a/src/Cat/Functor/Adjoint/AFT.lagda.md
+++ b/src/Cat/Functor/Adjoint/AFT.lagda.md
@@ -51,7 +51,7 @@ module _ {o ℓ o'} {C : Precategory o ℓ} {D : Precategory o' ℓ} (F : Functo
 ```
 -->
 
-A solution set (for $F$ with respect to $Y : \cD$) is a [[set]] $I$,
+A solution set (for $F$ with respect to $Y : \cD$) is a type $I$,
 together with an $I$-indexed family of objects $X_i$ and morphisms $m_i
 : Y \to F(X_i)$, which commute in the sense that, for every $X'$ and $h
 : Y \to X'$, there exists a $j : I$ and $t : X_i \to X'$ which satisfy
@@ -60,12 +60,13 @@ $h = F(t)m_i$.
 ```agda
   record Solution-set (Y : ⌞ D ⌟) : Type (o ⊔ lsuc ℓ) where
     field
-      {index}    : Type ℓ
-      has-is-set : is-set index
+      {index} : Type ℓ
 
-      dom    : index → ⌞ C ⌟
-      map    : ∀ i → D.Hom Y (F.₀ (dom i))
-      factor : ∀ {X'} (h : D.Hom Y (F.₀ X')) → ∃[ i ∈ index ] (Σ[ t ∈ C.Hom (dom i) X' ] (h ≡ F.₁ t D.∘ map i))
+      dom : index → ⌞ C ⌟
+      map : ∀ i → D.Hom Y (F.₀ (dom i))
+      factor
+        : ∀ {X'} (h : D.Hom Y (F.₀ X'))
+        → ∃[ i ∈ index ] (Σ[ t ∈ C.Hom (dom i) X' ] h ≡ F.₁ t D.∘ map i)
 ```
 
 <!--
@@ -112,14 +113,11 @@ the sea has risen above it:
     → (∀ y → Solution-set y)
     → Σ[ G ∈ Functor D C ] G ⊣ F
   solution-set→left-adjoint c-compl F-cont ss =
-    _ , universal-maps→left-adjoint init where module _ x where
-    instance
-      H-Level-ix : ∀ {n} → H-Level (ss x .index) (2 + n)
-      H-Level-ix = basic-instance 2 (ss x .has-is-set)
-
-    init : Initial (x ↙ F)
-    init = is-complete-weak-initial→initial (x ↙ F)
-      (solution-set→family (ss x))
-      (comma-is-complete F c-compl F-cont)
-      (solution-set→family-is-weak-initial (ss x))
+    let
+      init : ∀ x → Initial (x ↙ F)
+      init x = is-complete-weak-initial→initial (x ↙ F)
+        (solution-set→family (ss x))
+        (comma-is-complete F c-compl F-cont)
+        (solution-set→family-is-weak-initial (ss x))
+    in _ , universal-maps→left-adjoint init
 ```

--- a/src/Cat/Instances/Discrete/Pre.lagda.md
+++ b/src/Cat/Instances/Discrete/Pre.lagda.md
@@ -1,0 +1,92 @@
+<!--
+```agda
+open import Cat.Univalent
+open import Cat.Prelude
+
+import Cat.Reasoning as Cat
+```
+-->
+
+```agda
+module Cat.Instances.Discrete.Pre where
+```
+
+# Fundamental pregroupoids
+
+<!--
+```agda
+module _ where
+  open Precategory
+```
+-->
+
+If $X$ is a type with no known [[h-level]], we can not directly define a
+[[precategory]] where the type of objects is $X$ and $\hom(x, y)$ is the
+type of paths $x \is y$, since we will not know that this type is a
+[[set]]. However, we can still define an interesting precategory with
+type of objects $X$ by defining $\hom(x, y)$ to be the [[set
+truncation]] $\| x \is y \|_0$.
+
+Since under [[Rezk completion]] this precategory presents the "path
+groupoid" of the [[groupoid truncation|truncation]] $\| X \|_1$, we
+refer to it as the **fundamental pregroupoid** of $X$, and denote it
+$\Pi_1(X)$. The naming and notation refers to the [[fundamental groups]]
+of $X$. Indeed, if $x : X$ is a point, then the endomorphism space
+$\hom_{\Pi_1(X)}(x, x)$ is exactly the fundamental group $\pi_1(X, x)$.
+
+<!--
+:::{.definition #fundamental-pregroupoid}
+The **fundamental pregroupoid** of a type $X$ is the [[precategory]]
+$\Pi_1(X)$ with type of objects $X$, where the [[set]] of morphisms
+$$\hom_{\Pi_1}(X)(x, y) = \| x \is y \|_0$$ is given by the [[set
+truncation]] of the path space $x \is y$.
+:::
+-->
+
+```agda
+  Π₁ : ∀ {ℓ} → Type ℓ → Precategory ℓ ℓ
+  Π₁ X .Ob          = X
+  Π₁ X .Hom     x y = ∥ x ≡ y ∥₀
+  Π₁ X .Hom-set x y = hlevel 2
+
+  Π₁ X .id      = inc refl
+  Π₁ X ._∘_ p q = ⦇ q ∙ p ⦈
+
+  Π₁ X .idr   = elim! λ p     → ap ∥_∥₀.inc (∙-idl p)
+  Π₁ X .idl   = elim! λ p     → ap ∥_∥₀.inc (∙-idr p)
+  Π₁ X .assoc = elim! λ p q r → ap ∥_∥₀.inc (sym (∙-assoc r q p))
+```
+
+<!--
+```agda
+module _ {ℓx o ℓ} {X : Type ℓx} (C : Precategory o ℓ) where
+  open Functor
+  open Cat C
+```
+-->
+
+As for discrete categories, we can extend functions $X \to
+\operatorname{Ob}(\cC)$ to functors $\Pi_1(X) \to \cC$. Turning families
+of objects into diagrams is the primary motivation for the construction
+of $\Pi_1(-)$: if $\operatorname{Ob}(\cC)$ was known to be a groupoid,
+we could replace $X$ with its groupoid truncation, and use the ordinary
+"discrete category" construction as the domain of the diagram; but since
+we will not be able to eliminate $\| X \|_1$ in general, we have to
+choose a different domain instead.
+
+```agda
+  Π₁-adjunct₁ : {x y : X} (F : X → ⌞ C ⌟) → ∥ x ≡ y ∥₀ → Hom (F x) (F y)
+  Π₁-adjunct₁ F (inc x) = path→iso (ap F x) .to
+  Π₁-adjunct₁ F (squash x y p q i j) = Hom-set _ _
+    (Π₁-adjunct₁ F x) (Π₁-adjunct₁ F y)
+    (λ i → Π₁-adjunct₁ F (p i)) (λ i → Π₁-adjunct₁ F (q i)) i j
+
+  Π₁-adjunct : (X → ⌞ C ⌟) → Functor (Π₁ X) C
+  Π₁-adjunct F .F₀   = F
+  Π₁-adjunct F .F₁   = Π₁-adjunct₁ F
+  Π₁-adjunct F .F-id = transport-refl _
+  Π₁-adjunct F .F-∘ {x = x} = elim! λ p q →
+    path→iso (ap F (q ∙ p)) .to                     ≡⟨ ap (λ e → subst (Hom (F x)) e id) (ap-∙ F q p) ⟩
+    path→iso (ap F q ∙ ap F p) .to                  ≡⟨ path→to-∙ C (ap F q) (ap F p) ⟩
+    (path→iso (ap F p) .to ∘ path→iso (ap F q) .to) ∎
+```


### PR DESCRIPTION
This aux. definition allows us to compute indexed co/products as co/limits even when the indexing type does not have an h-level.