### PR TITLE
doc: fix typo in description of partiality monad's information ordering

### DIFF
--- a/src/Data/Partial/Base.lagda.md
+++ b/src/Data/Partial/Base.lagda.md
@@ -130,7 +130,7 @@ as Turing machines, one might have literally taken more steps than the
 other.
 
 We write the information ordering as $x \lsq y$: it holds whenever $x$
-is *more defined than* $y$, and they agree on this common extent.
+is *less defined than* $y$, and they agree on this common extent.
 
 ```agda
 record _⊑_ {ℓ} {A : Type ℓ} (x y : ↯ A) : Type ℓ where


### PR DESCRIPTION
If never is supposed to be the bottom, then clearly x must be *less* defined than y. Indeed, this agrees with the Agda definition.

## Checklist

Before submitting a merge request, please check the items below:

- [x] I've read [the contributing guidelines](https://github.com/plt-amy/1lab/blob/main/CONTRIBUTING.md).
- [x] The imports of new modules have been sorted with `support/sort-imports.hs` (or `nix run --experimental-features nix-command -f . sort-imports`).
- [x] All new code blocks have "agda" as their language.